### PR TITLE
spades: update url and regex

### DIFF
--- a/Livecheckables/spades.rb
+++ b/Livecheckables/spades.rb
@@ -1,4 +1,4 @@
 class Spades
-  livecheck :url   => "http://bioinf.spbau.ru/en/content/spades-download-0",
-            :regex => /href=".*SPAdes-([0-9\.]+)\.t/
+  livecheck :url   => "http://cab.spbu.ru/files/?C=M&O=D",
+            :regex => %r{href="release(\d+(?:\.\d+)+)/?"}
 end


### PR DESCRIPTION
The existing livecheckable for `spades` was giving the newest version as `3.11.1` (instead of `3.14.0`). This updates the URL to use the files index page of the upstream server (used in the formula's stable URL) and updates the regex accordingly.