### PR TITLE
grib-api: delete livecheckable

### DIFF
--- a/Livecheckables/grib-api.rb
+++ b/Livecheckables/grib-api.rb
@@ -1,4 +1,0 @@
-class GribApi
-  livecheck :url => "https://mirrors.ocf.berkeley.edu/debian/pool/main/g/grib-api/",
-            :regex => /href="grib-api_(([0-9\.]+))\.orig\.t/
-end


### PR DESCRIPTION
`grib-api` formula was [recently deleted in homebrew-core](https://github.com/Homebrew/homebrew-core/pull/46924)