### PR TITLE
gdb: add livecheckable

### DIFF
--- a/Livecheckables/gdb.rb
+++ b/Livecheckables/gdb.rb
@@ -1,0 +1,3 @@
+class Gdb
+  livecheck :regex => /gdb-(\d+(?:\.\d+)+)-release/
+end


### PR DESCRIPTION
The heuristic seems to favor the Git repo (though it will flop around to others if you fiddle with the regex) and this adds a livecheckable with a regex to match the release versions.