### PR TITLE
wiredtiger: update url and regex

### DIFF
--- a/Livecheckables/wiredtiger.rb
+++ b/Livecheckables/wiredtiger.rb
@@ -1,4 +1,4 @@
 class Wiredtiger
   livecheck :url   => "https://github.com/wiredtiger/wiredtiger.git",
-            :regex => /^mongodb-v?(\d+(?:\.\d+)+)$/
+            :regex => /^v?(\d+(?:\.\d+)+)$/
 end

--- a/Livecheckables/wiredtiger.rb
+++ b/Livecheckables/wiredtiger.rb
@@ -1,4 +1,4 @@
 class Wiredtiger
-  livecheck :url   => "https://github.com/wiredtiger/wiredtiger/releases",
-            :regex => %r{href="/wiredtiger/wiredtiger/tree/([0-9\.]+)}
+  livecheck :url   => "https://github.com/wiredtiger/wiredtiger.git",
+            :regex => /^mongodb-v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
# before

```
$ brew livecheck wiredtiger
Error: vips: Unable to get versions
```

# after

```
$ brew livecheck wiredtiger
wiredtiger : 3.2.0 ==> 3.2.1
```