### PR TITLE
afio: delete livecheckable

### DIFF
--- a/Livecheckables/afio.rb
+++ b/Livecheckables/afio.rb
@@ -1,4 +1,0 @@
-class Afio
-  livecheck :url => "http://members.chello.nl/~k.holtman/afio.html",
-            :regex => %r{latest version.*?href=".*?/afio-([0-9\.]+)\.t}
-end


### PR DESCRIPTION
`afio` livecheckable points to a website that doesn't exists anymore. Its source is downloaded from Github and livecheck correctly guesses the latest version without the livecheckable.