### PR TITLE
Show formula name in every error output

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -76,7 +76,7 @@ module Homebrew
     formulae_to_check.sort.each do |formula|
       print_latest_version formula
     rescue => e
-      onoe e unless Homebrew.args.quiet?
+      onoe "#{Tty.blue}#{formula}#{Tty.reset}: #{e}" unless Homebrew.args.quiet?
       Homebrew.failed = true
     end
   end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -167,5 +167,5 @@ def version_heuristic(urls, regex = nil)
     return match_version_map.values.max unless match_version_map.empty?
   end
 
-  raise TypeError, "Unable to get versions for #{Tty.blue}#{stable.name}#{Tty.reset}"
+  raise TypeError, "Unable to get versions"
 end


### PR DESCRIPTION
When errors other than `Unable to get versions` was raised, the formula name wasn't in the error message. When using livecheck over a large list of formulae it was a hassle to find the culprit.