### PR TITLE
igv: add regex

### DIFF
--- a/Livecheckables/igv.rb
+++ b/Livecheckables/igv.rb
@@ -1,3 +1,4 @@
 class Igv
-  livecheck :url => "https://github.com/igvteam/igv.git"
+  livecheck :url   => "https://github.com/igvteam/igv.git",
+            :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `igv` was reporting the newest version as `9` (instead of `2.8.1`) due to a `test9` tag in the Git repo. This adds a regex to restrict matching to versions like `v1.2.3` and only stable versions (no `-rc1`, etc.).