### PR TITLE
heuristic: allow use of capture group for version

### DIFF
--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -63,8 +63,17 @@ def version_heuristic(livecheckable, urls, regex = nil)
         # and upstream does not do only 'debian/' prefixed tags
         next if tag =~ %r{debian/} && !tags_only_debian
 
-        # Remove any character before the first number
-        tag_cleaned = tag[/\D*(.*)/, 1]
+        captures = tag.scan(regex) if regex
+        tag_cleaned = if captures &&
+                         !captures.empty? &&
+                         captures[0].is_a?(Array)
+          # Use the first capture group as the version
+          captures[0][0]
+        else
+          # Remove any character before the first number
+          tag[/\D*(.*)/, 1]
+        end
+
         match_version_map[tag] = Version.new(tag_cleaned)
       rescue TypeError
         nil


### PR DESCRIPTION
This fixes #408 (and is related to #443) but also addresses a number of issues with unwanted trailing text in versions when using the Git strategy (i.e., finding versions in Git tags from the upstream repository).

By default, the Git strategy will "clean" tags by removing any characters before the first number. However, as seen in #408, this didn't work correctly when the software name includes a number and precedes the numeric version (e.g., `ekg2_0.3.1`). In this case, the version number included everything after the first digit (`2_0.3.1`) instead of just the version (`0.3.1`). This couldn't be fixed with a regex, as regexes were only used in the Git strategy for filtering tags.

This resolves the issue by optionally using the first capture group in the regex match, when available. If a regex isn't provided or the regex doesn't contain a capture group, we fall back to the default behavior (removing characters before the first number and returning the string).

All of the existing livecheckables use capture groups around the desired version string, so we don't have to make widespread changes to take advantage of this. We already make sure to use a capture group around the part of the version text that we want to use as the version, so this also doesn't require us to adapt our behavior. Rather, this simply allows the Git strategy to take advantage of our existing work to produce a better result.

I did a full livecheck run and addressed any issues that appeared (comparing the output before/after). There were a handful of livecheckables that needed to be modified (due to issues with their regex) but these changes have already been merged.

Outside of addressing the issue for `ekg2`, notable positive output changes are listed below. In these cases, the output before was incorrect (given as a new version) and is correct now.

* **afl-fuzz**: `2.56b` before, `2.56` now
* **agedu**: `20200206.963bc9d` before, `20200206` now
* **ipbt**: `20190601.d1519e0` before, `20190601` now
* **john-jumbo**: `1.9.0-Jumbo-1` before, `1.9.0` now
* **nethack**: `3.6.6_Released` before, `3.6.6` now
* **spigot**: `20200101.b1b0b20` before, `20200101` now
* **voldemort**: `1.10.26-cutoff` before, `1.10.26` now