### PR TITLE
Update github action with current branch name during diff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,12 +27,9 @@ jobs:
 
     - name: Fetch origin/master
       run: git fetch --depth=1 origin master
-    
-    - name: Get branch name
-      uses: nelonoel/branch-name@v1
 
     - name: Run brew livecheck on added/modified Livecheckables
       run: |
-          git diff --name-only --diff-filter=AM origin/master...${BRANCH_NAME} -- Livecheckables/ |
+          git diff --name-only --diff-filter=AM origin/master...${{ github.head_ref }} -- Livecheckables/ |
           sed "s|Livecheckables/\(.*\)\.rb|\1|" |
           xargs brew livecheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,6 @@ jobs:
 
     - name: Run brew livecheck on added/modified Livecheckables
       run: |
-          git diff --name-only --diff-filter=AM origin/master -- Livecheckables/ |
+          git diff --name-only --diff-filter=AM origin/master...${GITHUB_REF##*/} -- Livecheckables/ |
           sed "s|Livecheckables/\(.*\)\.rb|\1|" |
           xargs brew livecheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,6 @@ jobs:
 
     - name: Run brew livecheck on added/modified Livecheckables
       run: |
-          git diff --name-only --diff-filter=AM origin/master...${{ github.head_ref }} -- Livecheckables/ |
+          git diff --name-only --diff-filter=AM origin/master...${{ github.sha }} -- Livecheckables/ |
           sed "s|Livecheckables/\(.*\)\.rb|\1|" |
           xargs brew livecheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,6 @@ jobs:
 
     - name: Run brew livecheck on added/modified Livecheckables
       run: |
-          git diff --name-only --diff-filter=AM origin/master...${GITHUB_REF##*/} -- Livecheckables/ |
+          git diff --name-only --diff-filter=AM origin/master...${github.head_ref} -- Livecheckables/ |
           sed "s|Livecheckables/\(.*\)\.rb|\1|" |
           xargs brew livecheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,12 @@ jobs:
 
     - name: Fetch origin/master
       run: git fetch --depth=1 origin master
+    
+    - name: Get branch name
+      uses: nelonoel/branch-name@v1
 
     - name: Run brew livecheck on added/modified Livecheckables
       run: |
-          git diff --name-only --diff-filter=AM origin/master...${github.head_ref} -- Livecheckables/ |
+          git diff --name-only --diff-filter=AM origin/master...${BRANCH_NAME} -- Livecheckables/ |
           sed "s|Livecheckables/\(.*\)\.rb|\1|" |
           xargs brew livecheck


### PR DESCRIPTION
I've spotted a few PR where the CI would fail if a newer change was made in master but not yet rebased on the PR branch. This forces `git diff` to only check newer changes coming from the PR branch.