### PR TITLE
Support upstreams that tag only with 'debian/' prefix

### DIFF
--- a/livecheck/euristic.rb
+++ b/livecheck/euristic.rb
@@ -35,9 +35,22 @@ def version_euristic(urls, regex = nil)
     when DownloadStrategyDetector.detect(url) <= GitDownloadStrategy
       puts "Possible git repo detected at #{url}" if ARGV.debug?
 
-      git_tags(url, regex).each do |tag|
+      tags = git_tags(url, regex)
+      tags_only_debian = true
+
+      # Check if upstream only does 'debian/' prefixed tags
+      tags.each do |tag|
+        if tag !~ /debian\//
+          tags_only_debian = false
+          break
+        end
+      end
+
+      tags.each do |tag|
         begin
-          next if tag =~ /debian\//
+          # Move to the next one if tag actually is prefixed with 'debian/'
+          # and upstream does not do only 'debian/' prefixed tags
+          next if tag =~ /debian\// && !tags_only_debian
           # Remove any character before the first number
           tag_cleaned = tag[/\D*(.*)/, 1]
           match_version_map[tag] = Version.new(tag_cleaned)

--- a/livecheck/euristic.rb
+++ b/livecheck/euristic.rb
@@ -36,15 +36,7 @@ def version_euristic(urls, regex = nil)
       puts "Possible git repo detected at #{url}" if ARGV.debug?
 
       tags = git_tags(url, regex)
-      tags_only_debian = true
-
-      # Check if upstream only does 'debian/' prefixed tags
-      tags.each do |tag|
-        if tag !~ /debian\//
-          tags_only_debian = false
-          break
-        end
-      end
+      tags_only_debian = git_tags_only_debian?(tags)
 
       tags.each do |tag|
         begin

--- a/livecheck/utils.rb
+++ b/livecheck/utils.rb
@@ -10,6 +10,16 @@ def git_tags(repo_url, filter = nil)
   tags
 end
 
+# Check if upstream only does 'debian/' prefixed tags
+def git_tags_only_debian?(tags)
+  tags.each do |tag|
+    unless tag.match?(%r{^debian/})
+      return false
+    end
+  end
+  true
+end
+
 def page_matches(url, regex)
   puts %[Using page_match("#{url}", "#{regex}")] if ARGV.debug?
   page = open(url).read


### PR DESCRIPTION
There are upstreams that only do `debian/` prefixed tags in their repositories, like this one: https://github.com/agx/git-buildpackage.

This PR aims to support checking the life of formulae that pull from repositories like these.