### PR TITLE
vault: update url and regex

### DIFF
--- a/Livecheckables/vault.rb
+++ b/Livecheckables/vault.rb
@@ -1,4 +1,4 @@
 class Vault
-  livecheck :url => "https://www.vaultproject.io/downloads.html",
-            :regex => %r{href="https://releases.hashicorp.com/vault/([0-9\.]+)}
+  livecheck :url => "https://releases.hashicorp.com/vault/",
+            :regex => %r{href="/vault/(\d+(?:\.\d+)+)/}
 end


### PR DESCRIPTION
The existing livecheckable uses a page that provides a very limited number of versions and the newest listed version has the possibility of being a beta version. This updates the URL to use a page that lists many releases instead.

The regex is also matching beta versions without returning any beta suffix, so "1.4.0-beta1" was being shown as "1.4.0" in livecheck and reported as the latest version. This restricts the regex to only match stable versions, resolving this issue.