### PR TITLE
libtiff: add the missing slash

### DIFF
--- a/Livecheckables/libtiff.rb
+++ b/Livecheckables/libtiff.rb
@@ -1,4 +1,4 @@
 class Libtiff
-  livecheck :url => "https://download.osgeo.org/libtiff",
+  livecheck :url => "https://download.osgeo.org/libtiff/",
             :regex => /href="tiff-([0-9\.\-]+)\.t/
 end


### PR DESCRIPTION
The missing slash prevents livecheck from working correctly.