### PR TITLE
Fix 'undefined method .exist?' error for lc_path

### DIFF
--- a/livecheck/extend/formulary.rb
+++ b/livecheck/extend/formulary.rb
@@ -4,14 +4,14 @@ module Formulary
   class << self
     # extended to load the Livecheckable version of a formula
 
-     def livecheckable_path(path)
-       path_suffix = "../../Livecheckables/#{path.basename}"
-       if (opt = path.realpath/path_suffix).exist?
-         opt
-       elsif (opt = Pathname(__dir__)/path_suffix).exist?
-         opt
-       end
-     end
+    def livecheckable_path(path)
+      path_suffix = "../../Livecheckables/#{path.basename}"
+      if (opt = path.realpath/path_suffix).exist?
+        opt
+      elsif (opt = Pathname(__dir__)/path_suffix).exist?
+        opt
+      end
+    end
 
     def load_formula(name, path, contents, namespace)
       mod = Module.new
@@ -19,7 +19,7 @@ module Formulary
       mod.module_eval(contents, path)
 
       lc_path = livecheckable_path(path)
-      if lc_path.exist?
+      if lc_path&.exist?
         puts "Loading #{lc_path}" if ARGV.debug?
         mod.module_eval(lc_path.read, lc_path)
       end


### PR DESCRIPTION
- Fixes #122.
- Check that `lc_path` is defined before calling `.exist?` on it.
- Also fix some inconsistent indentation.

Before:

```
$ brew livecheck gnuradio
Error: undefined method `exist?' for nil:NilClass
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-livecheck/livecheck/extend/formulary.rb:22:in `load_formula'
```
After:

```
$ brew livecheck gnuradio
gnuradio (guessed) : 3.7.13.4 ==> 3.8tech-preview
```