### PR TITLE
libosinfo: update url and regex

### DIFF
--- a/Livecheckables/libosinfo.rb
+++ b/Livecheckables/libosinfo.rb
@@ -1,4 +1,4 @@
 class Libosinfo
-  livecheck :url   => "https://releases.pagure.org/libosinfo/",
-            :regex => /libosinfo-([\d.]+)\.tar\.gz/
+  livecheck :url   => "https://releases.pagure.org/libosinfo/?C=M&O=D",
+            :regex => /href="libosinfo-([\d.]+)\.t/
 end


### PR DESCRIPTION
The existing `libosinfo` livecheckable wasn't matching the latest versions because the regex was restricted to `tar.gz` files and the newest versions are `tar.xz` files. This updates the regex to loosen the matching to `\.t` (to avoid this particular issue) and also restricts matching to `href` attributes (since this is generally more reliable than matching text across the whole page, as index pages can truncate file name text and potentially give us bad matches). This is an index page, so I also added `?C=M&O=D` to the end of the URL to sort the files, just for good measure.