### PR TITLE
afl-fuzz: remove url and update regex

### DIFF
--- a/Livecheckables/afl-fuzz.rb
+++ b/Livecheckables/afl-fuzz.rb
@@ -1,4 +1,3 @@
 class AflFuzz
-  livecheck :url   => "http://lcamtuf.coredump.cx/afl/releases/",
-            :regex => /href="afl-([0-9\.]+b)\.t/
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)b?$/
 end


### PR DESCRIPTION
The existing livecheckable for `afl-fuzz` was giving the latest version as `2.52b` (instead of `2.56` or `2.56b`). This removes the URL (allowing the heuristic to check the Git tags, since the formula uses the releases from GitHub) and updates the regex accordingly.

The version from the formula is reported as `2.56` (it's actually `2.56b`) but the version from the Git tag is `2.56b`. I'll address mismatches like this in a future commit that should automatically fix this for a number of formulae/livecheckables with issues like this.