### PR TITLE
linkerd: update livecheckable url and regex

### DIFF
--- a/Livecheckables/linkerd.rb
+++ b/Livecheckables/linkerd.rb
@@ -1,4 +1,4 @@
 class Linkerd
-  livecheck :url => "https://github.com/linkerd/linkerd/releases",
-            :regex => %r{href="/linkerd/linkerd/tree/v?([0-9\.]+)"}
+  livecheck :url => "https://github.com/linkerd/linkerd2/releases",
+            :regex => %r{href="/linkerd/linkerd2/tree/stable-([0-9\.]+)"}
 end


### PR DESCRIPTION
The upstream url changed and the release tags too, hence a new regex was needed.