### PR TITLE
john-jumbo: update url and regex

### DIFF
--- a/Livecheckables/john-jumbo.rb
+++ b/Livecheckables/john-jumbo.rb
@@ -1,4 +1,4 @@
 class JohnJumbo
-  livecheck :url   => "http://www.openwall.com/john/",
-            :regex => %r{href="j/john-([a-z0-9\.\-]+)\.t}
+  livecheck :url   => "https://github.com/magnumripper/JohnTheRipper.git",
+            :regex => /^v?(\d+(?:\.\d+)+)-jumbo-\d$/i
 end


### PR DESCRIPTION
# after the change

The version is 1.9.0
But it installed the jump release 1.9.0-Jumbo-1, which is different from core version, `1.9.0`

```
$ brew livecheck john-jumbo
john-jumbo : 1.9.0 ==> 1.9.0-Jumbo-1
```

Need some discussion and review in here.