### PR TITLE
vips: remove livecheckable

### DIFF
--- a/Livecheckables/vips.rb
+++ b/Livecheckables/vips.rb
@@ -1,3 +1,0 @@
-class Vips
-  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
-end

--- a/Livecheckables/vips.rb
+++ b/Livecheckables/vips.rb
@@ -1,4 +1,3 @@
 class Vips
-  livecheck :url   => "https://github.com/jcupitt/libvips/releases",
-            :regex => %r{Latest.*?href="/jcupitt/libvips/tree/v?([0-9\.]+)}m
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
# before

```
$ brew livecheck vips
Error: vips: Unable to get versions
```

# After

```
$ brew livecheck vips
vips (guessed) : 8.9.1 ==> 8.9.1
```