### PR TITLE
Provide new --tap option

### DIFF
--- a/cmd/brew-livecheck.rb
+++ b/cmd/brew-livecheck.rb
@@ -3,6 +3,7 @@
 #:
 #:  `brew livecheck`
 #:  `brew livecheck` <formula1> <formula2> <...>
+#:  `brew livecheck` [`--tap=<tap>`]
 #:  `brew livecheck` [`-i`|`--installed`]
 #:  `brew livecheck` [`-a`|`--all`]
 #:  `brew livecheck` [`-h`|`--help`]
@@ -92,6 +93,9 @@ end
 
 formulae_to_check =
   case
+  when ARGV.value("tap")
+    tap = ARGV.value("tap")
+    Tap.fetch(tap).formula_names.map { |name| Formula[name] }
   when ARGV.flag?("--installed")
     Formula.installed
   when ARGV.flag?("--all")


### PR DESCRIPTION
With `--tap` option, one can check all formulae from specified tap.

For example: `brew livecheck --tap=linuxbrew/xorg` would check all
formulae available in this tap.