### PR TITLE
lrzip: add livecheckable

### DIFF
--- a/Livecheckables/lrzip.rb
+++ b/Livecheckables/lrzip.rb
@@ -1,0 +1,4 @@
+class Lrzip
+  livecheck :url => "http://ck.kolivas.org/apps/lrzip",
+            :regex => /lrzip-(\d+(?:\.\d+)+)\.tar/
+end


### PR DESCRIPTION
Adding livecheckable for `lrzip` to fix `brew livecheck` errors.