### PR TITLE
ekg2: add livecheckable

### DIFF
--- a/Livecheckables/ekg2.rb
+++ b/Livecheckables/ekg2.rb
@@ -1,0 +1,4 @@
+class Ekg2
+  livecheck :url   => "https://github.com/ekg2/ekg2.git",
+            :regex => /^ekg2_(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The Git tags for the `ekg2` repository contain prerelease versions, so this adds a livecheckable to restrict matching to only stable versions.