### PR TITLE
tomcat@6: delete livecheckable

### DIFF
--- a/Livecheckables/tomcat@6.rb
+++ b/Livecheckables/tomcat@6.rb
@@ -1,4 +1,0 @@
-class TomcatAT6
-  livecheck :url => "http://archive.apache.org/dist/tomcat/tomcat-6/",
-            :regex => %r{href="v(.*?)/"}
-end


### PR DESCRIPTION
`tomcat@6` was [deleted from homebrew-core due to EOL](https://github.com/Homebrew/homebrew-core/pull/39942).