### PR TITLE
mariadb@10.0: delete livecheckable

### DIFF
--- a/Livecheckables/mariadb@10.0.rb
+++ b/Livecheckables/mariadb@10.0.rb
@@ -1,4 +1,0 @@
-class MariadbAT100
-  livecheck :url => "https://downloads.mariadb.org/",
-            :regex => /Download (10\.0\.[0-9\.]+) Stable Now/
-end


### PR DESCRIPTION
`mariadb@10.0` was [removed from homebrew-core](https://github.com/Homebrew/homebrew-core/pull/46338).