### PR TITLE
autossh: use https

### DIFF
--- a/Livecheckables/autossh.rb
+++ b/Livecheckables/autossh.rb
@@ -1,4 +1,4 @@
 class Autossh
-  livecheck :url => "http://www.harding.motd.ca/autossh/",
+  livecheck :url => "https://www.harding.motd.ca/autossh/",
             :regex => /HREF="autossh-([0-9\.]+[a-z]+)\.t/
 end


### PR DESCRIPTION
Livecheck would fail when trying to redirect from http to https.