### PR TITLE
v8: add livecheck

### DIFF
--- a/Livecheckables/v8.rb
+++ b/Livecheckables/v8.rb
@@ -1,0 +1,4 @@
+class V8 < Formula
+  livecheck :url => "https://omahaproxy.appspot.com/all.json?os=mac&channel=stable",
+            :regex => %r{"v8_version": "(([0-9]+\.){3}[0-9]+)"}
+end


### PR DESCRIPTION
Added a `v8` livecheck, tracking the version shipped in the latest Chrome stable release (using their omahaproxy webapp), for the `v8` upgrade in https://github.com/Homebrew/homebrew-core/pull/30961.