### PR TITLE
atool: update url and regex

### DIFF
--- a/Livecheckables/atool.rb
+++ b/Livecheckables/atool.rb
@@ -1,4 +1,4 @@
 class Atool
-  livecheck :url   => "https://namesdir.com/mirrors/nongnu/atool/",
-            :regex => /atool-(\d+(?:\.\d+)+)/
+  livecheck :url   => "https://namesdir.com/mirrors/nongnu/atool/?C=M&O=D",
+            :regex => /href="atool-(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
This is a follow-up PR to #354, since I couldn't get to it before it was merged and there were a few items that could have been addressed.

Since we're using the `tar.gz` file in the formula, we only want to match those archives on this page. Usually we do this by adding `\.t` after the numeric portion of the regex (as the archive could be `tar.gz`, `tar.xz`, `tar.bz2`, etc. and needs to be somewhat generic).

Additionally, we want to match the `href` attributes of the links rather than any text in the HTML. Index pages like this sometimes truncate the text for the filename, so we can run into matching problems if this occurs.

With these two ideas in mind the regex would be: `/href="atool-(\d+(?:\.\d+)+)\.t/`

Additionally, you can sometimes add `?C=M&O=D` to the end of index pages like these to get them to sort files in descending order ([I borrowed this from the heuristic](https://github.com/Homebrew/homebrew-livecheck/blob/d51d26604ee8da1652635d0a320391374c36bcd8/livecheck/heuristic.rb#L115)). This isn't explicitly necessary but it can sometimes help with ensuring we get the latest version.