### PR TITLE
graphviz: remove url, update regex

### DIFF
--- a/Livecheckables/graphviz.rb
+++ b/Livecheckables/graphviz.rb
@@ -1,4 +1,3 @@
 class Graphviz
-  livecheck :url => "https://graphviz.gitlab.io/_pages/Download/Download_source.html",
-    :regex => /href=".*stable.*graphviz-([\d.]+\.[\d.]+\.[\d.]+)\.t/
+  livecheck :regex => /stable_release_(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable was using the [Graphviz source download page](https://graphviz.gitlab.io/_pages/Download/Download_source.html) and matching against the stable tar.gz files. As of this PR, the download page lists 2.40.1 as the latest stable version, whereas the [Gitlab repo](https://gitlab.com/graphviz/graphviz/) says 2.42.2 (and is currently used in the Graphviz formula).

This updates the livecheckable to remove the URL (using the Git repo, due to the heuristic) and updates the regex to match the stable version tags. The tags in the repo are kind of messy, so the regex may need to be modified again in the future if things change.