### PR TITLE
httpie: remove livecheckable

### DIFF
--- a/Livecheckables/httpie.rb
+++ b/Livecheckables/httpie.rb
@@ -1,4 +1,0 @@
-class Httpie
-  livecheck :url => "https://pypi.python.org/pypi/httpie",
-            :regex => /httpie-([0-9,\.]+)\./
-end


### PR DESCRIPTION
The existing livecheckable isn't properly matching the full version number (returning "2.0" for version "2.0.0") and it isn't necessary since the default heuristic behavior (checking Git tags) works correctly. As such, this removes the livecheckable.