### PR TITLE
embulk: update url and regex

### DIFF
--- a/Livecheckables/embulk.rb
+++ b/Livecheckables/embulk.rb
@@ -1,4 +1,4 @@
 class Embulk
-  livecheck :url   => "http://www.embulk.org/docs/release.html",
-            :regex => />Release ([0-9\.]+)</
+  livecheck :url   => "https://github.com/embulk/embulk.git",
+            :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `embulk` gives an error (`Unable to get versions`), so this updates the URL to use the Git repo and updates the regex accordingly.