### PR TITLE
easy-git: add livecheckable

### DIFF
--- a/Livecheckables/easy-git.rb
+++ b/Livecheckables/easy-git.rb
@@ -1,0 +1,4 @@
+class EasyGit
+  livecheck :url => "https://people.gnome.org/~newren/eg/download/",
+            :regex => %r{href="(\d+(?:\.\d+)+)/eg"}
+end


### PR DESCRIPTION
Now that the gnome.org matching restriction has been merged (#218), we can add a livecheckable for `easy-git`.