### PR TITLE
systemc: use https url

### DIFF
--- a/Livecheckables/systemc.rb
+++ b/Livecheckables/systemc.rb
@@ -1,4 +1,4 @@
 class Systemc
-  livecheck :url => "http://www.accellera.org/downloads/standards/systemc",
+  livecheck :url => "https://www.accellera.org/downloads/standards/systemc",
             :regex => %r{href=".*?/systemc-([0-9\.]+)\.t}
 end


### PR DESCRIPTION
The previous url redirected to the https one. This led to a `redirection forbidden` error.