### PR TITLE
qt: add livecheckable

### DIFF
--- a/Livecheckables/qt.rb
+++ b/Livecheckables/qt.rb
@@ -1,0 +1,3 @@
+class Qt
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
This adds a livecheckable to restrict version matching to stable versions (e.g., no alpha, beta, or rc).