### PR TITLE
xboard: add livecheckable

### DIFF
--- a/Livecheckables/xboard.rb
+++ b/Livecheckables/xboard.rb
@@ -1,0 +1,4 @@
+class Xboard
+  livecheck :url   => "https://ftp.gnu.org/gnu/xboard/",
+            :regex => /href="xboard-v?(\d+(?:\.\d+)+)\.t/
+end


### PR DESCRIPTION
`livecheck` was using the Git repo tags for `xboard`, which contain a number of tags for other things (e.g., `master-20140119`, `gtk-20100806`), so the newest version was being given as `20140119`. This could be addressed by adding a livecheckable with a regex to restrict the tags (as in #434) but it made more sense to use the index page where the stable archives are hosted (since we typically want to align with where we download archives from).

This was a full rewrite of the `xboard` livecheckable, so it was more fitting to open a PR that closes #434.