### PR TITLE
imap-uw: add livecheckable to skip

### DIFF
--- a/Livecheckables/imap-uw.rb
+++ b/Livecheckables/imap-uw.rb
@@ -1,0 +1,3 @@
+class ImapUw
+  livecheck :skip => "Not maintained"
+end


### PR DESCRIPTION
As mentioned in the comment at the top of the `imap-uw` formula, the author of `imap-uw` passed away, so the software is no longer maintained and unlikely to ever see a new version. The archives in the formula still exist, so we want to keep the formula around but it's not necessary to check for new versions.

This adds a livecheckable to skip the formula, using the new `:skip` feature. The string that's used as `:skip`'s value is a very brief message explaining why the formula is being skipped. In this case, the output looks like this:

```
imap-uw : skipped - Not maintained
```