### PR TITLE
fortio: delete livecheckable

### DIFF
--- a/Livecheckables/fortio.rb
+++ b/Livecheckables/fortio.rb
@@ -1,4 +1,0 @@
-class Fortio
-  livecheck :url => "https://github.com/istio/fortio/releases",
-            :regex => %r{Latest.*?href="/istio/fortio/tree/v?([0-9\.]+)}m
-end


### PR DESCRIPTION
The livecheckable checked github releases but didn't work. The default heuristic works.