### PR TITLE
Github action to run brew livecheck on added/modified Livecheckables during PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,4 +26,4 @@ jobs:
       run: brew livecheck
 
     - name: Run brew livecheck on added/modified Livecheckables
-      run: git diff --name-only --diff-filter=AM master -- Livecheckables/ | sed "s/Livecheckables\/\(.*\).rb/\1/" | xargs brew livecheck
+      run: git diff --name-only --diff-filter=AM origin/master -- Livecheckables/ | sed "s|Livecheckables/\(.+\)\.rb|\1|" | xargs brew livecheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,3 +24,6 @@ jobs:
 
     - name: Run brew livecheck
       run: brew livecheck
+
+    - name: Run brew livecheck on added/modified Livecheckables
+      run: git diff --name-only --diff-filter=AM master -- Livecheckables/ | sed "s/Livecheckables\/\(.*\).rb/\1/" | xargs brew livecheck


### PR DESCRIPTION
Whenever a PR adds or modifies a Livecheckable, I manually check that it works locally. With this PR, the CI will do that check.

@MikeMcQuaid : requesting your review since I am not that familiar with Github actions.