### PR TITLE
gnutls: remove unnecessary comments

### DIFF
--- a/Livecheckables/gnutls.rb
+++ b/Livecheckables/gnutls.rb
@@ -1,6 +1,4 @@
 class Gnutls
-#livecheck.url   [lindex ${master_sites} 0]
-#livecheck.regex "${name}-(\\d+(?:\\.\\d+)*)${extract.suffix}"
   livecheck :url => "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/",
             :regex => /gnutls-(\d+(?:\.\d+)*)\.tar/
 end


### PR DESCRIPTION
The gnutls livecheckable has some seemingly unnecessary comments, so this removes them.