### PR TITLE
dnsperf: update url and regex

### DIFF
--- a/Livecheckables/dnsperf.rb
+++ b/Livecheckables/dnsperf.rb
@@ -1,4 +1,4 @@
 class Dnsperf
-  livecheck :url   => "https://www.akamai.com/us/en/products/network-operator/measurement-tools.jsp",
-            :regex => /dnsperf and resperf ([0-9\.]+) – source distribution/
+  livecheck :url   => "https://www.dns-oarc.net/tools/dnsperf",
+            :regex => /dnsperf-(\d+(?:\.\d+)+)\.tar/
 end


### PR DESCRIPTION
The existing livecheckable for `dnsperf` gives an error (`Unable to get versions`), so this updates the URL (addressing the redirection) and regex to fix the issue.