### PR TITLE
Fix RuboCop Style/RegexpLiteral offenses

### DIFF
--- a/Livecheckables/avfs.rb
+++ b/Livecheckables/avfs.rb
@@ -1,4 +1,4 @@
 class Avfs
   livecheck :url => "https://sourceforge.net/projects/avf/",
-            :regex => %r{avfs-([0-9\.]+)\.t}
+            :regex => /avfs-([0-9\.]+)\.t/
 end

--- a/Livecheckables/babl.rb
+++ b/Livecheckables/babl.rb
@@ -1,4 +1,4 @@
 class Babl
   livecheck :url => "https://download.gimp.org/pub/babl/0.1/",
-            :regex => %r{babl-(\d+(?:\.\d+)*)\.t}
+            :regex => /babl-(\d+(?:\.\d+)*)\.t/
 end

--- a/Livecheckables/bigloo.rb
+++ b/Livecheckables/bigloo.rb
@@ -1,4 +1,4 @@
 class Bigloo
   livecheck :url => "https://www-sop.inria.fr/indes/fp/Bigloo/",
-            :regex => %r{Current version is .*>([0-9a-z\.]+)<}
+            :regex => /Current version is .*>([0-9a-z\.]+)</
 end

--- a/Livecheckables/black.rb
+++ b/Livecheckables/black.rb
@@ -1,3 +1,3 @@
 class Black
-  livecheck :regex => %r{black (\d+\.\d+(b\d+)?)}
+  livecheck :regex => /black (\d+\.\d+(b\d+)?)/
 end

--- a/Livecheckables/buildkit.rb
+++ b/Livecheckables/buildkit.rb
@@ -1,3 +1,3 @@
 class Buildkit
-  livecheck :regex => %r{v([0-9\.]+)}
+  livecheck :regex => /v([0-9\.]+)/
 end

--- a/Livecheckables/cppad.rb
+++ b/Livecheckables/cppad.rb
@@ -1,4 +1,4 @@
 class Cppad
   livecheck :url => "https://github.com/coin-or/CppAD.git",
-            :regex => %r{(20[0-9]+\.[0-9]+)}
+            :regex => /(20[0-9]+\.[0-9]+)/
 end

--- a/Livecheckables/derby.rb
+++ b/Livecheckables/derby.rb
@@ -1,4 +1,4 @@
 class Derby
   livecheck :url => "http://db.apache.org/derby/derby_downloads.html",
-            :regex => /href="releases\/release-([0-9,\.]+)\.cgi"/
+            :regex => %r{href="releases/release-([0-9,\.]+)\.cgi"}
 end

--- a/Livecheckables/di.rb
+++ b/Livecheckables/di.rb
@@ -1,4 +1,4 @@
 class Di
   livecheck :url => "https://gentoo.com/di/",
-            :regex => /<p>Current Version: ([0-9,\.]+)<\/p>/
+            :regex => %r{<p>Current Version: ([0-9,\.]+)</p>}
 end

--- a/Livecheckables/dust.rb
+++ b/Livecheckables/dust.rb
@@ -1,3 +1,3 @@
 class Dust
-  livecheck :regex => %r{v([\d\.]+)}
+  livecheck :regex => /v([\d\.]+)/
 end

--- a/Livecheckables/eigen.rb
+++ b/Livecheckables/eigen.rb
@@ -1,4 +1,4 @@
 class Eigen
   livecheck :url => "http://eigen.tuxfamily.org/",
-            :regex => %r{Eigen (\d+(\.\d+)+) released}
+            :regex => /Eigen (\d+(\.\d+)+) released/
 end

--- a/Livecheckables/frei0r.rb
+++ b/Livecheckables/frei0r.rb
@@ -1,4 +1,4 @@
 class Frei0r
   livecheck :url => "https://github.com/dyne/frei0r/releases",
-            :regex => /<a href="\/dyne\/frei0r\/releases\/tag\/v([\d\.]+)"/
+            :regex => %r{<a href="/dyne/frei0r/releases/tag/v([\d\.]+)"}
 end

--- a/Livecheckables/gegl.rb
+++ b/Livecheckables/gegl.rb
@@ -1,4 +1,4 @@
 class Gegl
   livecheck :url => "https://download.gimp.org/pub/gegl/0.4/",
