### PR TITLE
yaws: update livecheckable

### DIFF
--- a/Livecheckables/yaws.rb
+++ b/Livecheckables/yaws.rb
@@ -1,4 +1,4 @@
 class Yaws
-  livecheck :url => "http://yaws.hyber.org/download/",
-            :regex => /href="yaws-([0-9\.]+)\.t/
+  livecheck :url => "https://github.com/klacke/yaws/releases",
+            :regex => /href=".*yaws-([0-9\.]+)\.t/
 end


### PR DESCRIPTION
`yaws` releases are now on Github. The tags need to be filtered so I updated the regex.