### PR TITLE
mawk: update url and regex

### DIFF
--- a/Livecheckables/mawk.rb
+++ b/Livecheckables/mawk.rb
@@ -1,4 +1,4 @@
 class Mawk
-  livecheck :url   => "https://invisible-mirror.net/archives/mawk/",
-            :regex => /href="mawk-(.*)\.t.*?"/
+  livecheck :url   => "https://invisible-mirror.net/archives/mawk/?C=M&O=D",
+            :regex => /href="mawk-(\d+(?:\.\d+)+(?:-\d+)?)\.t/
 end


### PR DESCRIPTION
The existing livecheckable for `mawk` was using wildcard matches `.*` which were escaping the bounds of the `href` attribute. As a result, the latest version was being given as `1.3.4-20200120.tgz">mawk-1.3.4-20200120`, instead of `1.3.4-20200120`. I've warned about this when providing feedback about livecheck PRs and this is a perfect example of why we almost always avoid using the `.` wildcard in livecheckable regexes.

This resolves the issue by reworking the regex to accomplish the same thing in a safer, more explicit fashion. This is an index page, so I also added `?C=M&O=D` to the end of the URL, to sort the archive files in descending order, for good measure.