### PR TITLE
git: update regex

### DIFF
--- a/Livecheckables/git.rb
+++ b/Livecheckables/git.rb
@@ -1,4 +1,4 @@
 class Git
   livecheck :url   => "https://www.kernel.org/pub/software/scm/git/",
-            :regex => /git-([0-9,\.]+)\./
+            :regex => /git-(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
The regex in the existing `git` livecheckable wasn't matching any versions, so this updates it to address the issue.