### PR TITLE
zeromq: add livecheckable

### DIFF
--- a/Livecheckables/zeromq.rb
+++ b/Livecheckables/zeromq.rb
@@ -1,0 +1,3 @@
+class Zeromq
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The `zeromq` git repo currently contains a tag ending in `-win`, which throws off livecheck, so this adds a livecheckable with a regex to restrict the version matching.