### PR TITLE
cowsay: add livecheckable

### DIFF
--- a/Livecheckables/cowsay.rb
+++ b/Livecheckables/cowsay.rb
@@ -1,0 +1,4 @@
+class Cowsay
+  livecheck :url   => "https://github.com/tnalpgge/rank-amateur-cowsay.git",
+            :regex => /^cowsay-(\d+(?:\.\d+)+)$/
+end


### PR DESCRIPTION
before:

```
$ brew livecheck cowsay
cowsay (guessed) : 3.04 ==> 3.04
```

after:

```
$ brew livecheck cowsay
cowsay : 3.04 ==> 3.04
```

I made livechecks for some of my installed stuff - some are old/haven't been updated in a while, though, and I noticed PR #312, potentially marking this formula "skipped" because it's older and not maintained... should I just submit them and see what happens? Thanks.
