### PR TITLE
logcheck: fix livecheckable regex

### DIFF
--- a/Livecheckables/logcheck.rb
+++ b/Livecheckables/logcheck.rb
@@ -1,4 +1,4 @@
 class Logcheck
   livecheck :url => "https://packages.debian.org/unstable/logcheck",
-            :regex => %r{href="http://http.debian.net/debian/pool/main/l/logcheck/logcheck_([0-9,\.]+)\.tar}
+            :regex => %r{logcheck_([0-9,\.]+)\.tar}
 end


### PR DESCRIPTION
The regex link changed slightly, making it more general.