### PR TITLE
kops: add livecheckable

### DIFF
--- a/Livecheckables/kops.rb
+++ b/Livecheckables/kops.rb
@@ -1,0 +1,3 @@
+class Kops
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
This adds a livecheckable to restrict matching to stable versions (skipping alpha/beta versions).