### PR TITLE
vapoursynth: add livecheckable

### DIFF
--- a/Livecheckables/vapoursynth.rb
+++ b/Livecheckables/vapoursynth.rb
@@ -1,0 +1,3 @@
+class Vapoursynth
+  livecheck :regex => /^R(\d+(?:\.\d+)*?)$/
+end


### PR DESCRIPTION
The Git tags for vapoursynth contain prerelease versions, so this adds a livecheckable to restrict matching to stable versions (e.g., `47.1`, `48` rather than `49-RC1`).