-            :regex => %r{gegl-(\d+(?:\.\d+)*)\.tar}
+            :regex => /gegl-(\d+(?:\.\d+)*)\.tar/
 end

--- a/Livecheckables/geos.rb
+++ b/Livecheckables/geos.rb
@@ -1,4 +1,4 @@
 class Geos
   livecheck :url => "https://trac.osgeo.org/geos",
-            :regex => /href="http:\/\/download.osgeo.org\/geos\/geos-(\d+.\d+.\d+).tar.bz2"/
+            :regex => %r{href="http://download.osgeo.org/geos/geos-(\d+.\d+.\d+).tar.bz2"}
 end

--- a/Livecheckables/gsmartcontrol.rb
+++ b/Livecheckables/gsmartcontrol.rb
@@ -1,4 +1,4 @@
 class Gsmartcontrol
   livecheck :url => "https://gsmartcontrol.sourceforge.io/",
-            :regex => %r{GSmartControl (\d+(\.\d+)*)}
+            :regex => /GSmartControl (\d+(\.\d+)*)/
 end

--- a/Livecheckables/icu4c.rb
+++ b/Livecheckables/icu4c.rb
@@ -1,4 +1,4 @@
 class Icu4c
   livecheck :url => "https://github.com/unicode-org/icu/releases",
-            :regex => /href="\/unicode-org\/icu\/releases\/tag\/release-[^"]+"[^>]*>ICU ([\d\.]+)</
+            :regex => %r{href="/unicode-org/icu/releases/tag/release-[^"]+"[^>]*>ICU ([\d\.]+)<}
 end

--- a/Livecheckables/interactive-rebase-tool.rb
+++ b/Livecheckables/interactive-rebase-tool.rb
@@ -1,3 +1,3 @@
 class InteractiveRebaseTool
-  livecheck :regex => %r{([\d]+[\.]+)}
+  livecheck :regex => /([\d]+[\.]+)/
 end

--- a/Livecheckables/jenkins-lts.rb
+++ b/Livecheckables/jenkins-lts.rb
@@ -1,4 +1,4 @@
 class JenkinsLts
   livecheck :url => "http://mirrors.jenkins-ci.org/war-stable/",
-            :regex => /href="(\d+.\d+.\d+)\/"/
+            :regex => %r{href="(\d+.\d+.\d+)/"}
 end

--- a/Livecheckables/kafka.rb
+++ b/Livecheckables/kafka.rb
@@ -1,4 +1,4 @@
 class Kafka
   livecheck :url => "https://kafka.apache.org/downloads",
-      :regex => %r{kafka-([\d,\.]+)-src\.tgz}
+      :regex => /kafka-([\d,\.]+)-src\.tgz/
 end

--- a/Livecheckables/leptonica.rb
+++ b/Livecheckables/leptonica.rb
@@ -1,4 +1,4 @@
 class Leptonica
   livecheck :url => "https://github.com/DanBloomberg/leptonica/releases",
-            :regex => /href="\/DanBloomberg\/leptonica\/releases\/tag\/([\d\.]+)"/
+            :regex => %r{href="/DanBloomberg/leptonica/releases/tag/([\d\.]+)"}
 end

--- a/Livecheckables/libbluray.rb
+++ b/Livecheckables/libbluray.rb
@@ -1,4 +1,4 @@
 class Libbluray
   livecheck :url => "https://download.videolan.org/pub/videolan/libbluray/",
-            :regex => />([\d\.]+)\/</
+            :regex => %r{>([\d\.]+)/<}
 end

--- a/Livecheckables/logcheck.rb
+++ b/Livecheckables/logcheck.rb
@@ -1,4 +1,4 @@
 class Logcheck
   livecheck :url => "https://packages.debian.org/unstable/logcheck",
-            :regex => %r{logcheck_([0-9,\.]+)\.tar}
+            :regex => /logcheck_([0-9,\.]+)\.tar/
 end

--- a/Livecheckables/mupdf.rb
+++ b/Livecheckables/mupdf.rb
@@ -1,4 +1,4 @@
 class Mupdf
   livecheck :url => "https://mupdf.com/downloads/",
