### PR TITLE
Delete erlang@17, erlang@18 and erlang@19 livecheckables

### DIFF
--- a/Livecheckables/erlang@17.rb
+++ b/Livecheckables/erlang@17.rb
@@ -1,4 +1,0 @@
-class ErlangAT17
-  livecheck :url => "https://github.com/erlang/otp.git",
-            :regex => /OTP-(17\.[0-9\.]+)/
-end

--- a/Livecheckables/erlang@18.rb
+++ b/Livecheckables/erlang@18.rb
@@ -1,4 +1,0 @@
-class ErlangAT18
-  livecheck :url => "https://github.com/erlang/otp.git",
-            :regex => /OTP-(18\.[0-9\.]+)/
-end

--- a/Livecheckables/erlang@19.rb
+++ b/Livecheckables/erlang@19.rb
@@ -1,4 +1,0 @@
-class ErlangAT19
-  livecheck :url => "https://github.com/erlang/otp.git",
-            :regex => /OTP-(19\.[0-9\.]+)/
-end


### PR DESCRIPTION
All three were deleted from homebrew-core: 
* [`erlang@17`](https://github.com/Homebrew/homebrew-core/pull/46552)
* [`erlang@18`](https://github.com/Homebrew/homebrew-core/pull/39877)
* [`erlang@19`](https://github.com/Homebrew/homebrew-core/pull/46869)