### PR TITLE
Update SourceForge RSS URL

### DIFF
--- a/livecheck/euristic.rb
+++ b/livecheck/euristic.rb
@@ -61,8 +61,7 @@ def version_euristic(urls, regex = nil)
                                                    !url.include?("/bashdb/") &&
                                                    !url.include?("/netpbm/")
       project_name = url.match(%r{/projects?/(.*?)/})[1]
-      page_url = "https://sourceforge.net/api/file/index/project-name/" \
-                 "#{project_name}/rss"
+      page_url = "https://sourceforge.net/projects/#{project_name}/rss"
 
       if ARGV.debug?
         puts "Possible SourceForge project [#{project_name}] detected" \


### PR DESCRIPTION
The URLs for SourceForge project RSS feeds changed (older URLs were redirecting to the new URLs), so this brings the URL format up to date.