### PR TITLE
livecheck: fix early return

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -49,8 +49,7 @@ module Homebrew
     end
 
     if cmd = Homebrew.args.named.first
-      require?("livecheck/commands/#{cmd}")
-      return
+      require?("livecheck/commands/#{cmd}") && return
     end
 
     formulae_to_check =


### PR DESCRIPTION
`brew livecheck FORMULA` always exits doing nothing, without this change.