### PR TITLE
Ansible delete @1.9 and @2.0 livecheckables

### DIFF
--- a/Livecheckables/ansible@1.9.rb
+++ b/Livecheckables/ansible@1.9.rb
@@ -1,4 +1,0 @@
-class AnsibleAT19
-  livecheck :url => "https://releases.ansible.com/ansible/",
-            :regex => /href="ansible-(1\.9\.[0-9\.]+)\.t/
-end

--- a/Livecheckables/ansible@2.0.rb
+++ b/Livecheckables/ansible@2.0.rb
@@ -1,4 +1,0 @@
-class AnsibleAT20
-  livecheck :url => "https://releases.ansible.com/ansible/",
-            :regex => /href="ansible-(2\.0\.[0-9\.]+)\.t/
-end


### PR DESCRIPTION
`ansible@1.9` and `ansible@2.0` were [deleted from homebrew-core](https://github.com/Homebrew/homebrew-core/pull/47055).