### PR TITLE
kustomize: add livecheckable

### DIFF
--- a/Livecheckables/kustomize.rb
+++ b/Livecheckables/kustomize.rb
@@ -1,0 +1,3 @@
+class Kustomize
+  livecheck :regex => %r{kustomize/v?(\d+(?:\.\d+)+)$}
+end


### PR DESCRIPTION
The `kustomize` Git repo contains tags for more than just `kustomize`, so this adds a livecheckable with a regex to restrict version matching to stable versions starting with `kustomize/`.