### PR TITLE
osinfo-db: delete

### DIFF
--- a/Livecheckables/osinfo-db.rb
+++ b/Livecheckables/osinfo-db.rb
@@ -1,4 +1,0 @@
-class OsinfoDb < Formula
-  livecheck :url => "https://releases.pagure.org/libosinfo/",
-            :regex => /osinfo-db-([\d.]+)\.tar\.xz/
-end


### PR DESCRIPTION
This livecheckable no longer has a corresponding formula and should be removed.