### PR TITLE
debian-utils: remove unnecessary comments

### DIFF
--- a/Livecheckables/debianutils.rb
+++ b/Livecheckables/debianutils.rb
@@ -1,6 +1,4 @@
 class Debianutils
-#livecheck.type  regex
-#livecheck.regex ${name}_(\\d+(?:.\\d+)+).dsc
   livecheck :url => "https://packages.qa.debian.org/d/debianutils.html",
             :regex => /debianutils_(\d+(?:.\d+)+).dsc/
 end


### PR DESCRIPTION
The debian-utils livecheckable has some unnecessary comments, so this removes them.