### PR TITLE
osquery: delete livecheckable

### DIFF
--- a/Livecheckables/osquery.rb
+++ b/Livecheckables/osquery.rb
@@ -1,4 +1,0 @@
-class Osquery
-  livecheck :url => "https://github.com/facebook/osquery/releases",
-            :regex => %r{latest.*?href="/facebook/osquery/tree/v?([0-9\.]+)}m
-end


### PR DESCRIPTION
The osquery livecheckable wasn't working and pointed to the Github releases page. The heuristic currently does a good job with Github release so I'm removing the livecheckable.