### PR TITLE
wine: delete

### DIFF
--- a/Livecheckables/wine.rb
+++ b/Livecheckables/wine.rb
@@ -1,4 +1,0 @@
-class Wine
-  livecheck :url => "https://www.winehq.org/",
-            :regex => %r{Stable:.*?href="/announce/3.0.*?">Wine&nbsp;([0-9\.]+)<}m
-end


### PR DESCRIPTION
This livecheckable no longer has a corresponding formula and should be removed.