### PR TITLE
atari800: update Livecheckable url and regex

### DIFF
--- a/Livecheckables/atari800.rb
+++ b/Livecheckables/atari800.rb
@@ -1,4 +1,4 @@
 class Atari800
-  livecheck :url => "https://sourceforge.net/projects/atari800/",
-            :regex => %r{.*?/atari800-([0-9\.]+)\.t}
+  livecheck :url => "https://github.com/atari800/atari800/releases",
+            :regex => %r{.*?/atari800-([0-9\.]+)-src\.t}
 end


### PR DESCRIPTION
`atari800` releases are now on Github but the tags were not recognized correctly by the heuristic.