### PR TITLE
Mongodb delete livecheckables

### DIFF
--- a/Livecheckables/mongodb.rb
+++ b/Livecheckables/mongodb.rb
@@ -1,4 +1,0 @@
-class Mongodb
-  livecheck :url => "https://www.mongodb.org/downloads",
-            :regex => /mongodb-src-r(\d+\.\d*[02468]\.\d+)\./
-end

--- a/Livecheckables/mongodb@3.0.rb
+++ b/Livecheckables/mongodb@3.0.rb
@@ -1,4 +1,0 @@
-class MongodbAT30
-  livecheck :url => "https://www.mongodb.org/downloads",
-            :regex => /mongodb-src-r(3\.0\.\d+)\./
-end

--- a/Livecheckables/mongodb@3.2.rb
+++ b/Livecheckables/mongodb@3.2.rb
@@ -1,4 +1,0 @@
-class MongodbAT32
-  livecheck :url => "https://www.mongodb.org/downloads",
-            :regex => /mongodb-src-r(3\.2\.\d+)\./
-end

--- a/Livecheckables/mongodb@3.4.rb
+++ b/Livecheckables/mongodb@3.4.rb
@@ -1,4 +1,0 @@
-class MongodbAT34
-  livecheck :url => "https://www.mongodb.org/downloads",
-            :regex => /mongodb-src-r(3\.4\.\d+)\./
-end

--- a/Livecheckables/mongodb@3.6.rb
+++ b/Livecheckables/mongodb@3.6.rb
@@ -1,4 +1,0 @@
-class MongodbAT36
-  livecheck :url => "https://www.mongodb.org/downloads",
-            :regex => /mongodb-src-r(3\.6\.\d+)\./
-end

--- a/Livecheckables/percona-server-mongodb.rb
+++ b/Livecheckables/percona-server-mongodb.rb
@@ -1,4 +1,0 @@
-class PerconaServerMongodb
-  livecheck :url => "https://www.percona.com/downloads/percona-server-mongodb-LATEST/",
-            :regex => %r{value="percona-server-mongodb-LATEST/percona-server-mongodb-([0-9\-\.]+)"}
-end


### PR DESCRIPTION
All mongodb formulae were [removed in homebrew-core](https://github.com/Homebrew/homebrew-core/pull/43770) after it was migrated to a non open-source license.