### PR TITLE
ipfs: remove url and update regex

### DIFF
--- a/Livecheckables/ipfs.rb
+++ b/Livecheckables/ipfs.rb
@@ -1,4 +1,3 @@
 class Ipfs
-  livecheck :url   => "https://github.com/ipfs/go-ipfs/releases",
-            :regex => %r{href="/ipfs/go-ipfs/releases/tag/v?([0-9a-z\.\-]+)}
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `ipfs` was giving a prerelease version as newest (`0.5.0-dev-8to9pre2`). This livecheckable was using the GitHub release page, so this removes the URL (allowing the heuristic to use the Git repo instead) and updates the regex to restrict matching to stable versions.