### PR TITLE
heuristic: add apache.org check

### DIFF
--- a/Livecheckables/activemq.rb
+++ b/Livecheckables/activemq.rb
@@ -1,4 +1,0 @@
-class Activemq
-  livecheck :url   => "https://activemq.apache.org/news.html",
-            :regex => /ActiveMQ ([0-9\.]+) Release/
-end

--- a/Livecheckables/apache-opennlp.rb
+++ b/Livecheckables/apache-opennlp.rb
@@ -1,4 +1,0 @@
-class ApacheOpennlp
-  livecheck :url   => "https://opennlp.apache.org/download.html",
-            :regex => /apache-opennlp-([0-9\.]+)-bin.tar.gz"/
-end

--- a/Livecheckables/apache-spark.rb
+++ b/Livecheckables/apache-spark.rb
@@ -1,4 +1,0 @@
-class ApacheSpark
-  livecheck :url   => "https://github.com/apache/spark.git",
-            :regex => /^v([\d\.]+)$/
-end

--- a/Livecheckables/apr-util.rb
+++ b/Livecheckables/apr-util.rb
@@ -1,4 +1,0 @@
-class AprUtil
-  livecheck :url   => "http://apr.apache.org/",
-            :regex => /recommended.*?APR-util (\d+(?:\.\d+)*)/m
-end

--- a/Livecheckables/apr.rb
+++ b/Livecheckables/apr.rb
@@ -1,4 +1,0 @@
-class Apr
-  livecheck :url   => "http://apr.apache.org/",
-            :regex => /recommended.*?APR (\d+(?:\.\d+)*)/m
-end

--- a/Livecheckables/avro-c.rb
+++ b/Livecheckables/avro-c.rb
@@ -1,4 +1,0 @@
-class AvroC
-  livecheck :url   => "http://mirrors.ocf.berkeley.edu/apache/avro/stable/",
-            :regex => /href="avro-src-([0-9\.]+)\.t/
-end

--- a/Livecheckables/avro-cpp.rb
+++ b/Livecheckables/avro-cpp.rb
@@ -1,4 +1,0 @@
-class AvroCpp
-  livecheck :url   => "http://mirrors.ocf.berkeley.edu/apache/avro/stable/cpp",
-            :regex => /href="avro-cpp-([0-9\.]+)\.t/
-end

--- a/Livecheckables/derby.rb
+++ b/Livecheckables/derby.rb
@@ -1,4 +1,0 @@
-class Derby
-  livecheck :url   => "http://db.apache.org/derby/derby_downloads.html",
-            :regex => %r{href="releases/release-([0-9,\.]+)\.cgi"}
-end

--- a/Livecheckables/fop.rb
+++ b/Livecheckables/fop.rb
@@ -1,4 +1,0 @@
-class Fop
-  livecheck :url   => "https://xmlgraphics.apache.org/fop/index.html",
-            :regex => /The latest version of FOP is available.*?>FOP ([0-9\.]+)</
-end

