### PR TITLE
libmetalink: add livecheckable

### DIFF
--- a/Livecheckables/libmetalink.rb
+++ b/Livecheckables/libmetalink.rb
@@ -1,0 +1,3 @@
+class Libmetalink
+  livecheck :regex => /libmetalink-(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The archive files for `libmetalink` start with `libmetalink-`, so this adds a regex to account for it and produce just the version number.