### PR TITLE
libpq: add livecheckable

### DIFF
--- a/Livecheckables/libpq.rb
+++ b/Livecheckables/libpq.rb
@@ -1,0 +1,4 @@
+class Libpq
+  livecheck :url   => "https://ftp.postgresql.org/pub/source/?C=M&O=A",
+            :regex => %r{href="v?(\d+(?:\.\d+)+)/?"}
+end


### PR DESCRIPTION
`libpq` was giving an `Unable to get versions` error, due to the heuristic not being able to find any versions. This adds a livecheckable to address the issue.