### PR TITLE
gcc: update url and regex

### DIFF
--- a/Livecheckables/gcc.rb
+++ b/Livecheckables/gcc.rb
@@ -1,4 +1,4 @@
 class Gcc
-  livecheck :url   => "https://gcc.gnu.org/git/gcc.git",
-            :regex => %r{^releases/gcc-([\d\.]+)$}
+  livecheck :url   => "https://ftp.gnu.org/gnu/gcc/?C=M&O=D",
+            :regex => %r{href="gcc-(\d+(?:\.\d+)+)(?:/?"|\.t)}
 end


### PR DESCRIPTION
With the change

```
$ brew livecheck gcc
gcc : 9.2.0 ==> 9.2.0
```