### PR TITLE
ephemeralpg: update url and regex (again)

### DIFF
--- a/Livecheckables/ephemeralpg.rb
+++ b/Livecheckables/ephemeralpg.rb
@@ -1,4 +1,4 @@
 class Ephemeralpg
-  livecheck :url   => "http://eradman.com/ephemeralpg/",
-            :regex => %r{href=.*?/ephemeralpg-(\d+(?:\.\d+)+)\.t}
+  livecheck :url   => "https://eradman.com/ephemeralpg/",
+            :regex => /href=['"][^'"]*?ephemeralpg-(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
This is a follow-up to #321. In the process of updating the URLs in the `ephemeralpg` formula, I discovered that the new URLs support HTTPS now (whereas the old ones gave an SSL error). I had mistakenly thought that the new domain/server gave SSL errors as well but that isn't the case.

This updates the URL to use `https` and further reworks the regex to be a little more strict, ensuring we wouldn't run into weird problems due to the `.*?`.