### PR TITLE
v2ray-plugin: add livecheckable

### DIFF
--- a/Livecheckables/v2ray-plugin.rb
+++ b/Livecheckables/v2ray-plugin.rb
@@ -1,0 +1,3 @@
+class V2rayPlugin
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
The Git tags in the `v2ray-plugin` repository are typically like `v1.3.0` but there are a couple like `v20190114` that are causing the latest version to be erroneously reported as 20190114 (instead of `1.3.0`). This adds a livecheckable with a regex to restrict matching to versions like `v1.3.0` (and only stable releases).