### PR TITLE
bower: remove url, update regex

### DIFF
--- a/Livecheckables/bower.rb
+++ b/Livecheckables/bower.rb
@@ -1,4 +1,3 @@
 class Bower
-  livecheck :url   => "https://www.npmjs.com/package/bower",
-            :regex => %r{package__sidebarText.*?>([0-9\.]+)</p>}
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for bower gives an error (`Unable to get versions`), so this removes the URL (allowing the heuristic to take over) and updates the regex accordingly.