### PR TITLE
Delete livecheckable related to the python@2 removal

### DIFF
--- a/Livecheckables/ipython@5.rb
+++ b/Livecheckables/ipython@5.rb
@@ -1,4 +1,0 @@
-class IpythonAT5
-  livecheck :url => "https://pypi.python.org/simple/ipython/",
-            :regex => %r{href=".*?/ipython-(5[0-9\.]+)\.t}
-end

--- a/Livecheckables/node@8.rb
+++ b/Livecheckables/node@8.rb
@@ -1,4 +1,0 @@
-class NodeAT8
-  livecheck :url => "https://nodejs.org/en/download/releases/",
-            :regex => %r{<td data-label="Version">Node.js (8\.[0-9\.]+)</td>}
-end


### PR DESCRIPTION
`ipython@5` and `node@8` were both [deleted in homebrew-core](https://github.com/Homebrew/homebrew-core/pull/48460) due to the future removal of `python@2`.