### PR TITLE
serf: remove livecheckable

### DIFF
--- a/Livecheckables/serf.rb
+++ b/Livecheckables/serf.rb
@@ -1,4 +1,0 @@
-class Serf
-  livecheck :url   => "https://www.serf.io/downloads.html",
-            :regex => %r{href="https://releases.hashicorp.com/serf/([0-9\.]+)}
-end


### PR DESCRIPTION
`serf` codebase is now on Github and the heuristic is able to find the latest version.