### PR TITLE
docbook: add livecheckable

### DIFF
--- a/Livecheckables/docbook.rb
+++ b/Livecheckables/docbook.rb
@@ -1,0 +1,4 @@
+class Docbook
+  livecheck :url => "https://docbook.org/xml/",
+            :regex => %r{href="(\d+(?:\.\d+)+)/?"}
+end


### PR DESCRIPTION
This adds a livecheckable for docbook and restricts it to stable versions.