### PR TITLE
heuristic: fix npm version finding

### DIFF
--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -114,10 +114,10 @@ def version_heuristic(livecheckable, urls, regex = nil)
         match_version_map[match] = version
       end
     elsif /registry\.npmjs\.org/.match?(url)
-      package = url.split("/")[3..-3].join("/")
-      page_url = "https://www.npmjs.com/package/#{package}/"
+      package = url.split("/")[3..-3].reject {|s| s === '-'}.join("/")
+      page_url = "https://www.npmjs.com/package/#{package}?activeTab=versions"
 
-      regex ||= %r{package__sidebarText.*?>([0-9\.]+)</p>}
+      regex ||= %r{/package/#{package}/v/([^"]+)"}
 
       page_matches(page_url, regex).each do |match|
         version = Version.new(match)


### PR DESCRIPTION
The npmjs.org version finding in the heuristic (for formulae containing a `registry.npmjs.org` URL) is broken and this updates it to work properly. The changes are as follows:

* The existing method of generating the package name failed for `atomist-cli` (producing "@atomist/cli/-" instead of "@atomist/cli") and needed to be addressed somehow (I chose to reject URL path parts consisting of only "-")
* The trailing slash at the end of the previous URL was leading to a redirection
* The homepage for an npm package only seems to list one version and it's tricky to create a regex to match it. This uses the "Versions" tab instead, which contains a number of versions (easily matched with a regex)
* The regex has been updated to work on the "Versions" tab

This fixes livecheck for the following formulae that contain a `registry.npmjs.org` URL (35 in total):

* angular-cli, apollo-cli, ask-cli, autocode, autorest, aws-cdk, babel, babel, balena-cli, bitwarden-cli, cash-cli, eslint, fauna-shell, fx, gatsby-cli, gitmoji, grunt-cli, jhipster, joplin, lerna, nativefier, newman, node-sass, now-cli, pnpm, pulp, fatal, react-native-cli, sloc, tdkjs, terrahub, triton, ungit, webtorrent-cli, whistle

Some of these will need subsequent livecheckables to address version matching (namely, to restrict matching to the versions we want):

* angular-cli, atomist-cli, balena-cli, now-cli