### PR TITLE
logstash: add livecheckable

### DIFF
--- a/Livecheckables/logstash.rb
+++ b/Livecheckables/logstash.rb
@@ -1,0 +1,3 @@
+class Logstash
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
`livecheck` is currently reporting `logstash`'s latested version as `2203`, since the Git repo contains a `pull/2203` tag. This adds a livecheckable to restrict matching to typical numeric versions and only stable versions (no `-snapshot1`, etc).