### PR TITLE
docker-compose: add livecheckable

### DIFF
--- a/Livecheckables/docker-compose.rb
+++ b/Livecheckables/docker-compose.rb
@@ -1,0 +1,3 @@
+class DockerCompose
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
This adds a livecheckable to restrict version matching to stable versions (no rc, test, etc.).