### PR TITLE
tfenv: add livecheckable

### DIFF
--- a/Livecheckables/tfenv.rb
+++ b/Livecheckables/tfenv.rb
@@ -1,0 +1,3 @@
+class Tfenv
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
This adds a livecheckable to restrict matching to stable versions (skipping alpha, beta, etc.).