### PR TITLE
apache-spark: add livecheckable

### DIFF
--- a/Livecheckables/apache-spark.rb
+++ b/Livecheckables/apache-spark.rb
@@ -1,0 +1,4 @@
+class ApacheSpark
+  livecheck :url => "https://github.com/apache/spark.git",
+            :regex => /^v([\d\.]+)$/
+end


### PR DESCRIPTION
The apache-spark livecheck returns unstable versions (e.g., 3.0.0-preview2), so this adds a livecheckable that only returns versions without trailing text (e.g., 2.4.5).

I used the GitHub repository tags here because the [Apache Spark website's downloads page](https://spark.apache.org/downloads.html) requires JavaScript to display the available versions. The version numbers are available in the [JavaScript file](https://spark.apache.org/js/downloads.js) but it seems less reliable than just parsing the GitHub releases.

If we absolutely need to use the Apache Spark website, I can rework this to parse the version numbers from the `downloads.js` file.

Past that, is there any preference around whether to parse a Git repo's tags or an HTML page?