### PR TITLE
exploitdb: delete

### DIFF
--- a/Livecheckables/exploitdb.rb
+++ b/Livecheckables/exploitdb.rb
@@ -1,4 +1,0 @@
-class Exploitdb
-  livecheck :url   => "https://github.com/offensive-security/exploit-database/releases",
-            :regex => %r{href="/offensive-security/exploit-database/releases/tag/([0-9,\.\-]+)"}
-end


### PR DESCRIPTION
The existing livecheckable for `exploitdb` gives an error (`Unable to get versions`), so this removes the livecheckable to allow the heuristic to take over, as it's capable of matching versions for `exploitdb` using the Git repo tags.