### PR TITLE
cataclysm: remove url, update regex

### DIFF
--- a/Livecheckables/cataclysm.rb
+++ b/Livecheckables/cataclysm.rb
@@ -1,4 +1,3 @@
 class Cataclysm
-  livecheck :url   => "https://github.com/CleverRaven/Cataclysm-DDA/releases",
-            :regex => %r{Latest.*?href="/CleverRaven/Cataclysm-DDA/tree/v?([0-9a-zA-Z\.]+)}m
+  livecheck :regex => /^(\d+(\.(?:\d+|[A-Z]+))+)$/
 end


### PR DESCRIPTION
The existing livecheckable gives an error (`Unable to get versions`), so this removes the URL (allowing the heuristic to take over) and updates the regex accordingly.

Though this fixes version finding and properly matches versions, it leads to an incorrect livecheck result. The latest version of cataclysm as of this PR is `0.D` (and this is present in the results) but livecheck reports `0.9` as newer than `0.D`. This would presumably need to be addressed in how `Version` handles comparisons in Homebrew/brew but this PR at least resolves the issues relating to the livecheckable itself.