### PR TITLE
openssl: delete

### DIFF
--- a/Livecheckables/openssl.rb
+++ b/Livecheckables/openssl.rb
@@ -1,4 +1,0 @@
-class Openssl
-  livecheck :url   => "https://www.openssl.org/source/",
-            :regex => /href="openssl-(1\.0[0-9a-z\.]+)\.t/
-end


### PR DESCRIPTION
`openssl` is no longer a formula for v1.0 and is instead an alias of `openssl@1.1` at the moment. This livecheckable is no longer needed, so it should be removed.