### PR TITLE
Update gstreamer livecheckables

### DIFF
--- a/Livecheckables/gst-libav.rb
+++ b/Livecheckables/gst-libav.rb
@@ -1,4 +1,4 @@
 class GstLibav
   livecheck :url => "https://gstreamer.freedesktop.org/src/gst-libav/",
-            :regex => /href="gst-libav-(1\.14\.[0-9\.]+)\.t/
+            :regex => /href="gst-libav-([\d.]+\.[\d.]+\.[\d.]+)\.t/
 end

--- a/Livecheckables/gst-plugins-bad.rb
+++ b/Livecheckables/gst-plugins-bad.rb
@@ -1,4 +1,4 @@
 class GstPluginsBad
   livecheck :url => "https://gstreamer.freedesktop.org/src/gst-plugins-bad/",
-            :regex => /href="gst-plugins-bad-(1\.14\.[0-9\.]+)\.t/
+            :regex => /href="gst-plugins-bad-([\d.]+\.[\d.]+\.[\d.]+)\.t/
 end

--- a/Livecheckables/gst-plugins-base.rb
+++ b/Livecheckables/gst-plugins-base.rb
@@ -1,4 +1,4 @@
 class GstPluginsBase
   livecheck :url => "https://gstreamer.freedesktop.org/src/gst-plugins-base/",
-            :regex => /href="gst-plugins-base-(1\.14\.[0-9\.]+)\.t/
+            :regex => /href="gst-plugins-base-([\d.]+\.[\d.]+\.[\d.]+)\.t/
 end

--- a/Livecheckables/gst-plugins-good.rb
+++ b/Livecheckables/gst-plugins-good.rb
@@ -1,4 +1,4 @@
 class GstPluginsGood
   livecheck :url => "https://gstreamer.freedesktop.org/src/gst-plugins-good/",
-            :regex => /href="gst-plugins-good-(1\.14\.[0-9\.]+)\.t/
+            :regex => /href="gst-plugins-good-([\d.]+\.[\d.]+\.[\d.]+)\.t/
 end

--- a/Livecheckables/gst-plugins-ugly.rb
+++ b/Livecheckables/gst-plugins-ugly.rb
@@ -1,4 +1,4 @@
 class GstPluginsUgly
   livecheck :url => "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/",
-            :regex => /href="gst-plugins-ugly-(1\.14\.[0-9\.]+)\.t/
+            :regex => /href="gst-plugins-ugly-([\d.]+\.[\d.]+\.[\d.]+)\.t/
 end

--- a/Livecheckables/gstreamer.rb
+++ b/Livecheckables/gstreamer.rb
@@ -1,4 +1,4 @@
 class Gstreamer
   livecheck :url => "https://gstreamer.freedesktop.org/src/gstreamer/",
-            :regex => /href="gstreamer-(1\.14\.[0-9\.]+)\.t/
+            :regex => /href="gstreamer-([\d.]+\.[\d.]+\.[\d.]+)\.t/
 end

--- a/Livecheckables/orc.rb
+++ b/Livecheckables/orc.rb
@@ -1,4 +1,4 @@
 class Orc
-  livecheck :url => "https://cgit.freedesktop.org/gstreamer/orc/",
-            :regex => %r{/gstreamer/orc/tag/\?h=orc-([0-9\.]+)}
+  livecheck :url => "https://gstreamer.freedesktop.org/src/orc/",
+            :regex => /href="orc-([\d.]+\.[\d.]+\.[\d.]+)\.t/
 end


### PR DESCRIPTION
Before (reporting newer version installed than what was found by livecheck):

```bash
$ brew livecheck gst-libav gst-plugins-bad gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer orc 
gst-libav : 1.16.0 ==> 1.14.5
gst-plugins-bad : 1.16.0 ==> 1.14.5
gst-plugins-base : 1.16.0 ==> 1.14.5
gst-plugins-good : 1.16.0 ==> 1.14.5
gst-plugins-ugly : 1.16.0 ==> 1.14.5
gstreamer : 1.16.0 ==> 1.14.5
orc : 0.4.29 ==> 0.4.28
```

After (version found matches what is installed):

```bash
$ brew livecheck gst-libav gst-plugins-bad gst-plugins-base gst-plugins-good gst-plugins-ugly gstreamer orc 
gst-libav : 1.16.0 ==> 1.16.0
gst-plugins-bad : 1.16.0 ==> 1.16.0
gst-plugins-base : 1.16.0 ==> 1.16.0
gst-plugins-good : 1.16.0 ==> 1.16.0
gst-plugins-ugly : 1.16.0 ==> 1.16.0
gstreamer : 1.16.0 ==> 1.16.0
orc : 0.4.29 ==> 0.4.29
```