### PR TITLE
libressl: update regex

### DIFF
--- a/Livecheckables/libressl.rb
+++ b/Livecheckables/libressl.rb
@@ -1,4 +1,4 @@
 class Libressl
   livecheck :url   => "https://www.libressl.org/",
-            :regex => /latest stable release is ([0-9\.]+)/
+            :regex => /latest stable release is (\d+(?:\.\d+)+)/
 end


### PR DESCRIPTION
The `libressl` livecheckable was using the old `([0-9\.]+)` style version matching in the regex, which is too loose and can match things it shouldn't. In this case, it was matching a trailing period behind the version string and reporting the latest version as `3.0.2.`.

This updates the livecheckable to use the stricter regex that has become more standard, `(\d+(?:\.\d+)+)`, which resolves this issue.