### PR TITLE
osrm-backend: remove url, update regex

### DIFF
--- a/Livecheckables/osrm-backend.rb
+++ b/Livecheckables/osrm-backend.rb
@@ -1,5 +1,3 @@
 class OsrmBackend
-  livecheck :url => "https://api.github.com/repos/Project-OSRM/osrm-backend/releases/latest",
-            :regex => /([0-9\.]+\.[0-9\.]+)"/
-            # :regex => /"tag_name": "v?([0-9\.]+)",/
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable wasn't catching the newest versions (it should be 5.22.0 but lists 5.18.0), so this removes the URL (letting the heuristic use the Git repo tags) and updates the regex to match only stable versions.