### PR TITLE
tidy-html5: add livecheckable

### DIFF
--- a/Livecheckables/tidy-html5.rb
+++ b/Livecheckables/tidy-html5.rb
@@ -1,0 +1,3 @@
+class TidyHtml5
+  livecheck :regex => /^v?(\d+\.\d*?[02468]\.\d+)$/
+end


### PR DESCRIPTION
[Stable HTML Tidy versions have an even-numbered minor version](https://github.com/htacg/tidy-html5/blob/next/README/VERSION.md#minor), so this adds a livecheckable to restrict matching accordingly.