### PR TITLE
Remove individual GNOME livecheckables in favor of generalized check

### DIFF
--- a/Livecheckables/at-spi2-atk.rb
+++ b/Livecheckables/at-spi2-atk.rb
@@ -1,4 +1,0 @@
-class AtSpi2Atk
-  livecheck :url => "https://download.gnome.org/sources/at-spi2-atk/2.26/",
-            :regex => /href="LATEST-IS-([\d.]+)"/
-end

--- a/Livecheckables/at-spi2-core.rb
+++ b/Livecheckables/at-spi2-core.rb
@@ -1,4 +1,0 @@
-class AtSpi2Core
-  livecheck :url => "https://download.gnome.org/sources/at-spi2-core/2.28/",
-            :regex => /href="LATEST-IS-([\d.]+)"/
-end

--- a/Livecheckables/glib.rb
+++ b/Livecheckables/glib.rb
@@ -1,4 +1,0 @@
-class Glib
-  livecheck :url => "https://download.gnome.org/sources/glib/2.56/",
-            :regex => /href="LATEST-IS-([\d.]+)"/
-end

--- a/Livecheckables/gnome-latex.rb
+++ b/Livecheckables/gnome-latex.rb
@@ -1,4 +1,0 @@
-class GnomeLatex
-  livecheck :url => "https://download.gnome.org/sources/gnome-latex/3.28/",
-            :regex => /href="LATEST-IS-([0-9\.]+)"/
-end

--- a/Livecheckables/gnumeric.rb
+++ b/Livecheckables/gnumeric.rb
@@ -1,4 +1,0 @@
-class Gnumeric
-  livecheck :url => "https://download.gnome.org/sources/gnumeric/1.12/",
-            :regex => /href="LATEST-IS-([0-9\.]+)"/
-end

--- a/Livecheckables/gobject-introspection.rb
+++ b/Livecheckables/gobject-introspection.rb
@@ -1,4 +1,0 @@
-class GobjectIntrospection
-  livecheck :url => "https://download.gnome.org/sources/gobject-introspection/1.56/",
-            :regex => /LATEST-IS-([\d.]+)"/
-end

--- a/Livecheckables/goffice.rb
+++ b/Livecheckables/goffice.rb
@@ -1,4 +1,3 @@
 class Goffice
-  livecheck :url => "https://download.gnome.org/sources/goffice/0.10/",
-            :regex => /href="LATEST-IS-([0-9\.]+)"/
+  livecheck :url => "https://download.gnome.org/sources/goffice/cache.json"
 end

--- a/Livecheckables/gom.rb
+++ b/Livecheckables/gom.rb
@@ -1,4 +1,0 @@
-class Gom
-  livecheck :url => "https://download.gnome.org/sources/gom/0.3/",
-            :regex => /href="LATEST-IS-([0-9\.]+)"/
-end

--- a/Livecheckables/goocanvas.rb
+++ b/Livecheckables/goocanvas.rb
@@ -1,4 +1,0 @@
-class Goocanvas
-  livecheck :url => "https://download.gnome.org/sources/goocanvas/2.0/",
-            :regex => /href="LATEST-IS-([0-9\.]+)"/
-end

--- a/Livecheckables/gsettings-desktop-schemas.rb
+++ b/Livecheckables/gsettings-desktop-schemas.rb
@@ -1,4 +1,0 @@
-class GsettingsDesktopSchemas
-  livecheck :url => "https://download.gnome.org/sources/gsettings-desktop-schemas/3.28/",
-            :regex => /href="LATEST-IS-([0-9\.]+)"/
-end

--- a/Livecheckables/gtk-vnc.rb
+++ b/Livecheckables/gtk-vnc.rb
@@ -1,4 +1,0 @@
-class GtkVnc < Formula
-  livecheck :url => "https://download.gnome.org/sources/gtk-vnc/cache.json",
-            :regex => /gtk-vnc-([\d.]+)\.tar\.xz/
-end

--- a/Livecheckables/gtksourceview@4.rb
+++ b/Livecheckables/gtksourceview@4.rb
@@ -1,4 +1,0 @@
-class GtksourceviewAT4
-  livecheck :url => "https://download.gnome.org/sources/gtksourceview/4.0/",
-            :regex => /href="LATEST-IS-([\d.]+)"/
-end

--- a/Livecheckables/jsonrpc-glib.rb
+++ b/Livecheckables/jsonrpc-glib.rb
@@ -1,4 +1,0 @@
-class JsonrpcGlib
-  livecheck :url => "https://download.gnome.org/sources/jsonrpc-glib/3.28/",
-            :regex => /href="LATEST-IS-([\d.]+)"/
-end

--- a/Livecheckables/libdazzle.rb
+++ b/Livecheckables/libdazzle.rb
@@ -1,4 +1,0 @@
-class Libdazzle
-  livecheck :url => "https://download.gnome.org/sources/libdazzle/3.28/",
-            :regex => /href="LATEST-IS-([\d.]+)"/
-end

--- a/Livecheckables/librsvg.rb
+++ b/Livecheckables/librsvg.rb
@@ -1,4 +1,0 @@
-class Librsvg
-  livecheck :url => "https://download.gnome.org/sources/librsvg/2.42/",
-            :regex => /href="LATEST-IS-([\d.]+)"/
-end

--- a/Livecheckables/libsoup.rb
+++ b/Livecheckables/libsoup.rb
@@ -1,4 +1,0 @@
-class Libsoup < Formula
-  livecheck :url => "https://download.gnome.org/sources/libsoup/cache.json",
-            :regex => /libsoup-([\d.]+\.[\d.]+\.[\d.]+)\.t/
-end

--- a/Livecheckables/template-glib.rb
+++ b/Livecheckables/template-glib.rb
@@ -1,4 +1,0 @@
-class TemplateGlib
-  livecheck :url => "https://download.gnome.org/sources/template-glib/3.28/",
-            :regex => /href="LATEST-IS-([\d.]+)"/
-end

--- a/Livecheckables/tepl.rb
+++ b/Livecheckables/tepl.rb
@@ -1,4 +1,0 @@
-class Tepl
-  livecheck :url => "https://download.gnome.org/sources/tepl/4.0/",
-            :regex => /href="LATEST-IS-([0-9\.]+)"/
-end


### PR DESCRIPTION
Test before/after with:

```bash
brew livecheck at-spi2-atk at-spi2-core glib gnome-latex gnumeric gobject-introspection goffice gom goocanvas gsettings-desktop-schemas gtk-vnc gtksourceview@4 jsonrpc-glib libdazzle librsvg libsoup template-glib tepl
```