### PR TITLE
xvid: update url

### DIFF
--- a/Livecheckables/xvid.rb
+++ b/Livecheckables/xvid.rb
@@ -1,4 +1,4 @@
 class Xvid
-  livecheck :url => "https://www.xvid.com/download/",
-            :regex => %r{href=".*?/Xvid-([0-9\.]+)-}
+  livecheck :url => "https://downloads.xvid.com/downloads/",
+            :regex => %r{href="[^"]+xvidcore-([\d\.]+)\.tar\.bz2"}
 end


### PR DESCRIPTION
The Xvid download page on www.xvid.com uses a web application firewall (StackPath) and can return a 403 (Forbidden) error code in certain circumstances.  The downloads.xvid.com download page doesn't have the same issue, so this modifies the livecheck to use it instead.