### PR TITLE
clojure: add livecheckable

### DIFF
--- a/Livecheckables/clojure.rb
+++ b/Livecheckables/clojure.rb
@@ -1,0 +1,4 @@
+class Clojure
+  livecheck :url   => "https://github.com/clojure/brew-install.git",
+            :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
# Current livecheck behavior
`Error: clojure: Unable to get versions`

# After the change.
`clojure : 1.10.1.510 ==> 1.10.1.536`