### PR TITLE
virt-manager: delete

### DIFF
--- a/Livecheckables/virt-manager.rb
+++ b/Livecheckables/virt-manager.rb
@@ -1,4 +1,0 @@
-class VirtManager
-  livecheck :url => "https://virt-manager.org/download/sources/virt-manager/",
-            :regex => /virt-manager-([\d.]+)\.tar\.gz/
-end


### PR DESCRIPTION
This livecheckable no longer has a corresponding formula and should be removed.