### PR TITLE
rlwrap: add livecheckable

### DIFF
--- a/Livecheckables/rlwrap.rb
+++ b/Livecheckables/rlwrap.rb
@@ -1,0 +1,3 @@
+class Rlwrap
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The Git tags for the `rlwrap` repo contain a snapshot version among the typical versions like `v0.43`. This adds a livecheckable to restrict matching to stable versions only.