### PR TITLE
mozjpeg: add livecheckable

### DIFF
--- a/Livecheckables/mozjpeg.rb
+++ b/Livecheckables/mozjpeg.rb
@@ -1,0 +1,3 @@
+class Mozjpeg
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The `mozjpeg` Git repo contains a number of tags that aren't for release versions, so the latest version was being reported as `8d` (rather than `3.3.1`). This adds a livecheckable to restrict matching to versions like `v3.3.1` and only stable versions (nothing trailing like `-pre`, etc).