### PR TITLE
freeradius-server: update url and regex

### DIFF
--- a/Livecheckables/freeradius-server.rb
+++ b/Livecheckables/freeradius-server.rb
@@ -1,4 +1,3 @@
 class FreeradiusServer
-  livecheck :url   => "https://build.opensuse.org/package/show/openSUSE:Factory/freeradius-server",
-            :regex => /freeradius-server-([0-9\.]+)\.t/
+  livecheck :regex => /^release_(\d+(?:[_\.]\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `freeradius-server` wasn't finding the latest version (giving `3.0.19` instead of `3.0.20`). This removes the URL (allowing the heuristic to check the Git tags) and updates the regex accordingly.

The tags in the Git repo are like `release_3_0_20`, so the reported version is formatted like `3_0_20` but this is the same as `3.0.20` from a comparison standpoint.