### PR TITLE
Fix RuboCop Layout/TrailingWhitespace offenses

### DIFF
--- a/Livecheckables/sagittarius-scheme.rb
+++ b/Livecheckables/sagittarius-scheme.rb
@@ -1,4 +1,4 @@
-class SagittariusScheme 
+class SagittariusScheme
   livecheck :url => "https://bitbucket.org/ktakashi/sagittarius-scheme/downloads/",
             :regex => %r{href=".*?/sagittarius-([0-9\.]+)\.t}
 end


### PR DESCRIPTION
This removes trailing whitespace from livecheckables, in line with RuboCop's [Layout/TrailingWhitespace](https://rubocop.readthedocs.io/en/latest/cops_layout/#layouttrailingwhitespace) cop.