### PR TITLE
yuicompressor: add livecheck

### DIFF
--- a/Livecheckables/yuicompressor.rb
+++ b/Livecheckables/yuicompressor.rb
@@ -1,0 +1,4 @@
+class Yuicompressor
+  livecheck :url => "https://github.com/yui/yuicompressor/releases/",
+            :regex => %r{href="/yui/yuicompressor/tree/v([\d\.]+)"}
+end

--- a/livecheck/euristic.rb
+++ b/livecheck/euristic.rb
@@ -12,7 +12,8 @@ def version_euristic(urls, regex = nil)
                                  !url.include?("prometheus") &&
                                  !url.include?("pyenv-virtualenv") &&
                                  !url.include?("sysdig") &&
-                                 !url.include?("shairport-sync")
+                                 !url.include?("shairport-sync") &&
+                                 !url.include?("yuicompressor")
       if url.include? "archive"
         url = url.sub(/\/archive\/.*/, ".git") if url.include? "github"
       elsif url.include? "releases"


### PR DESCRIPTION
YUI Compressor has older version tags like "yuicompressor-35" and "hudson-yuicompressor-43" before the current "2.4.8" version tag, so it doesn't play nicely with the default GitHub version-finding.  Currently it reports the latest version as 43 because of the aforementioned tag containing 43.

This uses the releases page instead and restricts the version-finding to tags starting with "v" and containing digits or periods.