### PR TITLE
docker-cloud: delete livecheckable

### DIFF
--- a/Livecheckables/docker-cloud.rb
+++ b/Livecheckables/docker-cloud.rb
@@ -1,4 +1,0 @@
-class DockerCloud
-  livecheck :url => "https://pypi.python.org/simple/docker-cloud/",
-            :regex => %r{href=".*?/docker-cloud-([0-9\.]+)\.t}
-end


### PR DESCRIPTION
`docker-cloud` was [deleted from homebrew-core](https://github.com/Homebrew/homebrew-core/pull/47752).