### PR TITLE
php: update url and regex

### DIFF
--- a/Livecheckables/php.rb
+++ b/Livecheckables/php.rb
@@ -1,4 +1,4 @@
 class Php
-  livecheck :url => "https://secure.php.net/releases/feed.php",
-            :regex => /PHP (7\.2[0-9\.]+)/
+  livecheck :url => "https://www.php.net/releases/feed.php",
+            :regex => /PHP (\d+(?:\.\d+)+) /
 end


### PR DESCRIPTION
The PHP livecheckable is currently being restricted to version 7.2.x, even though the formula is now at 7.4.3. This unrestricts the version matching, so it will match all stable versions.

Edit: Using the Git repo isn't the best idea, for reasons mentioned below.