### PR TITLE
ntfs-3g: add livecheckable

### DIFF
--- a/Livecheckables/ntfs-3g.rb
+++ b/Livecheckables/ntfs-3g.rb
@@ -1,0 +1,3 @@
+class Ntfs3g
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
There are all sorts of tags in the ntfs-3g repo that give false positives when checking for new versions (the current new version if listed as "20070925" from a "PERMISSION_HANDLING_BASE_20070925" tag). This adds a livecheckable to restrict matching to versions consisting of numbers and periods, which encompasses the current version style used (e.g., 2017.3.23).