### PR TITLE
openttd: fix livecheckable url

### DIFF
--- a/Livecheckables/openttd.rb
+++ b/Livecheckables/openttd.rb
@@ -1,4 +1,4 @@
 class Openttd
-  livecheck :url => "http://www.openttd.org/en/",
+  livecheck :url => "https://www.openttd.org/",
             :regex => %r{Download stable \((\d+(\.\d+)+)\)}
 end


### PR DESCRIPTION
`openttd` url doesn't have the `/en` part anymore. Also switch to `https`.