### PR TITLE
pound: delete livecheckable

### DIFF
--- a/Livecheckables/pound.rb
+++ b/Livecheckables/pound.rb
@@ -1,4 +1,0 @@
-class Pound
-  livecheck :url => "http://www.apsis.ch/pound",
-            :regex => %r{latest version.*?href=".*?/Pound-([0-9\.]+)\.t}
-end


### PR DESCRIPTION
`pound` was [recently deleted from homebrew-core](https://github.com/Homebrew/homebrew-core/pull/46539).