### PR TITLE
libcerf: update regex

### DIFF
--- a/Livecheckables/libcerf.rb
+++ b/Livecheckables/libcerf.rb
@@ -1,4 +1,4 @@
 class Libcerf
   livecheck :url   => "https://jugit.fz-juelich.de/api/v4/projects/269/releases",
-            :regex => /libcerf-([0-9\.]+)/
+            :regex => /libcerf-(\d+(?:\.\d+)+)/
 end


### PR DESCRIPTION
The `libcerf` livecheckable was using the old `([0-9\.]+)` style version matching in the regex, which is too loose and can match things it shouldn't. In this case, it was matching a trailing period behind the version string and reporting the latest version as `1.13.`.

This updates the regex to use the stricter regex that has become more standard, `(\d+(?:\.\d+)+)`, which resolves this issue.