### PR TITLE
fluxctl: add livecheckable

### DIFF
--- a/Livecheckables/fluxctl.rb
+++ b/Livecheckables/fluxctl.rb
@@ -1,0 +1,3 @@
+class Fluxctl
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The latest version of `fluxctl` was being reported as `9a99` (instead of `1.18.0`), due to a `master-ccb9a99` tag in the Git repo. This adds a livecheckable to restrict version matching to those like `1.18.0` (nothing before or after), to only match `fluxctl` versions (not `chart`, `helm`, etc.) and only stable versions.