### PR TITLE
bfg: update url and regex

### DIFF
--- a/Livecheckables/bfg.rb
+++ b/Livecheckables/bfg.rb
@@ -1,4 +1,4 @@
 class Bfg
-  livecheck :url   => "https://github.com/rtyley/bfg-repo-cleaner",
-            :regex => /^(v.*)/
+  livecheck :url   => "https://github.com/rtyley/bfg-repo-cleaner.git",
+            :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `bfg` used a regex with a capture group that included the numeric version as well as the leading `v` (e.g., `v1.13.0`), whereas we want the version from livecheck to be like `1.13.0`.

In a forthcoming PR (related to #408), we will be using the capture group as the version instead of the Git strategy's default behavior (using the part of the string from the first number onward), so this prepares for that change.