### PR TITLE
htop: add livecheckable

### DIFF
--- a/Livecheckables/htop.rb
+++ b/Livecheckables/htop.rb
@@ -1,0 +1,3 @@
+class Htop
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
This adds a livecheckable to restrict matching to stable versions (skipping beta, etc.).