### PR TITLE
tomcat-native: add livecheckable

### DIFF
--- a/Livecheckables/tomcat-native.rb
+++ b/Livecheckables/tomcat-native.rb
@@ -1,0 +1,4 @@
+class TomcatNative
+  livecheck :url   => "https://archive.apache.org/dist/tomcat/tomcat-connectors/native/",
+            :regex => %r{href="v?(\d+(?:\.\d+)+)/"}
+end


### PR DESCRIPTION
Right now it looks like this,

```
Error: tomcat-native: Unable to get versions
```

After the change,

```
tomcat-native : 1.2.23 ==> 1.2.23
```