### PR TITLE
nethack: add livecheckable

### DIFF
--- a/Livecheckables/nethack.rb
+++ b/Livecheckables/nethack.rb
@@ -1,0 +1,3 @@
+class Nethack
+  livecheck :regex => /^NetHack-(\d+(?:\.\d+)+)_Released?$/
+end


### PR DESCRIPTION
The latest version being reported for `nethack` was `3.7.0_WIP-2020-02-14`, which is a prerelease version. This adds a livecheckable that restricts verson matching to release versions but, unfortunately, the resulting version is like `3.6.6_Released` or `3.6.2_Release`.

Currently, `livecheck` isn't so smart in the way it's dealing with the resulting version string. In this case, it would be better if livecheck only used the capture group in the regex (resulting in something like `3.6.6` here) rather than the capture group and everything past it. This is something that will need to be handled in another PR and isn't appropriate here. Any system-wide changes to fix the issue will automatically address this particular wrinkle without needing any changes to the livecheckable.

In the interim time, at least the matched version gives the latest release version (not prerelease).