### PR TITLE
Add --full-name flag

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -41,6 +41,10 @@ module Homebrew
     end
   end
 
+  def formula_name(formula)
+    Homebrew.args.full_name? ? formula.full_name : formula
+  end
+
   def livecheck
     livecheck_args.parse
 
@@ -80,7 +84,7 @@ module Homebrew
     formulae_checked = formulae_to_check.sort.map do |formula|
       print_latest_version formula
     rescue => e
-      onoe "#{Tty.blue}#{formula}#{Tty.reset}: #{e}" unless Homebrew.args.quiet?
+      onoe "#{Tty.blue}#{formula_name(formula)}#{Tty.reset}: #{e}" unless Homebrew.args.quiet?
       Homebrew.failed = true
       nil
     end
@@ -90,13 +94,13 @@ module Homebrew
 
   def print_latest_version(formula)
     if formula.to_s.include?("@") && !formula.livecheckable
-      puts "#{Tty.red}#{formula}#{Tty.reset} : versioned" unless Homebrew.args.quiet?
+      puts "#{Tty.red}#{formula_name(formula)}#{Tty.reset} : versioned" unless Homebrew.args.quiet?
       return
     end
 
     if !formula.stable? && !formula.installed?
       unless Homebrew.args.quiet?
-        puts "#{Tty.red}#{formula}#{Tty.reset} : HEAD only formula must be installed to be livecheckable"
+        puts "#{Tty.red}#{formula_name(formula)}#{Tty.reset} : HEAD only formula must be installed to be livecheckable"
       end
       return
     end
@@ -112,7 +116,7 @@ module Homebrew
         skip_msg = ""
       end
 
-      puts "#{Tty.red}#{formula}#{Tty.reset} : skipped#{skip_msg}" unless Homebrew.args.quiet?
+      puts "#{Tty.red}#{formula_name(formula)}#{Tty.reset} : skipped#{skip_msg}" unless Homebrew.args.quiet?
       return
     end
 
@@ -125,13 +129,12 @@ module Homebrew
     is_outdated = current < latest
     is_newer_than_upstream = current > latest
 
-    formula_name = Homebrew.args.full_name? ? formula.full_name : formula
-    formula_s = "#{Tty.blue}#{formula_name}#{Tty.reset}"
+    formula_s = "#{Tty.blue}#{formula_name(formula)}#{Tty.reset}"
 
     if is_outdated || !Homebrew.args.newer_only?
       if Homebrew.args.json?
         return {
-          "formula" => formula_name,
+          "formula" => formula_name(formula),
           "version" => {
             "current"                => current.to_s,
             "latest"                 => latest.to_s,

--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -126,6 +126,7 @@ module Homebrew
     is_newer_than_upstream = current > latest
 
     formula_name = Homebrew.args.full_name? ? formula.full_name : formula
+    formula_s = "#{Tty.blue}#{formula_name}#{Tty.reset}"
 
     if is_outdated || !Homebrew.args.newer_only?
       if Homebrew.args.json?
@@ -140,7 +141,6 @@ module Homebrew
           },
         }
       else
-        formula_s = "#{Tty.blue}#{formula_name}#{Tty.reset}"
         formula_s += " (guessed)" unless formula.livecheckable
         current_s =
           if is_newer_than_upstream

--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -25,6 +25,8 @@ module Homebrew
       switch :verbose
       switch :quiet
       switch :debug
+      switch "--full-name",
+             description: "Print formulae with fully-qualified names."
       flag   "--tap=",
              description: "Check the formulae within the given tap, specified as <user>`/`<repo>."
       switch "--installed",
@@ -123,27 +125,12 @@ module Homebrew
     is_outdated = current < latest
     is_newer_than_upstream = current > latest
 
-    formula_s = "#{Tty.blue}#{formula}#{Tty.reset}"
-    formula_s += " (guessed)" unless formula.livecheckable
-    current_s =
-      if is_newer_than_upstream
-        "#{Tty.red}#{current}#{Tty.reset}"
-      else
-        current.to_s
-      end
+    formula_name = Homebrew.args.full_name? ? formula.full_name : formula
 
-    latest_s =
-      if is_outdated
-        "#{Tty.green}#{latest}#{Tty.reset}"
-      else
-        latest.to_s
-      end
-
-    needs_to_show = is_outdated || !Homebrew.args.newer_only?
-    if needs_to_show
+    if is_outdated || !Homebrew.args.newer_only?
       if Homebrew.args.json?
         return {
-          "formula" => formula.full_name,
+          "formula" => formula_name,
           "version" => {
             "current"                => current.to_s,
             "latest"                 => latest.to_s,
@@ -153,6 +140,20 @@ module Homebrew
           },
         }
       else
+        formula_s = "#{Tty.blue}#{formula_name}#{Tty.reset}"
+        formula_s += " (guessed)" unless formula.livecheckable
+        current_s =
+          if is_newer_than_upstream
+            "#{Tty.red}#{current}#{Tty.reset}"
+          else
+            current.to_s
+          end
+        latest_s =
+          if is_outdated
+            "#{Tty.green}#{latest}#{Tty.reset}"
+          else
+            latest.to_s
+          end
         puts "#{formula_s} : #{current_s} ==> #{latest_s}"
       end
     end


### PR DESCRIPTION
1. Add `--full-name` flag to use fully-qualified formulae names in reports.
2. Move formatted strings (`formula_s`, `current_s`, etc) to the corresponding `if` block to avoid evaluating them when they're not needed.
3. Squash
```ruby
    needs_to_show = is_outdated || !Homebrew.args.newer_only?
    if needs_to_show
```
into
```ruby
    if is_outdated || !Homebrew.args.newer_only?
```