### PR TITLE
composer: add regex

### DIFF
--- a/Livecheckables/composer.rb
+++ b/Livecheckables/composer.rb
@@ -1,3 +1,4 @@
 class Composer
-  livecheck :url => "https://github.com/composer/composer.git"
+  livecheck :url => "https://github.com/composer/composer.git",
+            :regex => /^[\d\.]+$/
 end


### PR DESCRIPTION
composer's existing livecheckable doesn't filter Git tags, so it also picks up release candidate versions (e.g., 1.10.0-RC). This adds a regex that restricts livecheck to stable releases.