### PR TITLE
buildkit: add livecheckable

### DIFF
--- a/Livecheckables/buildkit.rb
+++ b/Livecheckables/buildkit.rb
@@ -1,0 +1,3 @@
+class Buildkit
+  livecheck :regex => %r{v([0-9\.]+)}
+end


### PR DESCRIPTION
Without this livecheckable, `dockerfile/` prefixed releases are matched.