### PR TITLE
spigot: update regex

### DIFF
--- a/Livecheckables/spigot.rb
+++ b/Livecheckables/spigot.rb
@@ -1,4 +1,4 @@
 class Spigot
   livecheck :url   => "https://www.chiark.greenend.org.uk/~sgtatham/spigot/",
-            :regex => /href="spigot-([a-z0-9\.]+)\.t/
+            :regex => /href="spigot-(\d+)(?:\.[\da-z]+)?\.t/
 end


### PR DESCRIPTION
The existing livecheckable for `spigot` used a regex with a capture group that spanned the entire alphanumeric part of the version string (`20200101.b1b0b20`), whereas we want a version like `20200101` (to match the formula version). This updates the regex to only capture the first numeric part of the version.

In a forthcoming PR (related to #408), we will be using the capture group as the version (when available) instead of the Git strategy's default behavior (using the part of the string from the first number onward), so this prepares for that change.