### PR TITLE
sshfs: update url and regex

### DIFF
--- a/Livecheckables/sshfs.rb
+++ b/Livecheckables/sshfs.rb
@@ -1,4 +1,3 @@
 class Sshfs
-  livecheck :url   => "https://github.com/libfuse/sshfs/releases",
-            :regex => %r{href="/libfuse/sshfs/tree/sshfs-(2\.[0-9\.]+)"}
+  livecheck :regex => /^sshfs-(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
# after the change

```
$ brew livecheck sshfs
sshfs : 2.10 ==> 3.7.0
```

failed attempt to upgrade it to 3.6.0 (https://github.com/Homebrew/homebrew-core/pull/47971)