### PR TITLE
Delete php versioned livecheckables

### DIFF
--- a/Livecheckables/php@5.6.rb
+++ b/Livecheckables/php@5.6.rb
@@ -1,4 +1,0 @@
-class PhpAT56
-  livecheck :url => "https://secure.php.net/releases/feed.php",
-            :regex => /PHP (5\.6[0-9\.]+)/
-end

--- a/Livecheckables/php@7.0.rb
+++ b/Livecheckables/php@7.0.rb
@@ -1,4 +1,0 @@
-class PhpAT70
-  livecheck :url => "https://secure.php.net/releases/feed.php",
-            :regex => /PHP (7\.0[0-9\.]+)/
-end

--- a/Livecheckables/php@7.1.rb
+++ b/Livecheckables/php@7.1.rb
@@ -1,4 +1,0 @@
-class PhpAT71
-  livecheck :url => "https://secure.php.net/releases/feed.php",
-            :regex => /PHP (7\.1[0-9\.]+)/
-end


### PR DESCRIPTION
`php@5.6`, `php@7.0` and `php@7.1` were all deleted from homebrew-core due to EOL:
* [`php@5.6` deletion](https://github.com/Homebrew/homebrew-core/pull/35679)
* [`php@7.0` deletion](https://github.com/Homebrew/homebrew-core/pull/34739)
* [`php@7.1` deletion](https://github.com/Homebrew/homebrew-core/pull/47385)