### PR TITLE
openshift-cli: remove url and update regex

### DIFF
--- a/Livecheckables/openshift-cli.rb
+++ b/Livecheckables/openshift-cli.rb
@@ -1,4 +1,3 @@
 class OpenshiftCli
-  livecheck :url   => "https://github.com/openshift/origin/releases",
-            :regex => %r{Latest release.*?href="/openshift/origin/tree/v?([0-9\.]+)"}m
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `openshift-cli` was erroneously reporting the latest version as `3.11.0` (rather than `4.1.0`). This removes the URL (allowing the heuristic to use the Git tags) and updates the regex accordingly.