### PR TITLE
awscli: remove livecheckable

### DIFF
--- a/Livecheckables/awscli.rb
+++ b/Livecheckables/awscli.rb
@@ -1,4 +1,0 @@
-class Awscli
-  livecheck :url   => "https://github.com/aws/aws-cli/releases",
-            :regex => /href=".*([\d.]+\.[\d.]+\.[\d.]+)\.t/
-end


### PR DESCRIPTION
# behavior would stay the same

```
$ brew livecheck awscli
awscli (guessed) : 2.0.0 ==> 2.0.2
```