### PR TITLE
Generalize npm livechecks

### DIFF
--- a/Livecheckables/angular-cli.rb
+++ b/Livecheckables/angular-cli.rb
@@ -1,4 +1,0 @@
-class AngularCli
-  livecheck :url => "https://www.npmjs.com/package/@angular/cli",
-            :regex => %r{package__sidebarText.*?>([0-9\.]+)</p>}
-end

--- a/Livecheckables/bitwarden-cli.rb
+++ b/Livecheckables/bitwarden-cli.rb
@@ -1,4 +1,0 @@
-class BitwardenCli
-  livecheck :url => "https://www.npmjs.com/package/@bitwarden/cli",
-            :regex => %r{package__sidebarText.*?>([0-9\.]+)</p>}
-end

--- a/Livecheckables/joplin.rb
+++ b/Livecheckables/joplin.rb
@@ -1,4 +1,0 @@
-class Joplin
-  livecheck :url => "https://www.npmjs.com/package/joplin",
-            :regex => %r{package__sidebarText.*?>([0-9\.]+)</p>}
-end

--- a/Livecheckables/quicktype.rb
+++ b/Livecheckables/quicktype.rb
@@ -1,4 +1,0 @@
-class Quicktype
-  livecheck :url => "https://www.npmjs.com/package/quicktype",
-            :regex => %r{package__sidebarText.*?>([0-9\.]+)</p>}
-end

--- a/Livecheckables/typescript.rb
+++ b/Livecheckables/typescript.rb
@@ -1,4 +1,0 @@
-class Typescript
-  livecheck :url => "https://www.npmjs.com/package/typescript",
-            :regex => %r{package__sidebarText.*?>([0-9\.]+)</p>}
-end

--- a/Livecheckables/webpack.rb
+++ b/Livecheckables/webpack.rb
@@ -1,4 +1,0 @@
-class Webpack
-  livecheck :url => "https://www.npmjs.com/package/webpack",
-            :regex => %r{package__sidebarText.*?>([0-9\.]+)</p>}
-end

--- a/livecheck/euristic.rb
+++ b/livecheck/euristic.rb
@@ -103,6 +103,18 @@ def version_euristic(urls, regex = nil)
           match_version_map[match] = version
         end
       end
+    when url =~ /registry\.npmjs\.org/
+      package = url.split("/")[3..-3].join("/")
+      page_url = "https://www.npmjs.com/package/#{package}/"
+
+      if regex.nil?
+        regex = %r{package__sidebarText.*?>([0-9\.]+)</p>}
+      end
+
+      page_matches(page_url, regex).each do |match|
+        version = Version.new(match)
+        match_version_map[match] = version
+      end
     when regex
       # Fallback
       page_matches(url, regex).each do |match|


### PR DESCRIPTION
This PR:
* adds euristic for npm
* removes most of the livechecks with `npmjs.com` urls since they are now covered by this euristic
  * `bower.rb` & `imageoptim-cli.rb` are not removed. The reason is that their corresponding `homebrew-core` formula urls are not under `registry.npmjs.org`. 

Not sure if I am doing this right or not since this is my first non-formula PR for Homebrew. 