### PR TITLE
ascii: add livecheckable

### DIFF
--- a/Livecheckables/ascii.rb
+++ b/Livecheckables/ascii.rb
@@ -1,0 +1,4 @@
+class Ascii
+  livecheck :url   => "http://www.catb.org/~esr/ascii/",
+            :regex => /ascii-(\d+(?:\.\d+)+)/
+end


### PR DESCRIPTION
# before

```
$ brew livecheck ascii
Error: ascii: Unable to get versions
```

# after

```
$ brew livecheck ascii
ascii : 3.18 ==> 3.18
```