### PR TITLE
clinfo: update url and regex

### DIFF
--- a/Livecheckables/clinfo.rb
+++ b/Livecheckables/clinfo.rb
@@ -1,4 +1,4 @@
 class Clinfo
-  livecheck :url   => "https://github.com/Oblomov/clinfo",
-            :regex => /([0-9]+\.[0-9]+)/
+  livecheck :url   => "https://github.com/Oblomov/clinfo.git",
+            :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `clinfo` used a regex with a capture group that only addressed the first two numeric parts of the version string (`2.2`), whereas the versions are much longer (`2.2.18.04.06`) and we want to capture all of it. This updates the regex to use the standard regex for Git tags, which captures the entire numeric version.

In a forthcoming PR (related to #408), we will be using the capture group as the version instead of the Git strategy's default behavior (using the part of the string from the first number onward), so this prepares for that change.