### PR TITLE
nano: update livecheckable regex

### DIFF
--- a/Livecheckables/nano.rb
+++ b/Livecheckables/nano.rb
@@ -1,4 +1,4 @@
 class Nano
   livecheck :url => "https://www.nano-editor.org/download.php",
-            :regex => /nano-(\d+\.\d+\.\d+)/
+            :regex => /nano-([0-9\.]+)\.tar\.xz/
 end


### PR DESCRIPTION
`nano` webpage now uses two number version, this fixes the regex to be more general.