### PR TITLE
mg: delete livecheckable

### DIFF
--- a/Livecheckables/mg.rb
+++ b/Livecheckables/mg.rb
@@ -1,4 +1,0 @@
-class Mg
-  livecheck :url => "https://devio.us/~bcallah/mg/",
-            :regex => /href="mg-([0-9\.]+)\.t/
-end


### PR DESCRIPTION
`mg` releases are now on Github and the default heuristic work fine on it.