### PR TITLE
libtcod: delete livechekable

### DIFF
--- a/Livecheckables/libtcod.rb
+++ b/Livecheckables/libtcod.rb
@@ -1,4 +1,0 @@
-class Libtcod
-  livecheck :url => "https://bitbucket.org/libtcod/libtcod/downloads/",
-            :regex => %r{href="/libtcod/libtcod/downloads/.*?-libtcod-([0-9\.]+)\.t}
-end


### PR DESCRIPTION
`libtcod` has moved to Github and the default heuristic correctly guess the version.