### PR TITLE
cfengine: update url and regex

### DIFF
--- a/Livecheckables/cfengine.rb
+++ b/Livecheckables/cfengine.rb
@@ -1,4 +1,4 @@
 class Cfengine
-  livecheck :url   => "https://cfengine.com/product/community/source-code/",
-            :regex => %r{href=".*?/cfengine-([0-9\.]+)\.t}
+  livecheck :url   => "https://cfengine.com/release-data/community/releases.json",
+            :regex => /"version": ?"(\d+(?:\.\d+)+)"/
 end


### PR DESCRIPTION
The existing livecheckable for `cfengine` gives an error (`Unable to get versions`), so this updates the URL and regex to address this.

The page used in the livecheckable up to this point does not display versions without JavaScript, so we're unable to get the version information this way. Instead, the page fetches the version information from a JSON file and uses that information to populate the page.

This commit parses the aforementioned `releases.json` file for version information, restricting matching to stable versions.