### PR TITLE
libnice: update url and regex

### DIFF
--- a/Livecheckables/libnice.rb
+++ b/Livecheckables/libnice.rb
@@ -1,4 +1,4 @@
 class Libnice
-  livecheck :url   => "https://nice.freedesktop.org/releases/",
-            :regex => /href="libnice-([\d.]+\.[\d.]+\.[\d.]+)\.t/
+  livecheck :url   => "https://github.com/libnice/libnice.git",
+            :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
# after the change

404 for `https://libnice.freedesktop.org/releases/`, so I switch to github url.

```
$ brew livecheck libnice
libnice : 0.1.16 ==> 0.1.16
```