### PR TITLE
watch: delete livecheckable

### DIFF
--- a/Livecheckables/watch.rb
+++ b/Livecheckables/watch.rb
@@ -1,4 +1,0 @@
-class Watch
-  livecheck :url => "https://gitlab.com/procps-ng/procps/tags",
-            :regex => %r{href="/procps-ng/procps/tags/v([0-9\.]+)"}
-end


### PR DESCRIPTION
`watch` Livecheckable checks the gitlab page and didn't work. The default heuristic does work on gitlab.