### PR TITLE
go@1.8: delete livecheckable

### DIFF
--- a/Livecheckables/go@1.8.rb
+++ b/Livecheckables/go@1.8.rb
@@ -1,4 +1,0 @@
-class GoAT18
-  livecheck :url => "https://golang.org/dl/",
-            :regex => /go(1\.8\.[0-9\.]+)\.src/
-end


### PR DESCRIPTION
`go@1.8` was [deleted from homebrew-core](https://github.com/Homebrew/homebrew-core/pull/37621).