### PR TITLE
jenkins: add livecheckable

### DIFF
--- a/Livecheckables/jenkins.rb
+++ b/Livecheckables/jenkins.rb
@@ -1,0 +1,3 @@
+class Jenkins
+  livecheck :regex => /^jenkins-(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
There's a tag in the Jenkins Git repo that throws off livecheck (it returns "3a154d27f5bd99802eb" as the latest version), so this adds a livecheckable to restrict matching to real versions.