### PR TITLE
theora: add livecheckable

### DIFF
--- a/Livecheckables/theora.rb
+++ b/Livecheckables/theora.rb
@@ -1,0 +1,3 @@
+class Theora
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
This adds a livecheckable to restrict matching to stable versions (skipping alpha, etc.).