### PR TITLE
mysql@5.5: delete livecheckable

### DIFF
--- a/Livecheckables/mysql@5.5.rb
+++ b/Livecheckables/mysql@5.5.rb
@@ -1,4 +1,0 @@
-class MysqlAT55
-  livecheck :url => "https://dev.mysql.com/downloads/mysql/5.5.html",
-            :regex => %r{href="\/downloads\/gpg\/\?file=mysql-(\d+.\d+.\d+)-}
-end


### PR DESCRIPTION
`mysql@5.5` was [deleted from homebrew-core](https://github.com/Homebrew/homebrew-core/pull/46354).