### PR TITLE
interactive-rebase-tool: update regex

### DIFF
--- a/Livecheckables/interactive-rebase-tool.rb
+++ b/Livecheckables/interactive-rebase-tool.rb
@@ -1,3 +1,3 @@
 class InteractiveRebaseTool
-  livecheck :regex => /([\d]+[\.]+)/
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `interactive-rebase-tool` was using a poorly-written regex that was only matching part of the numeric version (`1.` instead of the full `1.2.1`). This replaces the regex with the standard regex for Git tags, which works as expected.