### PR TITLE
swi-prolog: move to https url

### DIFF
--- a/Livecheckables/swi-prolog.rb
+++ b/Livecheckables/swi-prolog.rb
@@ -1,4 +1,4 @@
 class SwiProlog
-  livecheck :url => "http://www.swi-prolog.org/download/stable/src",
+  livecheck :url => "https://www.swi-prolog.org/download/stable/src",
             :regex => /swipl-(\d+\.\d+\.\d+)\.t/
 end


### PR DESCRIPTION
The current url creates a redirection and leads to the following error: 
```
Error: redirection forbidden: http://www.swi-prolog.org/download/stable/src -> https://www.swi-prolog.org/download/stable/src
```