### PR TITLE
docker-credential-helper-ecr: add livecheckable

### DIFF
--- a/Livecheckables/docker-credential-helper-ecr.rb
+++ b/Livecheckables/docker-credential-helper-ecr.rb
@@ -1,0 +1,3 @@
+class DockerCredentialHelperEcr
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The Git repo for `docker-credential-helper-ecr` contains a `amzn2/0.3.0-1` tag, so the latest version was being reported as `2/0.3.0-1`. This adds a livecheckable to restrict matching to versions like `v0.4.0` and only stable versions (nothing trailing the version).