### PR TITLE
source-highlight: add livecheckable

### DIFF
--- a/Livecheckables/source-highlight.rb
+++ b/Livecheckables/source-highlight.rb
@@ -1,0 +1,3 @@
+class SourceHighlight
+  livecheck :regex => /source-highlight-(\d+(?:\.\d+)+)/
+end


### PR DESCRIPTION
The default regex used when matching versions for this package doesn't work because it searches for "src-highlite" but the archives have filenames beginning with "source-highlight". This livecheckable uses a similar regex but addresses the name mismatch.