### PR TITLE
heuristic: restrict npm version matching

### DIFF
--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -117,7 +117,7 @@ def version_heuristic(livecheckable, urls, regex = nil)
       package = url.split("/")[3..-3].reject {|s| s === '-'}.join("/")
       page_url = "https://www.npmjs.com/package/#{package}?activeTab=versions"
 
-      regex ||= %r{/package/#{package}/v/([^"]+)"}
+      regex ||= %r{/package/#{package}/v/(\d+(?:\.\d+)+)"}
 
       page_matches(page_url, regex).each do |match|
         version = Version.new(match)


### PR DESCRIPTION
Working on the formulae that were returning unstable versions after #265 (angular-cli, atomist-cli, balena-cli, now-cli), I found that restricting the heuristic's version-matching regex for npm formulae resolves this issue.