### PR TITLE
flashrom: update regex

### DIFF
--- a/Livecheckables/flashrom.rb
+++ b/Livecheckables/flashrom.rb
@@ -1,4 +1,4 @@
 class Flashrom
   livecheck :url   => "https://download.flashrom.org/releases/",
-            :regex => /href="flashrom-([0-9\.]+)\.t/
+            :regex => /href="flashrom-v?(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
The existing livecheckable for `flashrom` wasn't finding the latest version (giving `1.0` instead of `1.2`). This was because the regex was created with the expectation that file names would be like `flashrom-1.0.tar.bz2` but the newest versions are like `flashrom-v1.2.tar.bz2` (note the `v` before the version number). As a result, versions beyond `1.0` (`v1.0.1`, `v1.1`, and `v1.2`) weren't identified by livecheck.

This updates the regex to allow for an optional `v` and also replaces the (old) loose regex for matching numeric versions with the more explicit version we use these days. This is an index page but I did not add `?C=M&O=D` to the end of the URL because the server doesn't respond to the query string values (i.e., there's no change in sorting).