### PR TITLE
Skip formulae with gist.github.com stable URL

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -101,11 +101,14 @@ module Homebrew
 
     has_hash_arg_with_skip =
       formula.livecheck_args.is_a?(Hash) && formula.livecheck_args.key?(:skip)
-    if has_hash_arg_with_skip || formula.livecheck_args == :skip
+    is_gist = formula.stable.url.include?("gist.github.com")
+    if has_hash_arg_with_skip || formula.livecheck_args == :skip || is_gist
       skip_msg = if has_hash_arg_with_skip &&
                     formula.livecheck_args[:skip].is_a?(String) &&
                     !formula.livecheck_args[:skip].empty?
         " - #{formula.livecheck_args[:skip]}"
+      elsif is_gist
+        " - Stable URL is a GitHub Gist"
       else
         ""
       end


### PR DESCRIPTION
I previously set the heuristic to skip Gist URLs but this can lead to a generic "Unable to get versions" message when the only URL is a Gist. Currently, the only formula meeting this criteria is `browser`. I was planning on creating a `:skip` livecheckable for `browser` but I thought it might be better to automatically do this in livecheck for similar formulae that may pop up in the future (hopefully none, to be honest).

This PR modifies the existing logic for the `:skip` feature such that `livecheck` will automatically skip formulae with `gist.github.com` in `stable.url` and present the following output:

```
browser : skipped - Stable URL is a GitHub Gist
```

Is this something that we're interested in or do you think it would be better to simply create a `:skip` livecheckable for `browser`?