### PR TITLE
qscintilla2: update regex

### DIFF
--- a/Livecheckables/qscintilla2.rb
+++ b/Livecheckables/qscintilla2.rb
@@ -1,4 +1,4 @@
 class Qscintilla2
   livecheck :url   => "https://www.riverbankcomputing.com/software/qscintilla/download",
-            :regex => /QScintilla[_-]gpl-([0-9\.]+)\.t/
+            :regex => /href="[^"]*?QScintilla[^"]*?(\d+(?:\.\d+)+)\.t/i
 end


### PR DESCRIPTION
The archive file names on the [Qscintilla download page](https://www.riverbankcomputing.com/software/qscintilla/download) have gone from being like `QScintilla_gpl-2.11.2.tar.gz` to `QScintilla-2.11.3.tar.gz`, so livecheck wasn't finding the newest versions. This updates the regex as follows:

* Allow for text to optionally appear between the start of the filename ("QScintilla") and the numeric version (e.g., `2.11.4`)
* Restrict matching to `href` attributes
* Do case-insensitive matching (so we don't have to update the regex again if filenames switch to something like `qscintilla-2.11.4.tar.gz` in the future)
* Use the more explicit numeric version regex in place of the (old) loose regex