### PR TITLE
ephemeralpg: update url and regex

### DIFF
--- a/Livecheckables/ephemeralpg.rb
+++ b/Livecheckables/ephemeralpg.rb
@@ -1,4 +1,4 @@
 class Ephemeralpg
-  livecheck :url   => "http://ephemeralpg.org/",
-            :regex => %r{href=.*?/ephemeralpg-([0-9\.]+)\.t}
+  livecheck :url   => "http://eradman.com/ephemeralpg/",
+            :regex => %r{href=.*?/ephemeralpg-(\d+(?:\.\d+)+)\.t}
 end


### PR DESCRIPTION
The existing livecheckable gives an error (`Unable to get versions`), since the URL changed but the http://ephemeralpg.org page only uses JavaScript to redirect to the new URL (i.e., not a 301 or 302 status code). This updates the livecheckable with the new URL and replaces the loose version matching regex code with a more strict version.