### PR TITLE
voldemort: remove url and update regex

### DIFF
--- a/Livecheckables/voldemort.rb
+++ b/Livecheckables/voldemort.rb
@@ -1,4 +1,3 @@
 class Voldemort
-  livecheck :url   => "https://github.com/voldemort/voldemort/releases",
-            :regex => %r{href="/voldemort/voldemort/tree/release-([0-9\.]+)-cutoff}
+  livecheck :regex => /(?:release-)?v?(\d+(?:\.\d+)+)(?:-cutoff)?/
 end


### PR DESCRIPTION
The existing livecheckable for `voldemort` wasn't finding the newest version (giving `1.10.25` instead of `1.10.26`). This removes the URL (allowing the heuristic to use the Git tags, which are better than the GitHub releases page) and updates the regex accordingly. [Note: I've made the leading `release-` and trailing `-cutoff` text optional, in case this software gets updated in the future and the tags change to a more `1.2.3` or `v1.2.3` format.]

The only issue here is that the latest version is now given as `1.10.26-cutoff` (instead of `1.10.26`). This will be addressed in a future PR that will fix this category of issues for all affected checks (that match Git repo tags). This will be automatically fixed when that PR is merged, so all we need to worry about here is finding the newest version (which we are).