### PR TITLE
aalib: add livecheckable

### DIFF
--- a/Livecheckables/aalib.rb
+++ b/Livecheckables/aalib.rb
@@ -1,0 +1,4 @@
+class Aalib
+  livecheck :url => "https://sourceforge.net/projects/aa-project/files/aa-lib/",
+            :regex => /aalib-(\d+(?:\.\d+)+.*?)\.tar/
+end


### PR DESCRIPTION
This is not yet complete, as I have a query. Formula `aalib` is currently at version `1.4rc5`, which is an `rc` version. According to #246, if I understand correctly, such versions are not allowed on Homebrew/core, but `aalib` seems to be an exception (possibly more exist). How must I handle this?

Output for `brew livecheck aalib`:
* Before this change
```Error: aalib: undefined method `[]' for nil:NilClass```
* After this change
`aalib : 1.4rc5 ==> 1.2`