### PR TITLE
tesseract: add livecheckable

### DIFF
--- a/Livecheckables/tesseract.rb
+++ b/Livecheckables/tesseract.rb
@@ -1,0 +1,3 @@
+class Tesseract
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
This adds a livecheckable to restrict matching to stable versions (skipping alpha, beta, dev, RC, etc.).