### PR TITLE
node@6: delete livecheckable

### DIFF
--- a/Livecheckables/node@6.rb
+++ b/Livecheckables/node@6.rb
@@ -1,4 +1,0 @@
-class NodeAT6
-  livecheck :url => "https://nodejs.org/en/download/releases/",
-            :regex => %r{<td data-label="Version">Node.js (6\.[0-9\.]+)</td>}
-end


### PR DESCRIPTION
`node@6` was [deleted from hombrew-core](https://github.com/Homebrew/homebrew-core/pull/39465).