### PR TITLE
aardvark_shell_utils: add livecheckable

### DIFF
--- a/Livecheckables/aardvark_shell_utils.rb
+++ b/Livecheckables/aardvark_shell_utils.rb
@@ -1,0 +1,4 @@
+class AardvarkShellUtils
+  livecheck :url => "http://downloads.laffeycomputer.com/current_builds/shellutils/",
+            :regex => /aardvark_shell_utils-(\d+(?:\.\d+)+)\.tar/
+end


### PR DESCRIPTION
Adding livecheckable for `aardvark_shell_utils` to fix `brew livecheck` errors.