### PR TITLE
fastlane: add livecheckable

### DIFF
--- a/Livecheckables/fastlane.rb
+++ b/Livecheckables/fastlane.rb
@@ -1,0 +1,4 @@
+class Fastlane
+  livecheck :url => "https://github.com/fastlane/fastlane.git",
+            :regex => /^([\d\.]+)$/
+end


### PR DESCRIPTION
The default `fastlane` livecheck returns a weird version number (166) rather than the latest version (2.141.0), so this adds a livecheckable to address the issue.