### PR TITLE
pass explicit sort to handle APFS

### DIFF
--- a/cmd/brew-livecheck.rb
+++ b/cmd/brew-livecheck.rb
@@ -123,6 +123,6 @@ formulae_to_check =
     ARGV.formulae
   end
 
-formulae_to_check.each do |formula|
+formulae_to_check.sort.each do |formula|
   print_latest_version formula
 end


### PR DESCRIPTION
https://github.com/Homebrew/brew/issues/3311

```
$ brew livecheck -iq
gmp (guessed) : 6.1.2 ==> 6.1.2
ffmpeg (guessed) : 3.4 ==> 3.5-dev
doctl (guessed) : 1.7.1 ==> 1.7.1
magic-wormhole (guessed) : 0.10.3 ==> 0.10.3
go (guessed) : 1.9.2 ==> 2012-03-27
python3 : 3.6.3 ==> 3.7.0
nettle (guessed) : 3.3 ==> 3.3
gdbm (guessed) : 1.13 ==> 1.13
python : 2.7.14 ==> 2.7.14
saldl (guessed) : 37 ==> 37
```
```
brew livecheck -iq
antigen (guessed) : 2.2.1 ==> 2.2.1
bettercap (guessed) : 1.6.2 ==> 1.6.2
doctl (guessed) : 1.7.1 ==> 1.7.1
duti (guessed) : 1.5.3 ==> 20071221
exa (guessed) : 0.8.0 ==> 0.8.0
fd (guessed) : 5.0.0 ==> 5.0.0
ffmpeg (guessed) : 3.4 ==> 3.5-dev
fzf (guessed) : 0.17.1 ==> 0.17.1
gdbm (guessed) : 1.13 ==> 1.13
gettext (guessed) : 0.19.8.1 ==> 0.19.8.1
```