### PR TITLE
nuget: update url and regex

### DIFF
--- a/Livecheckables/nuget.rb
+++ b/Livecheckables/nuget.rb
@@ -1,4 +1,4 @@
 class Nuget
-  livecheck :url   => "http://www.crufty.net/ftp/pub/sjg/",
-            :regex => /href="bmake-([0-9,\.]+)\.tar/
+  livecheck :url   => "https://dist.nuget.org/index.json",
+            :regex => /"displayName":\s*?"nuget.exe",\s*?"version":\s*?"v?(\d+(?:\.\d+)+)"/i
 end


### PR DESCRIPTION
The existing livecheckable for `nuget` seems to be checking for something completely unrelated (`bmake`), so livecheck is giving an incorrect version as the newest (`20200212` rather than `5.4.0`).

The `nuget` formula uses `nuget.org` when downloading the archive but the [nuget.org downloads page](https://www.nuget.org/downloads) uses JavaScript to display the download/version information. This modifies the livecheckable to check the JSON file that's used to populate the version information on the downloads page and updates the regex accordingly.