### PR TITLE
wireguard-tools: update livecheckable with Github url

### DIFF
--- a/Livecheckables/wireguard-tools.rb
+++ b/Livecheckables/wireguard-tools.rb
@@ -1,4 +1,3 @@
 class WireguardTools
-  livecheck :url => "https://git.zx2c4.com/WireGuard",
-            :regex => %r{href=.*>WireGuard-([0-9,\.]+)\.tar}
+  livecheck :url => "https://github.com/WireGuard/wireguard-tools"
 end


### PR DESCRIPTION
I switched the url from the official repository to an official mirror repository on Github which is simpler to parse with the heuristic.