### PR TITLE
pyqt: remove livecheckable

### DIFF
--- a/Livecheckables/pyqt.rb
+++ b/Livecheckables/pyqt.rb
@@ -1,4 +1,0 @@
-class Pyqt
-  livecheck :url => "https://riverbankcomputing.com/software/pyqt/download5",
-            :regex => /PyQt5_gpl-([0-9\.]*)\.t/
-end


### PR DESCRIPTION
The existing livecheckable uses the [Riverbank Computing download page](https://riverbankcomputing.com/software/pyqt/download5), which doesn't list all the newest versions. The newest stable version of `pyqt` is 5.14.1 but the download page only goes up to 5.13.2 before listing the latest development version. The release of 5.14.1 is mentioned in the "Recent news" section (in the right-hand sidebar) but not the downloads page.

Removing the livecheckable lets the heuristic take over, which correctly reports 5.14.1 as the newest version.