### PR TITLE
syck: add livecheckable to skip

### DIFF
--- a/Livecheckables/syck.rb
+++ b/Livecheckables/syck.rb
@@ -1,0 +1,3 @@
+class Syck
+  livecheck :skip => "Not maintained"
+end


### PR DESCRIPTION
`syck` hasn't been actively developed or maintained for quite some time. why hasn't been around since 2009 and this repo (a copy of the last version but with some additional updates since 2009) hasn't been updated since 2012. I don't imagine this situation will change, so we're better off skipping it in livecheck.