### PR TITLE
ghostscript: add livecheckable

### DIFF
--- a/Livecheckables/ghostscript.rb
+++ b/Livecheckables/ghostscript.rb
@@ -1,0 +1,3 @@
+class Ghostscript
+  livecheck :regex => /^ghostscript-(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The tags in the Ghostscript repo are for more than just ghostscript, so this restricts matching to tags containing "ghostscript-" followed by a typical numeric version string (e.g., 1.2, 1.2.3, etc.).