### PR TITLE
Fix RuboCop Style/TrailingCommaInHashLiteral offense

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -134,7 +134,7 @@ module Homebrew
             "is_outdated"            => is_outdated,
             "is_newer_than_upstream" => is_newer_than_upstream,
             "guessed"                => !formula.livecheckable,
-          }
+          },
         }
       else
         puts "#{formula_s} : #{current_s} ==> #{latest_s}"


### PR DESCRIPTION
This adds trailing commas in hash literals, in line with RuboCop's [Style/TrailingCommaInHashLiteral](https://www.rubocop.org/en/stable/cops_style/#styletrailingcommainhashliteral) cop.