### PR TITLE
nss: update regex

### DIFF
--- a/Livecheckables/nss.rb
+++ b/Livecheckables/nss.rb
@@ -1,4 +1,4 @@
 class Nss
   livecheck :url   => "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases",
-            :regex => %r{href="/en-US/docs/Mozilla/Projects/NSS/NSS_([0-9\.]+)_release_notes"}
+            :regex => /href="[^"]*?NSS_(\d+(?:\.\d+)+)_release_notes"/
 end


### PR DESCRIPTION
The existing `nss` livecheckable wasn't finding the latest version (3.51) on the [NSS Releases page](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases) and was instead reporting `3.50` as the lasted version. This was due to the link for the 3.51 release using a full URL, rather than a relative URL. The old regex was only capable of matching relative URLs, do this loosens the leading path portion of the regex to avoid this issue.

This also updates the (old) loose regex for matching numeric versions with the more explicit version we use nowadays.