### PR TITLE
exempi: update url and regex

### DIFF
--- a/Livecheckables/exempi.rb
+++ b/Livecheckables/exempi.rb
@@ -1,4 +1,4 @@
 class Exempi
-  livecheck :url   => "https://libopenraw.freedesktop.org/download/",
-            :regex => /href="exempi-([0-9\.]+)\.t/
+  livecheck :url   => "https://libopenraw.freedesktop.org/exempi/",
+            :regex => /href="[^"']+exempi-(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
The existing livecheckable for `exempi` was broken due to the URL changing (from https://libopenraw.freedesktop.org/download/ to https://libopenraw.freedesktop.org/exempi/). This  updates the URL and regex to work properly.

In the future, it may be more appropriate to use https://wiki.freedesktop.org/libopenraw/Exempi/ but that page only goes up to version 2.5.0 and is missing 2.5.1 for some reason. I wrote the regex so it should match on both pages, at least.