### PR TITLE
[WIP] Add Mono

### DIFF
--- a/Livecheckables/mono.rb
+++ b/Livecheckables/mono.rb
@@ -1,0 +1,4 @@
+class Mono
+  livecheck :url => "https://download.mono-project.com/sources/mono/",
+            :regex => /mono-([0-9,\.]+)\./
+end


### PR DESCRIPTION
Hey, I struggling to add **Mono**.

When I run `brew livecheck mono -d` with the livecheckable vesion, this output shows up:
```
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/mono.rb
Loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-livecheck/Livecheckables/mono.rb
Trying with url https://github.com/mono/mono/archive/
Possible git repo detected at https://github.com/mono/mono.git
Error: Unable to get versions for mono
/usr/local/Homebrew/Library/Homebrew/brew.rb:108:in `exit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:108:in `<main>'
```

I don't know why this is happening. Can someone help me here?
