### PR TITLE
chronograf: delete

### DIFF
--- a/Livecheckables/chronograf.rb
+++ b/Livecheckables/chronograf.rb
@@ -1,4 +1,0 @@
-class Chronograf
-  livecheck :url   => "https://portal.influxdata.com/downloads",
-            :regex => /chronograf.*?>v?([0-9\.]+)</
-end


### PR DESCRIPTION
The existing chronograf livecheckable gives an error (`Unable to get versions`). This removes the livecheckable, as the heuristic is capable of finding and identifying versions perfectly fine.