### PR TITLE
Allow :skip in livecheckables to skip formulae

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -99,6 +99,21 @@ module Homebrew
       return
     end
 
+    has_hash_arg_with_skip =
+      formula.livecheck_args.is_a?(Hash) && formula.livecheck_args.key?(:skip)
+    if has_hash_arg_with_skip || formula.livecheck_args == :skip
+      if has_hash_arg_with_skip &&
+         formula.livecheck_args[:skip].is_a?(String) &&
+         !formula.livecheck_args[:skip].empty?
+        skip_msg = " - #{formula.livecheck_args[:skip]}"
+      else
+        skip_msg = ""
+      end
+
+      puts "#{Tty.red}#{formula}#{Tty.reset} : skipped#{skip_msg}" unless Homebrew.args.quiet?
+      return
+    end
+
     current = formula.stable? ? formula.version : formula.installed_version
     latest = formula.stable? ? formula.latest : formula.latest_head_version
     if (m = latest.to_s.match(/(.*)-release$/)) && !current.to_s.match(/.*-release$/)

--- a/livecheck/extend/formula.rb
+++ b/livecheck/extend/formula.rb
@@ -5,12 +5,16 @@ class Formula
     self.class.latest
   end
 
+  def livecheck_args
+    self.class.livecheck_args
+  end
+
   def livecheckable
     self.class.livecheckable
   end
 
   class << self
-    attr_reader :livecheckable
+    attr_reader :livecheck_args, :livecheckable
 
     def all_urls
       urls = []


### PR DESCRIPTION
Some formulae are important and we want to keep them around but they will not see a new version anytime soon (if ever) and livecheck shouldn't waste effort checking them. For example, the `imap-uw` formula states, "imap-uw is unmaintained software; the author has passed away and there is no active successor project."

I personally have this installed and I feel that there's still value in keeping this in Homebrew but the URLs in the formula are dead (imap-uw has been seemingly scrubbed from University of Washington's website). As it stands, livecheck will always fail with this formula unless something changes upstream. I regularly run `brew livecheck --installed` and `brew livecheck --all`, so it would be nice to avoid unnecessary checks.

To address this issue, this PR adds support for using `:skip` in the `livecheck` arguments to tell livecheck not to check for new versions of a formula. The value is either a string containing a _very_ brief message explaining why the formula is skipped or `nil` (no message).

The livecheckable looks like this in practice:

```ruby
class ImapUw
  livecheck :skip => "Not maintained"
end
```

The output looks like this when an explanation is provided:

```
imap-uw : skipped - Not maintained
```

The output looks like this when an explanation is omitted (i.e., `:skip => nil`):

```
imap-uw : skipped
```

Please look through the code and provide feedback if you have a moment. My Ruby's a bit rusty these days and my knowledge of Homebrew is incomplete, so there's likely room for improvement.