### PR TITLE
opencore-amr: add livecheck

### DIFF
--- a/Livecheckables/opencore-amr.rb
+++ b/Livecheckables/opencore-amr.rb
@@ -1,0 +1,4 @@
+class OpencoreAmr
+  livecheck :url => "https://sourceforge.net/projects/opencore-amr/files/opencore-amr/",
+            :regex => />opencore-amr-([\d\.]+)\.tar\.gz/
+end

--- a/livecheck/euristic.rb
+++ b/livecheck/euristic.rb
@@ -59,7 +59,8 @@ def version_euristic(urls, regex = nil)
                                                    !url.include?("remake") &&
                                                    !url.include?("/avf/") &&
                                                    !url.include?("/bashdb/") &&
-                                                   !url.include?("/netpbm/")
+                                                   !url.include?("/netpbm/") &&
+                                                   !url.include?("opencore-amr")
       project_name = url.match(%r{/projects?/(.*?)/})[1]
       page_url = "https://sourceforge.net/api/file/index/project-name/" \
                  "#{project_name}/rss"


### PR DESCRIPTION
opencore-amr doesn't seem to work properly with the default Sourceforge version-finding (even after updating the URL in the formula), so I've created a livecheck to handle this special case.