### PR TITLE
globus-toolkit: delete livecheckable

### DIFF
--- a/Livecheckables/globus-toolkit.rb
+++ b/Livecheckables/globus-toolkit.rb
@@ -1,4 +1,0 @@
-class GlobusToolkit
-  livecheck :url => "https://downloads.globus.org/toolkit/gt6/stable/installers/src/",
-            :regex => /href='globus_toolkit-([0-9,\.]+)\.t/
-end


### PR DESCRIPTION
`globus-toolkit` was [deleted in homebrew-core](https://github.com/Homebrew/homebrew-core/pull/48714).