### PR TITLE
deployer: update regex

### DIFF
--- a/Livecheckables/deployer.rb
+++ b/Livecheckables/deployer.rb
@@ -1,4 +1,4 @@
 class Deployer
   livecheck :url   => "https://deployer.org/download",
-            :regex => %r{Latest version.*?href=".*?/v?([0-9,\.]+)/deployer\.phar}m
+            :regex => %r{/releases/v?(\d+(?:\.\d+)+)/deployer.phar}
 end


### PR DESCRIPTION
The existing livecheckable for `deployer` gives an error (`Unable to get versions`), so this updates the regex to fix the issue.