### PR TITLE
sonarqube: update url

### DIFF
--- a/Livecheckables/sonarqube.rb
+++ b/Livecheckables/sonarqube.rb
@@ -1,4 +1,4 @@
 class Sonarqube
-  livecheck :url => "https://sonarsource.bintray.com/Distribution/sonarqube/",
-            :regex => /href="sonarqube-([0-9\.]+)\.z/
+  livecheck :url => "https://binaries.sonarsource.com/Distribution/sonarqube/",
+            :regex => /sonarqube-([0-9\.]+)\.z/
 end


### PR DESCRIPTION
Previous url leads to a 404 error.