### PR TITLE
ghc: update regex

### DIFF
--- a/Livecheckables/ghc.rb
+++ b/Livecheckables/ghc.rb
@@ -1,4 +1,4 @@
 class Ghc
   livecheck :url   => "https://www.haskell.org/ghc/download.html",
-            :regex => /Current Stable Release \(([0-9\.]+)/
+            :regex => /href="download_ghc_(?:\d+(?:_?\d+)+).html">(\d+(?:\.\d+)+)</
 end


### PR DESCRIPTION
The regex for the existing `ghc` livecheckable wasn't matching any versions. This updates the regex to match all the versions on the page which follow the same format, including the latest stable version.