-            :regex => /href="archive\/mupdf-([0-9\.]+)-source/
+            :regex => %r{href="archive/mupdf-([0-9\.]+)-source}
 end

--- a/Livecheckables/mysql-connector-c++.rb
+++ b/Livecheckables/mysql-connector-c++.rb
@@ -1,4 +1,4 @@
 class MysqlConnectorCxx
   livecheck :url => "https://dev.mysql.com/downloads/connector/cpp/",
-            :regex => /href="\/downloads\/gpg\/\?file=mysql-connector-c%2B%2B-(\d+.\d+.\d+)-/
+            :regex => %r{href="/downloads/gpg/\?file=mysql-connector-c%2B%2B-(\d+.\d+.\d+)-}
 end

--- a/Livecheckables/nifi.rb
+++ b/Livecheckables/nifi.rb
@@ -1,4 +1,4 @@
 class Nifi
   livecheck :url => "https://nifi.apache.org/download.html",
-            :regex => %r{href=.*nifi-([0-9,\.]+)-bin\.tar}
+            :regex => /href=.*nifi-([0-9,\.]+)-bin\.tar/
 end

--- a/Livecheckables/ninja.rb
+++ b/Livecheckables/ninja.rb
@@ -1,4 +1,4 @@
 class Ninja
   livecheck :url => "https://github.com/ninja-build/ninja/releases",
-            :regex => /href="\/ninja-build\/ninja\/tree\/v([\d.]+\.[\d.]+\.[\d.]+)"/
+            :regex => %r{href="/ninja-build/ninja/tree/v([\d.]+\.[\d.]+\.[\d.]+)"}
 end

--- a/Livecheckables/ocaml.rb
+++ b/Livecheckables/ocaml.rb
@@ -1,4 +1,4 @@
 class Ocaml
   livecheck :url => "https://ocaml.org/releases",
-            :regex => %r{<a href='([\d.]+\.[\d.]+\.?[\d.]?)\.html'>}
+            :regex => /<a href='([\d.]+\.[\d.]+\.?[\d.]?)\.html'>/
 end

--- a/Livecheckables/openttd.rb
+++ b/Livecheckables/openttd.rb
@@ -1,4 +1,4 @@
 class Openttd
   livecheck :url => "https://www.openttd.org/",
-            :regex => %r{Download stable \((\d+(\.\d+)+)\)}
+            :regex => /Download stable \((\d+(\.\d+)+)\)/
 end

--- a/Livecheckables/r.rb
+++ b/Livecheckables/r.rb
@@ -1,4 +1,4 @@
 class R
   livecheck :url => "https://cran.rstudio.com/banner.shtml",
-            :regex => /href="src\/base\/R-.*>R-([\d.]+)\.tar/
+            :regex => %r{href="src/base/R-.*>R-([\d.]+)\.tar}
 end

--- a/Livecheckables/rav1e.rb
+++ b/Livecheckables/rav1e.rb
@@ -1,3 +1,3 @@
 class Rav1e
-  livecheck :regex => %r{v([\d\.]+)}
+  livecheck :regex => /v([\d\.]+)/
 end

--- a/Livecheckables/socat.rb
+++ b/Livecheckables/socat.rb
@@ -1,4 +1,4 @@
 class Socat
   livecheck :url => "http://www.dest-unreach.org/socat/download/",
-            :regex => %r{socat-([0-9\.]+)\.tar\.gz}
+            :regex => /socat-([0-9\.]+)\.tar\.gz/
 end

--- a/Livecheckables/spades.rb
+++ b/Livecheckables/spades.rb
@@ -1,4 +1,4 @@
 class Spades
   livecheck :url => "http://bioinf.spbau.ru/en/content/spades-download-0",
-            :regex => %r{href=".*SPAdes-([0-9\.]+)\.t}
+            :regex => /href=".*SPAdes-([0-9\.]+)\.t/
 end

--- a/Livecheckables/sqliteodbc.rb
+++ b/Livecheckables/sqliteodbc.rb
@@ -1,4 +1,4 @@
 class Sqliteodbc
   livecheck :url => "http://www.ch-werner.de/sqliteodbc/",
-            :regex => %r{HREF="sqliteodbc-([0-9\.]+)\.t}
+            :regex => /HREF="sqliteodbc-([0-9\.]+)\.t/
 end

--- a/Livecheckables/swift.rb
+++ b/Livecheckables/swift.rb
@@ -1,4 +1,4 @@
 class Swift
   livecheck :url => "https://swift.org/download/",
-            :regex => %r{Releases<.*?>Swift ([0-9\.]+)<}m
+            :regex => /Releases<.*?>Swift ([0-9\.]+)</m
 end

--- a/Livecheckables/taktuk.rb
+++ b/Livecheckables/taktuk.rb
@@ -1,4 +1,4 @@
 class Taktuk
   livecheck :url => "https://gforge.inria.fr/frs/?group_id=274",
-            :regex => %r{href=".*?taktuk-([0-9\.]+)\.t}
+            :regex => /href=".*?taktuk-([0-9\.]+)\.t/
 end

--- a/Livecheckables/tor.rb
+++ b/Livecheckables/tor.rb
@@ -1,4 +1,4 @@
 class Tor
   livecheck :url => "https://dist.torproject.org/",
-            :regex => %r{tor-([0-9\.]+)\.tar\.gz}
+            :regex => /tor-([0-9\.]+)\.tar\.gz/
 end

--- a/Livecheckables/v8.rb
+++ b/Livecheckables/v8.rb
@@ -1,4 +1,4 @@
 class V8
   livecheck :url => "https://omahaproxy.appspot.com/all.json?os=mac&channel=stable",
-            :regex => %r{"v8_version": "(([0-9]+\.){3}[0-9]+)"}
+            :regex => /"v8_version": "(([0-9]+\.){3}[0-9]+)"/
 end

--- a/Livecheckables/wapm.rb
+++ b/Livecheckables/wapm.rb
@@ -1,3 +1,3 @@
 class Wapm
-  livecheck :regex => %r{^v?[^3]([\d\.]+)}
+  livecheck :regex => /^v?[^3]([\d\.]+)/
 end

--- a/Livecheckables/websocat.rb
+++ b/Livecheckables/websocat.rb
@@ -1,3 +1,3 @@
 class Websocat
-  livecheck :regex => %r{v([\d\.]+$)}
+  livecheck :regex => /v([\d\.]+$)/
 end

--- a/Livecheckables/wildfly-as.rb
+++ b/Livecheckables/wildfly-as.rb
@@ -1,4 +1,4 @@
 class WildflyAs
   livecheck :url => "http://wildfly.org/downloads/",
-            :regex => %r{href=".*?wildfly-([0-9\.]+\.Final)\.t}
+            :regex => /href=".*?wildfly-([0-9\.]+\.Final)\.t/
 end

--- a/Livecheckables/wireguard-go.rb
+++ b/Livecheckables/wireguard-go.rb
@@ -1,4 +1,4 @@
 class WireguardGo
   livecheck :url => "https://git.zx2c4.com/wireguard-go",
-            :regex => %r{href=.*>wireguard-go-([0-9\.]+)\.t}
+            :regex => /href=.*>wireguard-go-([0-9\.]+)\.t/
 end

--- a/Livecheckables/x265.rb
+++ b/Livecheckables/x265.rb
@@ -1,4 +1,4 @@
 class X265
   livecheck :url => "https://bitbucket.org/multicoreware/x265/downloads/",
-            :regex => /href="\/multicoreware\/x265\/downloads\/x265_([\d.]+)\.tar/
+            :regex => %r{href="/multicoreware/x265/downloads/x265_([\d.]+)\.tar}
 end

--- a/Livecheckables/xvid.rb
+++ b/Livecheckables/xvid.rb
@@ -1,4 +1,4 @@
 class Xvid
   livecheck :url => "https://downloads.xvid.com/downloads/",
-            :regex => %r{href="[^"]+xvidcore-([\d\.]+)\.tar\.bz2"}
+            :regex => /href="[^"]+xvidcore-([\d\.]+)\.tar\.bz2"/
 end


### PR DESCRIPTION
This modifies livecheckables to use the most appropriate regex format (`//` or `%r`) based on the regex contents, in line with RuboCop's [Style/RegexpLiteral](https://rubocop.readthedocs.io/en/latest/cops_style/#styleregexpliteral) cop.

I ran livecheck on the affected formula before and after making these modifications and the output was identical, as expected.