### PR TITLE
netpbm: update livecheckable regex

### DIFF
--- a/Livecheckables/netpbm.rb
+++ b/Livecheckables/netpbm.rb
@@ -1,4 +1,4 @@
 class Netpbm
   livecheck :url => "https://sourceforge.net/p/netpbm/code/HEAD/tree/stable/",
-            :regex => /Release (10\.73\.[0-9]+)/
+    :regex => /Release ([0-9\.]+)/
 end


### PR DESCRIPTION
Generalize the regex to be able to catch the latest version.