### PR TITLE
Restrict gnome.org matching

### DIFF
--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -123,7 +123,7 @@ def version_heuristic(urls, regex = nil)
         version = Version.new(match)
         match_version_map[match] = version
       end
-    elsif /gnome\.org/.match?(url)
+    elsif /download\.gnome\.org/.match?(url)
       package = url.match(%r{/sources\/(.*?)/})[1]
       page_url = "https://download.gnome.org/sources/#{package}/cache.json"
 


### PR DESCRIPTION
The formulae to which the gnome.org behavior in `livecheck/heuristic.rb` should apply all have a download.gnome.org URL, so I've modified the URL in `heuristic.rb` accordingly.

The default `easy-git` livecheck fails (``Error: easy-git: undefined method `[]' for nil:NilClass``) because its URL uses the people.gnome.org domain and the gnome.org behavior is wrongly applied. Further, the gnome.org behavior even overrides the livecheckable that I created to address this issue, so `heuristic.rb` needed to be updated for accuracy but also to allow for `easy-git` to be fixed with a livecheckable.