### PR TITLE
ddclient: add livecheckable

### DIFF
--- a/Livecheckables/ddclient.rb
+++ b/Livecheckables/ddclient.rb
@@ -1,0 +1,4 @@
+class Ddclient
+  livecheck :url   => "https://sourceforge.net/projects/ddclient/files/ddclient/",
+            :regex => /ddclient-(\d+(?:\.\d+)+)/
+end


### PR DESCRIPTION
# before

```
$ brew livecheck ddclient --debug
Trying with url https://github.com/wimpunk/ddclient.git
Possible git repo detected at https://github.com/wimpunk/ddclient.git
v3.8.2 => #<Version:0x00007fe8a9224018 @version="3.8.2", @tokens=[#<Version::NumericToken 3>, #<Version::NumericToken 8>, #<Version::NumericToken 2>]>
v3.8.3 => #<Version:0x00007fe8a922f7d8 @version="3.8.3", @tokens=[#<Version::NumericToken 3>, #<Version::NumericToken 8>, #<Version::NumericToken 3>]>
v3.9.0 => #<Version:0x00007fe8a922fee0 @version="3.9.0", @tokens=[#<Version::NumericToken 3>, #<Version::NumericToken 9>, #<Version::NumericToken 0>]>
v3.9.1 => #<Version:0x00007fe8a922fda0 @version="3.9.1", @tokens=[#<Version::NumericToken 3>, #<Version::NumericToken 9>, #<Version::NumericToken 1>]>
ddclient (guessed) : 3.9.0 ==> 3.9.1
```

# after the change

```
$ brew livecheck ddclient
ddclient : 3.9.0 ==> 3.9.0
```