### PR TITLE
kubernetes-cli: add livecheckable

### DIFF
--- a/Livecheckables/kubernetes-cli.rb
+++ b/Livecheckables/kubernetes-cli.rb
@@ -1,0 +1,4 @@
+class KubernetesCli
+  livecheck :url => "https://github.com/kubernetes/kubernetes.git",
+            :regex => /^v([\d\.]+)$/
+end


### PR DESCRIPTION
The default livecheck for kubernetes-cli also picks up unstable releases (e.g., 1.18.0-alpha.5), so this restricts it to stable releases.

In testing this, I found that it's possible to drop the `:url` argument and rely on the default behavior for the formula (searching Git tags), simply providing the regex:

```ruby
class KubernetesCli
  livecheck :regex => /^v([\d\.]+)$/
end
```

Is there an established norm around whether to explicitly provide the Git repo URL or allow it to be implicitly inferred? I see 29 existing livecheckables that explicitly provide the Git repo URL and two livecheckables that only include a regex.

On the one hand, omitting the URL means the livecheckable doesn't have to be updated if the Git repo URL changes in the formula. On the other hand, if something changes in livecheck's behavior where a different fetching method is favored for a given formula other than Git, the livecheck may fail. If I had to choose, I would go with regex-only, so the URL is kept in the formula (rather than duplicating effort).

Thoughts?