### PR TITLE
netcdf: remove url, update regex

### DIFF
--- a/Livecheckables/netcdf.rb
+++ b/Livecheckables/netcdf.rb
@@ -1,4 +1,3 @@
 class Netcdf
-  livecheck :url   => "https://www.unidata.ucar.edu/software/netcdf/",
-            :regex => /alt='NetCDF ([0-9\.]+)'/
+  livecheck :regex => /^(?:netcdf-|v)?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The `netcdf` livecheckable wasn't properly finding the newest version (only matching 4.7.2 on the page when 4.7.3 was the newest version), so this removes the URL (allowing the heuristic to take over and use Git tags) and updates the regex to match stable versions.