### PR TITLE
cherokee: delete livecheckable

### DIFF
--- a/Livecheckables/cherokee.rb
+++ b/Livecheckables/cherokee.rb
@@ -1,4 +1,0 @@
-class Cherokee
-  livecheck :url => "http://cherokee-project.com/",
-            :regex => %r{href="/downloads.html">Download Cherokee ([0-9\.]+)</a>}
-end


### PR DESCRIPTION
`cherokee` was [deleted from homebrew-core](https://github.com/Homebrew/homebrew-core/pull/43544).