### PR TITLE
sphinx-doc: delete livecheckable

### DIFF
--- a/Livecheckables/sphinx-doc.rb
+++ b/Livecheckables/sphinx-doc.rb
@@ -1,4 +1,0 @@
-class SphinxDoc
-  livecheck :url => "https://pypi.python.org/pypi/Sphinx/",
-            :regex => /Sphinx-([0-9,\.]+)-py2\.py3-none-any\.whl/
-end


### PR DESCRIPTION
It does not seem to work.

But it does with this PR: https://github.com/Homebrew/homebrew-livecheck/pull/161