### PR TITLE
itk: add livecheckable

### DIFF
--- a/Livecheckables/itk.rb
+++ b/Livecheckables/itk.rb
@@ -1,0 +1,3 @@
+class Itk
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The heuristic uses the ITK Git repo tags by default but it reports an unstable version as the newest. This adds a livecheckable to restrict matching to stable versions only.