### PR TITLE
ipbt: update regex

### DIFF
--- a/Livecheckables/ipbt.rb
+++ b/Livecheckables/ipbt.rb
@@ -1,4 +1,4 @@
 class Ipbt
   livecheck :url   => "https://www.chiark.greenend.org.uk/~sgtatham/ipbt/",
-            :regex => /ipbt-([0-9.a-z]*)\.t/
+            :regex => /ipbt-(\d+)(?:\.[\da-z]+)?\.t/
 end


### PR DESCRIPTION
The existing livecheckable for `ipbt` used a regex with a capture group that spanned the entire alphanumeric part of the version string (`20190601.d1519e0`), whereas we want a version like `20190601` (to match the formula version). This updates the regex to only capture the first numeric part of the version.

In a forthcoming PR (related to #408), we will be using the capture group as the version (when available) instead of the Git strategy's default behavior (using the part of the string from the first number onward), so this prepares for that change.