### PR TITLE
cfr-decompiler: update regex

### DIFF
--- a/Livecheckables/cfr-decompiler.rb
+++ b/Livecheckables/cfr-decompiler.rb
@@ -1,4 +1,4 @@
 class CfrDecompiler
   livecheck :url => "http://www.benf.org/other/cfr/",
-            :regex => /href="cfr_([0-9\_\.]+)\.j/
+            :regex => /href=".*cfr-([0-9\_\.]+)\.j/
 end


### PR DESCRIPTION
Upstream changed their `href` links to full urls.