### PR TITLE
mkvtoolnix: update regex

### DIFF
--- a/Livecheckables/mkvtoolnix.rb
+++ b/Livecheckables/mkvtoolnix.rb
@@ -1,4 +1,4 @@
 class Mkvtoolnix
   livecheck :url   => "https://mkvtoolnix.download/sources/",
-            :regex => /href="mkvtoolnix-([0-9\.]+)\.t/
+            :regex => /href="[^"]*?mkvtoolnix-(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
The existing livecheckable for `mkvtoolnix` gives an error (`Unable to get versions`), so this updates the regex accordingly.

My review of #397 would have been a complete replacement of the changes in that PR, so it made more sense to create a different PR to address this. Closes #397.