### PR TITLE
Update livecheck urls for tomcat formulae

### DIFF
--- a/Livecheckables/tomcat.rb
+++ b/Livecheckables/tomcat.rb
@@ -1,4 +1,4 @@
 class Tomcat
   livecheck :url   => "https://archive.apache.org/dist/tomcat/tomcat-9/",
-            :regex => %r{href="v(.*?)/"}
+            :regex => %r{href="v?(\d+(?:\.\d+)+)/"}
 end

--- a/Livecheckables/tomcat.rb
+++ b/Livecheckables/tomcat.rb
@@ -1,4 +1,4 @@
 class Tomcat
-  livecheck :url   => "http://apache.panu.it/tomcat/tomcat-9/",
+  livecheck :url   => "https://archive.apache.org/dist/tomcat/tomcat-9/",
             :regex => %r{href="v(.*?)/"}
 end

--- a/Livecheckables/tomcat@7.rb
+++ b/Livecheckables/tomcat@7.rb
@@ -1,4 +1,4 @@
 class TomcatAT7
-  livecheck :url   => "http://archive.apache.org/dist/tomcat/tomcat-7/",
+  livecheck :url   => "https://archive.apache.org/dist/tomcat/tomcat-7/",
             :regex => %r{href="v(.*?)/"}
 end

--- a/Livecheckables/tomcat@7.rb
+++ b/Livecheckables/tomcat@7.rb
@@ -1,4 +1,4 @@
 class TomcatAT7
   livecheck :url   => "https://archive.apache.org/dist/tomcat/tomcat-7/",
-            :regex => %r{href="v(.*?)/"}
+            :regex => %r{href="v?(\d+(?:\.\d+)+)/"}
 end

--- a/Livecheckables/tomcat@8.rb
+++ b/Livecheckables/tomcat@8.rb
@@ -1,4 +1,4 @@
 class TomcatAT8
-  livecheck :url   => "http://archive.apache.org/dist/tomcat/tomcat-8/",
+  livecheck :url   => "https://archive.apache.org/dist/tomcat/tomcat-8/",
             :regex => %r{href="v(.*?)/"}
 end

--- a/Livecheckables/tomcat@8.rb
+++ b/Livecheckables/tomcat@8.rb
@@ -1,4 +1,4 @@
 class TomcatAT8
   livecheck :url   => "https://archive.apache.org/dist/tomcat/tomcat-8/",
-            :regex => %r{href="v(.*?)/"}
+            :regex => %r{href="v?(\d+(?:\.\d+)+)/"}
 end


### PR DESCRIPTION
- use https instead of http
- update url for tomcat one with `https://archive.apache.org/dist/tomcat/`