### PR TITLE
alluxio: add livecheckable

### DIFF
--- a/Livecheckables/alluxio.rb
+++ b/Livecheckables/alluxio.rb
@@ -1,0 +1,4 @@
+class Alluxio
+  livecheck :url   => "https://downloads.alluxio.io/downloads/files/",
+            :regex => %r{href="(\d+(?:\.\d+)+)/?"}
+end


### PR DESCRIPTION
# before

```
$ brew livecheck alluxio
Error: alluxio: Unable to get versions
```

# after

There is some issue
```
$ brew livecheck alluxio
alluxio : 1.8.1 ==> 2.1.2
```