### PR TITLE
docker-compose-completion: add livecheckable

### DIFF
--- a/Livecheckables/docker-compose-completion.rb
+++ b/Livecheckables/docker-compose-completion.rb
@@ -1,0 +1,3 @@
+class DockerComposeCompletion
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The latest version for `docker-compose-completion` was being reported as `1.26.0-test`. There are some other unrelated tags in the Git repo, so this adds a livecheckable to restrict version matching to those like `1.25.4` and only stable versions.