### PR TITLE
htpdate: update url and regex

### DIFF
--- a/Livecheckables/htpdate.rb
+++ b/Livecheckables/htpdate.rb
@@ -1,4 +1,4 @@
 class Htpdate
-  livecheck :url   => "http://www.vervest.org/htp/download",
-            :regex => %r{href=.*?/htpdate-([0-9\.]+)\.t}
+  livecheck :url   => "http://www.vervest.org/htp/archive/c/?C=M&O=D",
+            :regex => /href="htpdate-(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
Right now it takes too much time to check on it locally.
```
Loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-livecheck/Livecheckables/htpdate.rb
Trying with url http://www.vervest.org/htp/archive/c/?C=M&O=D
Using page_match("http://www.vervest.org/htp/archive/c/?C=M&O=D", "(?-mix:href="htpdate-(\d+(?:\.\d+)+)\.t)")
Error: htpdate: execution expired
```