### PR TITLE
[WIP] Adding livecheckables for formulae

### DIFF
--- a/Livecheckables/a52dec.rb
+++ b/Livecheckables/a52dec.rb
@@ -1,0 +1,4 @@
+class A52dec
+  livecheck :url => "http://liba52.sourceforge.net",
+            :regex => /a52dec-([0-9\.]+)/
+end

--- a/Livecheckables/aacgain.rb
+++ b/Livecheckables/aacgain.rb
@@ -1,0 +1,4 @@
+class Aacgain
+  livecheck :url => "https://aacgain.altosdesign.com/alvarez",
+            :regex => /aacgain-([0-9\.]+).tar.bz2/
+end

--- a/Livecheckables/aamath.rb
+++ b/Livecheckables/aamath.rb
@@ -1,0 +1,4 @@
+class Aamath
+  livecheck :url => "http://fuse.superglue.se/aamath",
+            :regex => /aamath-([0-9\.]+).tar.gz/
+end

--- a/Livecheckables/lrzip.rb
+++ b/Livecheckables/lrzip.rb
@@ -1,0 +1,4 @@
+class Lrzip
+  livecheck :url => "http://ck.kolivas.org/apps/lrzip",
+            :regex => /Latest-Is-([0-9\.]+)/
+end


### PR DESCRIPTION
Refer to Issue #236, adding explicit Livecheckables for formulae where `brew livecheck <formula>` throws errors (or) shows wrong version names.