### PR TITLE
opencv: remove url, update regex

### DIFF
--- a/Livecheckables/opencv.rb
+++ b/Livecheckables/opencv.rb
@@ -1,4 +1,3 @@
 class Opencv
-  livecheck :url => "https://github.com/opencv/opencv/releases",
-            :regex => %r{Latest release.*?href="/opencv/opencv/tree/(3[0-9\.]+)"}m
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable wasn't returning the latest version (3.4.9 instead of 4.2.0), so this removes the URL (letting the heuristic use the Git repo tags) and updates the regex accordingly.