### PR TITLE
raine: remove livecheckable

### DIFF
--- a/Livecheckables/raine.rb
+++ b/Livecheckables/raine.rb
@@ -1,4 +1,0 @@
-class Raine
-  livecheck :url => "http://raine.1emulation.com/download/latest.html",
-            :regex => /Available files for version ([0-9\.]+)</
-end


### PR DESCRIPTION
`raine` was [removed from homebrew-core](https://github.com/Homebrew/homebrew-core/pull/46556).