### PR TITLE
emacs: add livecheckable

### DIFF
--- a/Livecheckables/emacs.rb
+++ b/Livecheckables/emacs.rb
@@ -1,0 +1,3 @@
+class Emacs
+  livecheck :regex => /emacs-(\d+\.\d+)$/
+end


### PR DESCRIPTION
Per the [Emacs version scheme explanation](https://www.gnu.org/software/emacs/manual/html_node/efaq/Latest-version-of-Emacs.html), versions with two components (e.g., 1.2) are releases and versions with three components (e.g., 1.2.3) are development versions. This adds a regex to restrict version matching for Emacs to stable versions (those with two components).