### PR TITLE
libvterm: update regex

### DIFF
--- a/Livecheckables/libvterm.rb
+++ b/Livecheckables/libvterm.rb
@@ -1,3 +1,3 @@
 class Libvterm
-  livecheck :regex => /libvterm-\d\+bzr(\d*)/
+  livecheck :regex => /libvterm-(\d+(?:\.\d+)+)\./
 end


### PR DESCRIPTION
The regex in the existing `libvterm` livecheckable isn't properly matching the version string (returning "726" instead of "0.1.3"), so this updates the regex to address the issue.