### PR TITLE
freeswitch: remove url and update regex

### DIFF
--- a/Livecheckables/freeswitch.rb
+++ b/Livecheckables/freeswitch.rb
@@ -1,4 +1,3 @@
 class Freeswitch
-  livecheck :url   => "https://freeswitch.org/confluence/display/FREESWITCH/macOS+Installation",
-            :regex => /<p>([0-9\.]+) .*?Current Production/
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `freeswitch` gives an error (`Unable to get versions`), so this removes the URL (allowing the heuristic to take over) and updates the regex accordingly.