### PR TITLE
percona-server@5.6: delete livecheckable

### DIFF
--- a/Livecheckables/percona-server@5.6.rb
+++ b/Livecheckables/percona-server@5.6.rb
@@ -1,4 +1,0 @@
-class PerconaServerAT56
-  livecheck :url => "https://www.percona.com/downloads/Percona-Server-5.6/LATEST/",
-            :regex => %r{value="Percona-Server-5.6/Percona-Server-([0-9\-\.]+)"}
-end


### PR DESCRIPTION
`percona-server@5.6` was [deleted from homebrew-core](https://github.com/Homebrew/homebrew-core/pull/36025).