### PR TITLE
lablgtk: remove url and update regex

### DIFF
--- a/Livecheckables/lablgtk.rb
+++ b/Livecheckables/lablgtk.rb
@@ -1,4 +1,3 @@
 class Lablgtk
-  livecheck :url   => "http://lablgtk.forge.ocamlcore.org",
-            :regex => %r{href=".*?/lablgtk-([0-9\.]+)\.t}
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `lablgtk` wasn't finding the latest versions (giving `2.18.8` instead of `3.1.0`). The `lablgtk` formula is using the upstream GitHub repo releases, so this removes the URL (allowing the heuristic to use the Git tags) and updates the regex accordingly.