### PR TITLE
cracklib: remove url, update regex

### DIFF
--- a/Livecheckables/cracklib.rb
+++ b/Livecheckables/cracklib.rb
@@ -1,4 +1,3 @@
 class Cracklib
-  livecheck :url   => "https://github.com/cracklib/cracklib/releases",
-            :regex => %r{href="/cracklib/cracklib/tree/cracklib-([0-9\.]+)}
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for cracklib gives an error (`Unable to get versions`), so this removes the URL (allowing the heuristic to take over) and updates the regex accordingly (restricting matching to stable versions).