### PR TITLE
wapm: update regex and add explanatory comment

### DIFF
--- a/Livecheckables/wapm.rb
+++ b/Livecheckables/wapm.rb
@@ -1,3 +1,5 @@
 class Wapm
-  livecheck :regex => /^v?[^3]([\d\.]+)/
+  # There is a "3.2" tag in the Git repo that we avoid by only matching versions
+  # with 3+ parts (e.g., 0.1.2)
+  livecheck :regex => /^v?(\d+(?:\.\d+){2,})/
 end


### PR DESCRIPTION
The existing livecheckable for `wapm` used a regex with a capture group that didn't capture the full numeric version (it was missing the first digit, like `.5.0`), whereas we want a version like `0.5.0` (to match the formula version). This updates the regex to capture the entire numeric version.

This regex was also restricting matching to versions where the major version wasn't `3`, to avoid an issue where the git tags contained a `3.2` tag but the actual releases were like `0.5.0`. If there's ever a `3` major version, this wouldn't find those versions. Instead, we can accomplish what we want by only matching versions with three or more parts (e.g., `1.2.3` not `1.2`). This regex wouldn't match a version with only two parts, so that would be a problem if a valid version like that appears, but it doesn't seem likely at the moment.

In a forthcoming PR (related to #408), we will be using the capture group as the version (when available) instead of the Git strategy's default behavior (using the part of the string from the first number onward), so this prepares for that change.