### PR TITLE
node-build: add livecheckable

### DIFF
--- a/Livecheckables/node-build.rb
+++ b/Livecheckables/node-build.rb
@@ -1,0 +1,3 @@
+class NodeBuild
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The default livecheck is picking up tags for ruby-build versions (e.g., "ruby-build/v20191024") and returning the numeric portion (e.g., "20191024"), giving a persistent false positive when checking for a new version. This adds a livecheckable to restrict matching to versions consisting of numbers and periods (e.g., 1.2.3).