### PR TITLE
eye-d3: delete

### DIFF
--- a/Livecheckables/eye-d3.rb
+++ b/Livecheckables/eye-d3.rb
@@ -1,4 +1,0 @@
-class EyeD3
-  livecheck :url   => "http://eyed3.nicfit.net/releases/",
-            :regex => /href="eyeD3-([0-9\.]+)\.t/
-end


### PR DESCRIPTION
The `eye-d3` livecheckable was returning a 403 and needed to be updated somehow. The formula was recently switched to use the PyPI archive (Homebrew/homebrew-core#50883), so the heuristic is now capable of finding the newest version for this formula. This removes the livecheckable to allow the heuristic to take over.