### PR TITLE
Livecheckables should not inherit from Formula

### DIFF
--- a/Livecheckables/libosinfo.rb
+++ b/Livecheckables/libosinfo.rb
@@ -1,4 +1,4 @@
-class Libosinfo < Formula
+class Libosinfo
   livecheck :url => "https://releases.pagure.org/libosinfo/",
             :regex => /libosinfo-([\d.]+)\.tar\.gz/
 end

--- a/Livecheckables/v8.rb
+++ b/Livecheckables/v8.rb
@@ -1,4 +1,4 @@
-class V8 < Formula
+class V8
   livecheck :url => "https://omahaproxy.appspot.com/all.json?os=mac&channel=stable",
             :regex => %r{"v8_version": "(([0-9]+\.){3}[0-9]+)"}
 end


### PR DESCRIPTION
Four existing livecheckables were inheriting from Formula (e.g., `class FormulaName < Formula`), like you would see in a formula file. Presumably, someone copied the entire `class` line from the formula when creating these livecheckables. This removes the Formula inheritance for the two livecheckables with existing formulae, bringing them in line with the others.

The two livecheckables not addressed here (`osinfo-db.rb`, `osinfo-db-tools.rb`) will be removed in separate PRs, as they no longer have corresponding formulae.