### PR TITLE
atool: add livecheckable

### DIFF
--- a/Livecheckables/atool.rb
+++ b/Livecheckables/atool.rb
@@ -1,0 +1,4 @@
+class Atool
+  livecheck :url   => "https://namesdir.com/mirrors/nongnu/atool/",
+            :regex => /atool-(\d+(?:\.\d+)+)/
+end


### PR DESCRIPTION
# before

```
$ brew livecheck atool
Error: atool: Unable to get versions
```

# after

```
$ brew livecheck atool
atool : 0.39.0 ==> 0.39.0
```