### PR TITLE
gcc: add livecheckable

### DIFF
--- a/Livecheckables/gcc.rb
+++ b/Livecheckables/gcc.rb
@@ -1,0 +1,4 @@
+class Gcc
+  livecheck :url => "https://gcc.gnu.org/git/gcc.git",
+            :regex => %r{^releases/gcc-([\d\.]+)$}
+end


### PR DESCRIPTION
gcc's default livecheck picks up releases other than just gcc (e.g., g77-0.5.22) and returns an incorrect new version (e.g., 77-0.5.22). This livecheckable restricts the search to just gcc releases.