### PR TITLE
utils: explicitly use URI.open

### DIFF
--- a/livecheck/utils.rb
+++ b/livecheck/utils.rb
@@ -22,7 +22,7 @@ end
 
 def page_matches(url, regex)
   puts %Q[Using page_match("#{url}", "#{regex}")] if Homebrew.args.debug?
-  page = open(url).read
+  page = URI.open(url).read
   matches = page.scan(regex)
   puts matches.join(", ") if Homebrew.args.debug?
   matches.map(&:first).uniq


### PR DESCRIPTION
`utils.rb` currently contains the code `open(url).read`, where it would be better to use `URI.open(url).read` to avoid any security issues with `Kernel#open`.