### PR TITLE
Fix issue with true values appearing in JSON output

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -80,6 +80,7 @@ module Homebrew
     rescue => e
       onoe "#{Tty.blue}#{formula}#{Tty.reset}: #{e}" unless Homebrew.args.quiet?
       Homebrew.failed = true
+      nil
     end
 
     puts JSON.generate(formulae_checked.compact) if Homebrew.args.json?


### PR DESCRIPTION
While parsing livecheck JSON output, I noticed that `true` values were interspersed into the output array.  Looking closer, they appeared to correspond with formulae that had run into errors.

It looks like the source of the issue was `Homebrew.failed = true` being implicitly returned where the error is handled in `livecheck.rb`.  Adding a `nil` after this line prevents `true` from being returned and all seems well in the output.

For example, we can test `acme` using `brew livecheck --json acme`, since it currently errors.

**Before**
```
Error: acme: undefined method `[]' for nil:NilClass
[true]
```

**After**:
```
Error: acme: undefined method `[]' for nil:NilClass
[]
```

---

Ideally, passing the `--json` flag should output JSON and nothing else. This would require any errors or warnings to be part of the JSON somehow (rather being displayed like normal livecheck output), so that's a matter for a later PR.