### PR TITLE
spin: delete livecheckable

### DIFF
--- a/Livecheckables/spin.rb
+++ b/Livecheckables/spin.rb
@@ -1,4 +1,0 @@
-class Spin
-  livecheck :url => "http://spinroot.com/spin/Bin/index.html",
-            :regex => /Current Version ([0-9\.]+) /
-end


### PR DESCRIPTION
`spin` Livecheckable was broken. Its codebase is now on Github and the heuristic works fine without the Livecheckable.