### PR TITLE
gitlab-runner: add livecheckable

### DIFF
--- a/Livecheckables/gitlab-runner.rb
+++ b/Livecheckables/gitlab-runner.rb
@@ -1,0 +1,3 @@
+class GitlabRunner
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
Adds a livecheckable that restricts matching to stable versions (skipping release candidates).