### PR TITLE
frotz: add livecheckable

### DIFF
--- a/Livecheckables/frotz.rb
+++ b/Livecheckables/frotz.rb
@@ -1,0 +1,4 @@
+class Frotz
+  livecheck :url   => "https://gitlab.com/DavidGriffith/frotz.git",
+            :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
Current livecheck behavior

```
Error: frotz: Unable to get versions
```

After the change.

```
frotz : 2.51 ==> 2.51
```