### PR TITLE
alure: add livecheckable

### DIFF
--- a/Livecheckables/alure.rb
+++ b/Livecheckables/alure.rb
@@ -1,0 +1,4 @@
+class Alure
+  livecheck :url   => "https://kcat.strangesoft.net/alure-releases/",
+            :regex => /alure-(\d+(?:\.\d+)+)/
+end


### PR DESCRIPTION
# before

```
$ brew livecheck alure
Error: alure: Unable to get versions
```

# after
```
$ brew livecheck alure
alure : 1.2 ==> 1.2
```