### PR TITLE
libsndfile: add livecheck

### DIFF
--- a/Livecheckables/libsndfile.rb
+++ b/Livecheckables/libsndfile.rb
@@ -1,0 +1,4 @@
+class Libsndfile
+  livecheck :url => "http://www.mega-nerd.com/libsndfile/",
+            :regex => /libsndfile-([\d\.]+)\.tar\.gz/
+end


### PR DESCRIPTION
The main website (used in this commit) doesn't provide a secure connection, unfortunately.   Release versions *are* available in the [GitHub repo](https://github.com/erikd/libsndfile/releases) but the last release was over two years ago, so it's hard to say whether the GitHub releases page will be updated in the future.  However, if you prefer to use the GitHub releases page, I can update the livecheck accordingly.