### PR TITLE
apache-zeppelin: add livecheckable

### DIFF
--- a/Livecheckables/apache-zeppelin.rb
+++ b/Livecheckables/apache-zeppelin.rb
@@ -1,0 +1,3 @@
+class ApacheZeppelin
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The newest version for `apache-zeppelin` is listed as `0.8.2-docker` due to that tag existing in the Git repo. This adds a livecheckable with a regex to restrict matching to only versions without anything extra at the end (which would also filter out pre-releases, should they appear).