### PR TITLE
cscope & libnice: add livecheckables

### DIFF
--- a/Livecheckables/cscope.rb
+++ b/Livecheckables/cscope.rb
@@ -1,0 +1,4 @@
+class Cscope
+  livecheck :url => "https://sourceforge.net/projects/cscope/rss",
+            :regex => /cscope-([a-zA-Z0-9.]+(?:\.[a-zA-Z0-9.]+)*)\.t/
+end

--- a/Livecheckables/libnice.rb
+++ b/Livecheckables/libnice.rb
@@ -1,0 +1,4 @@
+class Libnice
+  livecheck :url => "https://nice.freedesktop.org/releases/",
+            :regex => /href="libnice-([\d.]+\.[\d.]+\.[\d.]+)\.t/
+end


### PR DESCRIPTION
Before:

```bash
$ brew livecheck cscope libnice
cscope (guessed) : 15.9 ==> 15.8b
Error: Unable to get versions for libnice
```

After:

```bash
$ brew livecheck cscope libnice
cscope : 15.9 ==> 15.9
libnice : 0.1.16 ==> 0.1.16
```