### PR TITLE
heuristic: add bitbucket.org check

### DIFF
--- a/Livecheckables/amdatu-bootstrap.rb
+++ b/Livecheckables/amdatu-bootstrap.rb
@@ -1,0 +1,4 @@
+class AmdatuBootstrap
+  livecheck :url   => "https://bitbucket.org/amdatuadm/amdatu-bootstrap/downloads/",
+            :regex => /href=.*?bootstrap-(?:bin-)?r(\d+(?:\.\d+)*)(?:-bin)?\./
+end

--- a/Livecheckables/fantom.rb
+++ b/Livecheckables/fantom.rb
@@ -1,4 +1,0 @@
-class Fantom
-  livecheck :url   => "https://bitbucket.org/fantom/fan-1.0/downloads/",
-            :regex => %r{href=".*?/fantom-([0-9\.]+)\.z}
-end

--- a/Livecheckables/fuse-zip.rb
+++ b/Livecheckables/fuse-zip.rb
@@ -1,4 +1,0 @@
-class FuseZip
-  livecheck :url   => "https://bitbucket.org/agalanin/fuse-zip/downloads/",
-            :regex => %r{href=".*?/fuse-zip-([0-9\.]+)\.t}
-end

--- a/Livecheckables/mecab-ko-dic.rb
+++ b/Livecheckables/mecab-ko-dic.rb
@@ -1,0 +1,4 @@
+class MecabKoDic
+  livecheck :url   => "https://bitbucket.org/eunjeon/mecab-ko-dic/downloads/",
+            :regex => /href=.*?mecab-ko-dic-(\d+(?:\.\d+)+-\d+)\.t/
+end

--- a/Livecheckables/mecab-ko.rb
+++ b/Livecheckables/mecab-ko.rb
@@ -1,0 +1,4 @@
+class MecabKo
+  livecheck :url   => "https://bitbucket.org/eunjeon/mecab-ko/downloads/",
+            :regex => /href=.*?mecab-(\d+(?:\.\d+)+-ko-\d+(?:\.\d+)+)\.t/
+end

--- a/Livecheckables/ode.rb
+++ b/Livecheckables/ode.rb
@@ -1,4 +1,0 @@
-class Ode
-  livecheck :url   => "https://bitbucket.org/odedevs/ode/downloads/",
-            :regex => %r{href="/.*?ode-([0-9\.]+)\.t}
-end

--- a/Livecheckables/ompl.rb
+++ b/Livecheckables/ompl.rb
@@ -1,4 +1,0 @@
-class Ompl
-  livecheck :url   => "https://bitbucket.org/ompl/ompl/downloads/",
-            :regex => %r{href=.*?/ompl-([0-9\.]+)-Source\.t}
-end

--- a/Livecheckables/sagittarius-scheme.rb
+++ b/Livecheckables/sagittarius-scheme.rb
@@ -1,4 +1,0 @@
-class SagittariusScheme
-  livecheck :url   => "https://bitbucket.org/ktakashi/sagittarius-scheme/downloads/",
-            :regex => %r{href=".*?/sagittarius-([0-9\.]+)\.t}
-end

--- a/Livecheckables/x265.rb
+++ b/Livecheckables/x265.rb
@@ -1,4 +1,0 @@
-class X265
-  livecheck :url   => "https://bitbucket.org/multicoreware/x265/downloads/",
-            :regex => %r{href="/multicoreware/x265/downloads/x265_([\d.]+)\.tar}
-end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -190,6 +190,18 @@ def version_heuristic(livecheckable, urls, regex = nil)
         version = Version.new(match)
         match_version_map[match] = version
       end
+    elsif %r{bitbucket\.org(/[^/]+){4}\.\w+}.match?(url)
+      path, kind, suffix =
+        url.match(%r{bitbucket\.org/(.+?)/(get|downloads)/(?:.*?[-_])?v?\d+(?:\.\d+)+([^/]+)})[1, 3]
+      page_url = "https://bitbucket.org/#{path}/downloads/"
+      page_url << "?tab=tags" if kind == "get"
+
+      regex ||= /(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}"/
+
+      page_matches(page_url, regex).each do |match|
+        version = Version.new(match)
+        match_version_map[match] = version
+      end
     elsif regex
       # Fallback
       page_matches(url, regex).each do |match|


### PR DESCRIPTION
Similar to #317, fetches version numbers for Bitbucket-hosted projects by checking either their lists of downloads or tags, and removes livecheckables that are covered by the new check. Also adds livecheckables for `amdatu-bootstrap`, `mecab-ko`, and `mecab-ko-dic` which have unusual version number schemes.