### PR TITLE
shared-mime-info: update livecheck

### DIFF
--- a/Livecheckables/shared-mime-info.rb
+++ b/Livecheckables/shared-mime-info.rb
@@ -1,4 +1,4 @@
 class SharedMimeInfo
-  livecheck :url => "https://freedesktop.org/~hadess/",
-            :regex => /href="shared-mime-info-([\d.]+\.[\d.]+)\.t/
+  livecheck :url => "https://gitlab.freedesktop.org/api/v4/projects/1205/releases",
+            :regex => /shared-mime-info ([0-9\.]+)/
 end


### PR DESCRIPTION
Uses GitLab API to retrieve the list of releases.