### PR TITLE
osinfo-db-tools: delete

### DIFF
--- a/Livecheckables/osinfo-db-tools.rb
+++ b/Livecheckables/osinfo-db-tools.rb
@@ -1,4 +1,0 @@
-class OsinfoDbTools < Formula
-  livecheck :url => "https://releases.pagure.org/libosinfo/",
-            :regex => /osinfo-db-tools-([\d.]+)\.tar\.gz/
-end


### PR DESCRIPTION
This livecheckable no longer has a corresponding formula and should be removed.