### PR TITLE
term: add livecheckable to skip

### DIFF
--- a/Livecheckables/term.rb
+++ b/Livecheckables/term.rb
@@ -1,0 +1,3 @@
+class Term
+  livecheck :skip => "Cannot reliably check for new releases upstream"
+end


### PR DESCRIPTION
`term` is one script in [a GitHub repo consisting of many scripts](https://github.com/liyanage/macosx-shell-scripts). These scripts are updated individually and no releases are made, so there doesn't appear to be a way to reliably check for new versions. Even if we could, the script hasn't been updated since 2009 and it doesn't seem likely it will be updated in the future. All in all, it makes sense to skip `term` in livecheck.