### PR TITLE
heuristic: reject prereleases

### DIFF
--- a/livecheck/extend/formula.rb
+++ b/livecheck/extend/formula.rb
@@ -44,7 +44,7 @@ class Formula
           urls ||= all_urls
           regex = @livecheck_args[:regex]
 
-          version_heuristic(urls, regex)
+          version_heuristic(livecheckable, urls, regex)
         end
 
       Version.new(version_s)


### PR DESCRIPTION
Homebrew does not allow prerelease versions in core tap.
So it might be a good idea to filter them out.

Before:

```
acmetool (guessed) : 0.0.67 ==> 0.2.1
anycable-go (guessed) : 0.6.4 ==> 1.0.0.preview1
apache-brooklyn-cli (guessed) : 0.12.0 ==> 1.0.0-rc3
arangodb (guessed) : 3.6.0 ==> 3.7.0-alpha.1
arduino-cli (guessed) : 0.8.0 ==> 2
auditbeat (guessed) : 6.8.6 ==> 7.6.0
berglas (guessed) : 0.5.0 ==> 0.5.1
buildkit (guessed) : 0.6.3 ==> 1.1.5-experimental
cacli (guessed) : 1.2.29 ==> 1.04
caddy (guessed) : 1.0.4 ==> 2.0.0-beta12
calicoctl (guessed) : 3.12.0 ==> 3.13.0-0.dev
convox (guessed) : 20200129210159 ==> 20200207161122-danone-nodejs10
cosi (guessed) : 0.8.5 ==> 0.8.6
crc (guessed) : 1.4.0 ==> 1.6.0
csvq (guessed) : 1.12.4 ==> 1.12.4-pr.2
devdash (guessed) : 0.2.0 ==> 0.3.0
dlite (guessed) : 1.1.5 ==> 2.0.0-beta9
dnscontrol (guessed) : 2.11 ==> 5609e41703f05f4ad331
docker-credential-helper-ecr (guessed) : 0.4.0 ==> 2/0.3.0-1
filebeat (guessed) : 6.2.4 ==> 7.6.0
fluxctl (guessed) : 1.18.0 ==> 9a99
geoipupdate (guessed) : 4.1.5 ==> 4.2.2
go-bindata (guessed) : 3.16.0 ==> 3.17.0
gollum (guessed) : 0.5.4 ==> 0.6.0-beta2
goose (guessed) : 2.3.0 ==> 2.7.0-rc4
goreman (guessed) : 0.3.5 ==> 93
govc (guessed) : 0.22.1 ==> 0.22.2
fatal: repository 'https://kobo.github.io/groovyserv.git/' not found
heartbeat (guessed) : 6.2.4 ==> 7.6.0
immortal (guessed) : 0.23.0 ==> 0.24.1
inlets (guessed) : 2.6.4 ==> 851a2492f240628e1
istioctl (guessed) : 1.4.5 ==> 1.5.0-beta.2
k3d (guessed) : 1.6.0 ==> 3.0.0-alpha.1
k6 (guessed) : 0.26.0 ==> 0.26.1
krew (guessed) : 0.3.3 ==> 0.3.4
kubernetes-service-catalog-client (guessed) : 0.2.2 ==> 0.3.0-beta.2
kustomize (guessed) : 3.5.4 ==> 8s/v0.1.0
metricbeat (guessed) : 6.8.6 ==> 7.6.0
oauth2l (guessed) : 1.0.1 ==> 1.0.2
okteto (guessed) : 1.6.5 ==> 1.7.2
pilosa (guessed) : 1.4.0 ==> 2.0.0-alpha.1
protoc-gen-go (guessed) : 1.3.3 ==> 1.4.0-rc.1
reposurgeon (guessed) : 3.48 ==> 4.4
rke (guessed) : 1.0.4 ==> 1.1.0-rc6
scc (guessed) : 2.11.0 ==> 928286b8064e2cf6dd35
scw (guessed) : 1.20 ==> 2.0.0-beta.1
singularity (guessed) : 3.5.0 ==> 3.5.3
sonobuoy (guessed) : 0.17.2 ==> 1.11.5-prerelease.1
step (guessed) : 0.13.3 ==> 0.14.0-rc.3
sync_gateway (guessed) : 2.7.0 ==> 4
talisman (guessed) : 1.0.0 ==> 1.1.0
terrahelp (guessed) : 0.7.3 ==> 0.7.4
v2ray-plugin (guessed) : 1.2.0 ==> 20190114
velero (guessed) : 1.2.0 ==> 1.3.0-beta.1
virgil (guessed) : 5.1.7 ==> 5.1.18-alpha
```

After:

```
acmetool (guessed) : 0.0.67 ==> 0.2.1
apache-brooklyn-cli (guessed) : 0.12.0 ==> 1.0.0-M1
auditbeat (guessed) : 6.8.6 ==> 7.6.0
berglas (guessed) : 0.5.0 ==> 0.5.1
buildkit (guessed) : 0.6.3 ==> 1.1.5
cacli (guessed) : 1.2.29 ==> 1.04
convox (guessed) : 20200129210159 ==> 20200207161122-danone-nodejs10
cosi (guessed) : 0.8.5 ==> 0.8.6
crc (guessed) : 1.4.0 ==> 1.6.0
csvq (guessed) : 1.12.4 ==> 1.12.4-pr.2
devdash (guessed) : 0.2.0 ==> 0.3.0
docker-credential-helper-ecr (guessed) : 0.4.0 ==> 2/0.3.0-1
filebeat (guessed) : 6.2.4 ==> 7.6.0
geoipupdate (guessed) : 4.1.5 ==> 4.2.2
goose (guessed) : 2.3.0 ==> 2.6.0
fatal: repository 'https://kobo.github.io/groovyserv.git/' not found
heartbeat (guessed) : 6.2.4 ==> 7.6.0
immortal (guessed) : 0.23.0 ==> 0.24.1
inlets (guessed) : 2.6.4 ==> 851a2492f240628e1
k6 (guessed) : 0.26.0 ==> 0.26.1
krew (guessed) : 0.3.3 ==> 0.3.4
metricbeat (guessed) : 6.8.6 ==> 7.6.0
oauth2l (guessed) : 1.0.1 ==> 1.0.2
okteto (guessed) : 1.6.5 ==> 1.7.2
singularity (guessed) : 3.5.0 ==> 3.5.3
terrahelp (guessed) : 0.7.3 ==> 0.7.4
v2ray-plugin (guessed) : 1.2.0 ==> 20190114
```