### PR TITLE
Fix RuboCop Layout/IndentationWidth offenses

### DIFF
--- a/Livecheckables/armadillo.rb
+++ b/Livecheckables/armadillo.rb
@@ -1,4 +1,4 @@
 class Armadillo
-   livecheck :url => "http://bit.ly/2kLBPoS", # http://arma.sourceforge.net/download.html
-             :regex => /armadillo-(\d+.\d+.\d+).tar.xz/m
+  livecheck :url => "http://bit.ly/2kLBPoS", # http://arma.sourceforge.net/download.html
+            :regex => /armadillo-(\d+.\d+.\d+).tar.xz/m
 end

--- a/Livecheckables/lzo.rb
+++ b/Livecheckables/lzo.rb
@@ -1,4 +1,4 @@
 class Lzo
-    livecheck :url => "https://www.oberhumer.com/opensource/lzo/download/",
-              :regex => /lzo-([\d\.]+)\./
+  livecheck :url => "https://www.oberhumer.com/opensource/lzo/download/",
+            :regex => /lzo-([\d\.]+)\./
 end


### PR DESCRIPTION
This fixes the indentation in livecheckables, in line with RuboCop's [Layout/IndentationWidth](https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutindentationwidth) cop.