### PR TITLE
icu4c: update url and regex

### DIFF
--- a/Livecheckables/icu4c.rb
+++ b/Livecheckables/icu4c.rb
@@ -1,4 +1,4 @@
 class Icu4c
-  livecheck :url => "https://ssl.icu-project.org/files/icu4c/",
-            :regex => /href="([\d.]+\.[\d.]+\.?[\d.]*)\/"/
+  livecheck :url => "https://github.com/unicode-org/icu/releases",
+            :regex => /href="\/unicode-org\/icu\/releases\/tag\/release-[^"]+"[^>]*>ICU ([\d\.]+)</
 end


### PR DESCRIPTION
https://ssl.icu-project.org URLs appear to be dead or in a state of prolonged downtime.  http://ssl.icu-project.org (not using https) simply redirects to http://site.icu-project.org

With this in mind, it may be a good idea to modify the icu4c livecheckable to use a different page.  I'm using the [ICU download page](http://site.icu-project.org/download/) in this PR but that site doesn't allow for secure connections, unfortunately.

If a secure connection is preferred, it's also possible to use the GitHub release page like so:

```ruby
  livecheck :url => "https://github.com/unicode-org/icu/releases",
            :regex => /href="\/unicode-org\/icu\/releases\/tag\/release-[^"]+"[^>]*>ICU ([\d\.]+)</
```

The main downside of using the GitHub release page is that this regex relies on the release title always being "ICU" and then the version (e.g., "ICU 65.1").  This is true for newer releases but older releases simply use the name from the tag, like "release-60-2".  Using the release title is necessary because the periods in the version string are replaced with hyphens or underscores elsewhere on the page (tags, filenames).  It's also worth noting that this GitHub regex targets non-RC releases (e.g., "ICU 65 RC" won't be matched), as I assumed that would be desired behavior.

What are everyone's thoughts on this?