### PR TITLE
dnscrypt-proxy: remove url, update regex

### DIFF
--- a/Livecheckables/dnscrypt-proxy.rb
+++ b/Livecheckables/dnscrypt-proxy.rb
@@ -1,4 +1,3 @@
 class DnscryptProxy
-  livecheck :url   => "https://github.com/jedisct1/dnscrypt-proxy/releases",
-            :regex => %r{Latest.*?href="/jedisct1/dnscrypt-proxy/tree/v?([0-9\.]+)}m
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `dnscrypt-proxy` gives an error (`Unable to get versions`), so this removes the URL (allowing the heuristic to take over) and updates the regex accordingly.