### PR TITLE
graphviz: update url and regex

### DIFF
--- a/Livecheckables/graphviz.rb
+++ b/Livecheckables/graphviz.rb
@@ -1,3 +1,4 @@
 class Graphviz
-  livecheck :regex => /stable_release_(\d+(?:\.\d+)+)$/
+  livecheck :url   => "https://www2.graphviz.org/Packages/stable/portable_source/",
+            :regex => /href="graphviz-(\d+(?:\.\d+)+)\.tar/
 end


### PR DESCRIPTION
As @Bo98 mentioned in Homebrew/homebrew-core#51115, the 2.42.3 release of Graphviz wasn't (or hasn't yet been) tagged in Git, so livecheck isn't picking it up.

This PR updates the livecheckable to use the archive index page found in the Graphviz formula (https://www2.graphviz.org/Packages/stable/portable_source/) and modifies the regex to match the stable archive files.