--- a/Livecheckables/fuseki.rb
+++ b/Livecheckables/fuseki.rb
@@ -1,4 +1,0 @@
-class Fuseki
-  livecheck :url   => "https://jena.apache.org/download/index.cgi",
-            :regex => %r{href=".*?/binaries/apache-jena-([0-9\.]+)\.z}
-end

--- a/Livecheckables/hadoop.rb
+++ b/Livecheckables/hadoop.rb
@@ -1,4 +1,0 @@
-class Hadoop
-  livecheck :url   => "http://apache.claz.org/hadoop/common/",
-            :regex => %r{href="hadoop-([0-9\.]+)/}
-end

--- a/Livecheckables/hbase.rb
+++ b/Livecheckables/hbase.rb
@@ -1,4 +1,0 @@
-class Hbase
-  livecheck :url   => "https://mirrors.ocf.berkeley.edu/apache/hbase/stable/",
-            :regex => /href="hbase-([0-9,\.]+)-bin\.t/
-end

--- a/Livecheckables/hive.rb
+++ b/Livecheckables/hive.rb
@@ -1,4 +1,0 @@
-class Hive
-  livecheck :url   => "https://hive.apache.org/downloads.html",
-            :regex => /release ([0-9\.]+) available/
-end

--- a/Livecheckables/httpd.rb
+++ b/Livecheckables/httpd.rb
@@ -1,4 +1,0 @@
-class Httpd
-  livecheck :url   => "https://www.apache.org/dist/httpd/Announcement2.4.html",
-            :regex => /Apache HTTP Server ([0-9\.]+) Released/
-end

--- a/Livecheckables/jena.rb
+++ b/Livecheckables/jena.rb
@@ -1,4 +1,0 @@
-class Jena
-  livecheck :url   => "https://jena.apache.org/download/index.cgi",
-            :regex => %r{/binaries/apache-jena-([0-9\.]+)\.t}
-end

--- a/Livecheckables/kafka.rb
+++ b/Livecheckables/kafka.rb
@@ -1,4 +1,0 @@
-class Kafka
-  livecheck :url   => "https://kafka.apache.org/downloads",
-            :regex => /kafka-([\d,\.]+)-src\.tgz/
-end

--- a/Livecheckables/nifi-registry.rb
+++ b/Livecheckables/nifi-registry.rb
@@ -1,4 +1,0 @@
-class NifiRegistry
-  livecheck :url   => "http://apache.claz.org/nifi/nifi-registry/",
-            :regex => %r{href="nifi-registry-([0-9\.]+)/}
-end

--- a/Livecheckables/nifi.rb
+++ b/Livecheckables/nifi.rb
@@ -1,4 +1,0 @@
-class Nifi
-  livecheck :url   => "https://nifi.apache.org/download.html",
-            :regex => /href=.*nifi-([0-9,\.]+)-bin\.tar/
-end

--- a/Livecheckables/solr.rb
+++ b/Livecheckables/solr.rb
@@ -1,4 +1,0 @@
-class Solr
-  livecheck :url   => "https://lucene.apache.org/solr/",
-            :regex => /Solr ([0-9\.]+) available/
-end

--- a/Livecheckables/sqoop.rb
+++ b/Livecheckables/sqoop.rb
@@ -1,0 +1,4 @@
+class Sqoop
+  livecheck :url   => "https://sqoop.apache.org/",
+            :regex => /Latest stable release is (\d+(?:\.\d+)+)/
+end

--- a/Livecheckables/storm.rb
+++ b/Livecheckables/storm.rb
@@ -1,4 +1,0 @@
-class Storm
-  livecheck :url   => "http://apache.claz.org/storm/",
-            :regex => %r{href="apache-storm-([0-9\.]+)/}
-end

--- a/Livecheckables/tika.rb
+++ b/Livecheckables/tika.rb
@@ -1,4 +1,0 @@
-class Tika
-  livecheck :url   => "http://mirrors.ocf.berkeley.edu/apache/tika/",
-            :regex => /href="tika-app-([0-9\.]+)\.j/
-end

--- a/Livecheckables/tomcat.rb
+++ b/Livecheckables/tomcat.rb
@@ -1,4 +1,0 @@
-class Tomcat
-  livecheck :url   => "https://archive.apache.org/dist/tomcat/tomcat-9/",
-            :regex => %r{href="v?(\d+(?:\.\d+)+)/"}
-end

--- a/Livecheckables/xerces-c.rb
+++ b/Livecheckables/xerces-c.rb
@@ -1,4 +1,0 @@
-class XercesC
-  livecheck :url   => "http://xerces.apache.org/xerces-c/download.cgi",
-            :regex => %r{sources/xerces-c-([0-9\.]+)\.t}
-end

--- a/Livecheckables/xml-security-c.rb
+++ b/Livecheckables/xml-security-c.rb
@@ -1,4 +1,0 @@
-class XmlSecurityC
-  livecheck :url   => "http://apache.claz.org/santuario/c-library/",
-            :regex => /href="xml-security-c-([0-9\.]+)\.t/
-end

--- a/Livecheckables/zookeeper.rb
+++ b/Livecheckables/zookeeper.rb
@@ -1,4 +1,4 @@
 class Zookeeper
-  livecheck :url   => "http://apache.claz.org/zookeeper/stable",
-            :regex => /href="zookeeper-([0-9\.]+)\.t/
+  livecheck :url   => "https://zookeeper.apache.org/releases.html",
+            :regex => /ZooKeeper (\d+(?:\.\d+)+) is our latest stable release/
 end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -169,6 +169,17 @@ def version_heuristic(livecheckable, urls, regex = nil)
       page_url = "https://launchpad.net/#{package}"
 
       regex ||= %r{<div class="version">\s*Latest version is (.+)\s*</div>}
+
+      page_matches(page_url, regex).each do |match|
+        version = Version.new(match)
+        match_version_map[match] = version
+      end
+    elsif %r{www\.apache\.org/dyn}.match?(url)
+      path, prefix, suffix = url.match(%r{path=(.+?)/([^/]*?)\d+(?:\.\d+)+(/|[^/]*)})[1, 3]
+      page_url = "https://archive.apache.org/dist/#{path}/"
+
+      regex ||= /href="#{Regexp.escape(prefix)}(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/
+
       page_matches(page_url, regex).each do |match|
         version = Version.new(match)
         match_version_map[match] = version


### PR DESCRIPTION
Fetches version numbers for Apache-hosted projects at archive.apache.org by checking the directory listing for the parent directory of the path component where the version number first appears, and removed livecheckables that are covered by the new check. Also updated `zookeeper` and added an entry for `sqoop` which has an odd way of [marking prerelease versions](http://sqoop.apache.org/).