### PR TITLE
wrk-trello: add livecheckable to skip

### DIFF
--- a/Livecheckables/wrk-trello.rb
+++ b/Livecheckables/wrk-trello.rb
@@ -1,0 +1,3 @@
+class WrkTrello
+  livecheck :skip => "Not actively developed or maintained"
+end


### PR DESCRIPTION
`wrk-trello` hasn't been updated since 2012 and the author has mentioned in issues that it isn't maintained. There aren't any releases tagged on GitHub, so we can't really check for new versions anyway. With this in mind, it's probably best to skip this formula until/unless something changes upstream.