### PR TITLE
varnish@4: remove livecheckable

### DIFF
--- a/Livecheckables/varnish@4.rb
+++ b/Livecheckables/varnish@4.rb
@@ -1,4 +1,0 @@
-class VarnishAT4
-  livecheck :url => "https://varnish-cache.org/releases/",
-            :regex => %r{href="\.\./_downloads/varnish-(4\.[0-9,\.]+)\.t}
-end


### PR DESCRIPTION
`varnish@4` was [removed from homebrew-core](https://github.com/Homebrew/homebrew-core/pull/41203).