### PR TITLE
euristic.rb: escape package name for gnome regex (gtk+3)

### DIFF
--- a/livecheck/euristic.rb
+++ b/livecheck/euristic.rb
@@ -124,7 +124,7 @@ def version_euristic(urls, regex = nil)
       end
 
       if regex.nil?
-        regex = /#{package}-([\d.]+\.[\d.]+\.[\d.]+)\.t/
+        regex = /#{Regexp.escape(package)}-([\d.]+\.[\d.]+\.[\d.]+)\.t/
       end
 
       page_matches(page_url, regex).each do |match|


### PR DESCRIPTION
Before:

```bash
$ brew livecheck gtk+3
Error: Unable to get versions for gtk+3
```

After:

```bash
$ brew livecheck gtk+3
gtk+3 (guessed) : 3.24.10 ==> 3.94.0
```