### PR TITLE
libdnet: add livecheckable

### DIFF
--- a/Livecheckables/libdnet.rb
+++ b/Livecheckables/libdnet.rb
@@ -1,0 +1,3 @@
+class Libdnet
+  livecheck :regex => /^libdnet-(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The latest version for `libdnet` was being reported as `2001-Oct-11` (rather than `1.12`), so this adds a livecheckable to restrict matching (of Git tags) to those starting with `libdnet-` and only stable versions (nothing trailing the numeric version).