### PR TITLE
fish: remove url, update regex

### DIFF
--- a/Livecheckables/fish.rb
+++ b/Livecheckables/fish.rb
@@ -1,4 +1,3 @@
 class Fish
-  livecheck :url => "https://fishshell.com/release_notes.html",
-            :regex => /Release Notes for fish ([0-9\.]+)/
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable returns an incorrect version (3.0.2 instead of 3.1.0), so this removes the URL (letting the heuristic use the Git repo) and updates the regex accordingly.