### PR TITLE
udunits: remove livecheckable

### DIFF
--- a/Livecheckables/udunits.rb
+++ b/Livecheckables/udunits.rb
@@ -1,4 +1,0 @@
-class Udunits
-  livecheck :url   => "https://www.unidata.ucar.edu/software/udunits/udunits-current/doc/udunits/CHANGE_LOG",
-            :regex => /([0-9\.]+)\s+[0-9\-]+T/
-end


### PR DESCRIPTION
`udunits` codebase is now on Github and the heuristic is able to find the latest version.