### PR TITLE
activemq-cpp: add livecheckable

### DIFF
--- a/Livecheckables/activemq-cpp.rb
+++ b/Livecheckables/activemq-cpp.rb
@@ -1,0 +1,4 @@
+class ActivemqCpp
+  livecheck :url   => "https://archive.apache.org/dist/activemq/activemq-cpp/",
+            :regex => %r{href="v?(\d+(?:\.\d+)+)/"}
+end


### PR DESCRIPTION
# before

```
$ brew livecheck activemq-cpp
Error: activemq-cpp: Unable to get versions
```

# after

```
$ brew livecheck activemq-cpp
activemq-cpp : 3.9.5 ==> 3.9.5
```
