### PR TITLE
exiftool: update url

### DIFF
--- a/Livecheckables/exiftool.rb
+++ b/Livecheckables/exiftool.rb
@@ -1,4 +1,4 @@
 class Exiftool
-  livecheck :url => "https://www.sno.phy.queensu.ca/~phil/exiftool/history.html",
+  livecheck :url => "https://exiftool.org/history.html",
             :regex => /production release is <a href="Image-ExifTool-([0-9\.]+)\.t/
 end


### PR DESCRIPTION
The exiftool livecheck is failing with `Error: redirection forbidden: https://www.sno.phy.queensu.ca/~phil/exiftool/history.html -> http://exiftool.org/history.html`, so this addresses the issue.