### PR TITLE
simgrid: update livecheckable url

### DIFF
--- a/Livecheckables/simgrid.rb
+++ b/Livecheckables/simgrid.rb
@@ -1,4 +1,4 @@
 class Simgrid
-  livecheck :url => "http://simgrid.gforge.inria.fr",
+  livecheck :url => "https://simgrid.org/",
             :regex => /href=".*?SimGrid-([0-9\.]+)\.t/
 end


### PR DESCRIPTION
`simgrid` homepage changed which broke the Livecheckable.