### PR TITLE
hana: delete livecheckable

### DIFF
--- a/Livecheckables/hana.rb
+++ b/Livecheckables/hana.rb
@@ -1,4 +1,0 @@
-class Hana
-  livecheck :url => "https://github.com/boostorg/hana/releases",
-            :regex => %r{href="/boostorg/hana/tree/v?([0-9\.]+)}
-end


### PR DESCRIPTION
The homebrew-core formula was [recently deleted](https://github.com/Homebrew/homebrew-core/pull/46711).