### PR TITLE
hdf5: update url and regex

### DIFF
--- a/Livecheckables/hdf5.rb
+++ b/Livecheckables/hdf5.rb
@@ -1,4 +1,4 @@
 class Hdf5
-  livecheck :url => "https://www.hdfgroup.org/downloads/",
-            :regex => /Download HDF5 (.*?)</
+  livecheck :url => "https://www.hdfgroup.org/downloads/hdf5/",
+            :regex => /Newsletter for HDF5-(.*?) Release/
 end


### PR DESCRIPTION
The webpage of hdf5 changed, this updates the livecheckable for the current format.