### PR TITLE
hypre: remove url and update regex

### DIFF
--- a/Livecheckables/hypre.rb
+++ b/Livecheckables/hypre.rb
@@ -1,4 +1,3 @@
 class Hypre
-  livecheck :url   => "https://computation.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods/software",
-            :regex => %r{href=".*?/hypre-([0-9\.]+)\.t}
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `hypre` wasn't finding the newest versions (giving `2.11.2` instead of `2.18.2`). This removes the URL (allowing the heuristic to use the Git tags) and updates the regex accordingly.