### PR TITLE
agedu: update regex

### DIFF
--- a/Livecheckables/agedu.rb
+++ b/Livecheckables/agedu.rb
@@ -1,4 +1,4 @@
 class Agedu
   livecheck :url   => "https://www.chiark.greenend.org.uk/~sgtatham/agedu/",
-            :regex => /href="agedu-([0-9]+\.[a-f0-9]+)\.t/
+            :regex => /href="agedu-(\d+)(?:\.[\da-z]+)?\.t/
 end


### PR DESCRIPTION
The existing livecheckable for `agedu` used a regex with a capture group that spanned the entire alphanumeric part of the version string (`20200206.963bc9d`), whereas the version from the formula is like `20200206`. In a forthcoming PR (related to #408), we will be using the capture group as the version instead of the Git strategy's default behavior (using the part of the string from the first number onward), so this prepares for that change.