### PR TITLE
kubernetes-cli: delete livecheckable

### DIFF
--- a/Livecheckables/kubernetes-cli.rb
+++ b/Livecheckables/kubernetes-cli.rb
@@ -1,4 +1,0 @@
-class KubernetesCli
-  livecheck :url => "https://github.com/kubernetes/kubernetes/releases",
-            :regex => %r{href="/kubernetes/kubernetes/tree/v?(1\.11\.[0-9\.]+)}m
-end


### PR DESCRIPTION
It does not work and it is not necessary anyway.