### PR TITLE
codec2: remove livecheckable

### DIFF
--- a/Livecheckables/codec2.rb
+++ b/Livecheckables/codec2.rb
@@ -1,4 +1,0 @@
-class Codec2
-  livecheck :url   => "https://hobbes1069.fedorapeople.org/freetel/codec2/",
-            :regex => /href="codec2-([0-9\.]+)\.t/
-end


### PR DESCRIPTION
`codec2` codebase moved to Github. The previous livecheckable wasn't pointing to the current version and the heuristic correctly guesses the current one.