### PR TITLE
goenv: remove url and update regex

### DIFF
--- a/Livecheckables/goenv.rb
+++ b/Livecheckables/goenv.rb
@@ -1,4 +1,3 @@
 class Goenv
-  livecheck :url   => "https://github.com/syndbg/goenv/releases",
-            :regex => %r{releases/latest.*?href="/syndbg/goenv/tree/([0-9\.]+)"}m
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `goenv` gives an error (`Unable to get versions`), so this removes the URL (allowing the heuristic to take over) and updates the regex accordingly.