### PR TITLE
fossil: update url and regex

### DIFF
--- a/Livecheckables/fossil.rb
+++ b/Livecheckables/fossil.rb
@@ -1,4 +1,4 @@
 class Fossil
-  livecheck :url   => "https://www.fossil-scm.org/index.html/uv/download.html",
-            :regex => /"title":     "Version ([0-9\.]+)",/
+  livecheck :url   => "https://www.fossil-scm.org/home/uv/download.js",
+            :regex => /"title":[ ]*?"Version (\d+(?:\.\d+)+)"/
 end


### PR DESCRIPTION
The existing livecheckable for `fossil` gives an error (`Unable to get versions`), due to the download page not actually containing the version information. The version information on the page is found in a JavaScript file (`download.js`), which populates the version content on that page.

This updates the livecheckable to check `download.js` for the version information and updates the regex to be a little less strict when it comes to the whitespace but more strict when it comes to matching the version string.