### PR TITLE
azure-cli: add livecheckable

### DIFF
--- a/Livecheckables/azure-cli.rb
+++ b/Livecheckables/azure-cli.rb
@@ -1,0 +1,4 @@
+class AzureCli
+  livecheck :url => "https://github.com/Azure/azure-cli/releases",
+            :regex => %r{href="/Azure/azure-cli/releases/tag/azure-cli-([\d\.]+)"}
+end


### PR DESCRIPTION
This adds a livecheckable for `azure-cli` since the formula uses an unusual URL and doesn't livecheck properly.