### PR TITLE
syncthing: remove url, update regex

### DIFF
--- a/Livecheckables/syncthing.rb
+++ b/Livecheckables/syncthing.rb
@@ -1,4 +1,3 @@
 class Syncthing
-  livecheck :url => "https://github.com/syncthing/syncthing/releases",
-            :regex => %r{href="/syncthing/syncthing/releases/download/.*syncthing-source-v([0-9,\.]+)\.tar}
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing `syncthing` livecheckable uses the GitHub release page, so this removes the URL to allow the heuristic to use the Git repo and updates the regex to match the version tags.