### PR TITLE
digdag: add regex

### DIFF
--- a/Livecheckables/digdag.rb
+++ b/Livecheckables/digdag.rb
@@ -1,3 +1,4 @@
 class Digdag
-  livecheck :url => "https://github.com/treasure-data/digdag.git"
+  livecheck :url   => "https://github.com/treasure-data/digdag.git",
+            :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `digdag` wasn't restricting the Git tags using a regex, so a tag named `v0_10_before_merge_v0_9_38` was being listed as the newest version. This adds the standard regex we use for Git tags like `v1.2.3`, to restrict matching to these tags (and only stable versions, not `-pre1`, etc.).