### PR TITLE
disktype: update regex

### DIFF
--- a/Livecheckables/disktype.rb
+++ b/Livecheckables/disktype.rb
@@ -1,3 +1,3 @@
 class Disktype
-  livecheck :regex => /release_\d+/
+  livecheck :regex => /release_(\d+)/
 end


### PR DESCRIPTION
The existing livecheckable for `disktype` used a regex with no capture group, whereas we want to be capturing a version like `9` (from `release_9`). This updates the regex to add a capture group around the `\d+` part of the regex.

In a forthcoming PR (related to #408), we will be using the capture group as the version (when available) instead of the Git strategy's default behavior (using the part of the string from the first number onward), so this prepares for that change.