### PR TITLE
crystal: add livecheckable

### DIFF
--- a/Livecheckables/crystal.rb
+++ b/Livecheckables/crystal.rb
@@ -1,0 +1,3 @@
+class Crystal
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The Git tags for the `crystal` repo contain some non-release tags (e.g., `test-ci-1`, `tets-doc-4`) and this was causing the latest version to be erroneously reported as `4`. This adds a livecheckable to restrict version matching to only tags with stable versions.