### PR TITLE
luajit: add livecheckable

### DIFF
--- a/Livecheckables/luajit.rb
+++ b/Livecheckables/luajit.rb
@@ -1,0 +1,4 @@
+class Luajit
+  livecheck :url => "https://luajit.org/download.html",
+    :regex => /class="downname">LuaJIT-([\d\.]+)</
+end


### PR DESCRIPTION
The default livechecking for LuaJIT doesn't distinguish between stable and beta releases (2.1.0-beta3 is given as the latest version), so this adds a livecheckable to address this.

This assumes that `livecheck` should return the latest stable version and that alpha/beta/RC/etc. releases aren't desirable, of course.