### PR TITLE
squid: update url and regex

### DIFF
--- a/Livecheckables/squid.rb
+++ b/Livecheckables/squid.rb
@@ -1,4 +1,4 @@
 class Squid
-  livecheck :url   => "http://www.squid-cache.org/Versions/v3/3.5/",
-            :regex => /squid-([0-9.]+)-RELEASENOTES\.html/
+  livecheck :url   => "http://www.squid-cache.org/Versions/v4/",
+            :regex => /squid-(\d+(?:\.\d+)+)-RELEASENOTES\.html/i
 end


### PR DESCRIPTION
The existing livecheckable for `squid` was reporting `3.5.28` as the newest version (instead of `4.10`), due to the URL still using the `3.5` series release page. This updates the URL to use the v4 release page, which fixes the issue until a new major version becomes stable (e.g., v5).

This also replaces the (old) loose numeric version matching regex with the more explicit regex we use these days and makes the regex case-insensitive (to avoid any related issues in the future).