### PR TITLE
Fix newly-tweaked RuboCop style offenses in main Livecheck code

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -50,7 +50,7 @@ module Homebrew
       puts $LOAD_PATH
     end
 
-    if cmd = Homebrew.args.named.first
+    if (cmd = Homebrew.args.named.first)
       require?("livecheck/commands/#{cmd}") && return
     end
 

--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -102,12 +102,12 @@ module Homebrew
     has_hash_arg_with_skip =
       formula.livecheck_args.is_a?(Hash) && formula.livecheck_args.key?(:skip)
     if has_hash_arg_with_skip || formula.livecheck_args == :skip
-      if has_hash_arg_with_skip &&
-         formula.livecheck_args[:skip].is_a?(String) &&
-         !formula.livecheck_args[:skip].empty?
-        skip_msg = " - #{formula.livecheck_args[:skip]}"
+      skip_msg = if has_hash_arg_with_skip &&
+                    formula.livecheck_args[:skip].is_a?(String) &&
+                    !formula.livecheck_args[:skip].empty?
+        " - #{formula.livecheck_args[:skip]}"
       else
-        skip_msg = ""
+        ""
       end
 
       puts "#{Tty.red}#{formula}#{Tty.reset} : skipped#{skip_msg}" unless Homebrew.args.quiet?

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -49,7 +49,8 @@ def version_heuristic(livecheckable, urls, regex = nil)
     match_version_map = {}
     if /hackage\.haskell\.org/.match?(url)
       package = ((url.split("/")[4]).split("-")[0..-2]).join("-")
-      ver = `curl -s https://hackage.haskell.org/package/"#{package}"/src/`.sub!(/.*Directory listing for #{package}-(.*) source tarball.*/, "\\1")
+      haskell_pkg_url = "https://hackage.haskell.org/package/#{package}/src"
+      ver = `curl -s "#{haskell_pkg_url}"`.sub!(/.*Directory listing for #{package}-(.*) source tarball.*/, "\\1")
       match_version_map[ver] = Version.new(ver)
     elsif DownloadStrategyDetector.detect(url) <= GitDownloadStrategy
       puts "Possible git repo detected at #{url}" if Homebrew.args.debug?
@@ -95,7 +96,11 @@ def version_heuristic(livecheckable, urls, regex = nil)
         # puts "#{match} => #{version.inspect}" if Homebrew.args.debug?
         match_version_map[match] = version
       end
-    elsif url =~ /gnu\.org/ && !url.include?("kawa") && !url.include?("lzip") && !url.include?("numdiff") && !url.include?("icoutils") && !url.include?("dvdrtools")
+    elsif url =~ /gnu\.org/ && !url.include?("kawa") &&
+          !url.include?("lzip") &&
+          !url.include?("numdiff") &&
+          !url.include?("icoutils") &&
+          !url.include?("dvdrtools")
       project_name_regexps = [
         %r{/(?:software|gnu)/(.*?)/},
         %r{//(.*?)\.gnu\.org(?:/)?$},

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -41,9 +41,7 @@ def version_heuristic(livecheckable, urls, regex = nil)
         github_repo_url = url[%r{((?:[a-z]+://)?github.com/[^/]+/[^/#]+)}]
         url = github_repo_url unless github_repo_url.nil?
 
-        if url.end_with?("/")
-          url = url[0..-2]
-        end
+        url = url[0..-2] if url.end_with?("/")
 
         url += ".git"
       end
@@ -106,17 +104,13 @@ def version_heuristic(livecheckable, urls, regex = nil)
         url.match(r)
       end.compact
 
-      if match_list.length > 1
-        puts "Multiple project names found: #{match_list}"
-      end
+      puts "Multiple project names found: #{match_list}" if match_list.length > 1
 
       unless match_list.empty?
         project_name = match_list[0][1]
         page_url = "http://ftp.gnu.org/gnu/#{project_name}/?C=M&O=D"
 
-        if Homebrew.args.debug?
-          puts "Possible GNU project [#{project_name}] detected at #{url}"
-        end
+        puts "Possible GNU project [#{project_name}] detected at #{url}" if Homebrew.args.debug?
 
         regex ||= /#{project_name}-(\d+(?:\.\d+)*)/
 
@@ -149,9 +143,7 @@ def version_heuristic(livecheckable, urls, regex = nil)
       package = url.match(%r{/sources\/(.*?)/})[1]
       page_url = "https://download.gnome.org/sources/#{package}/cache.json"
 
-      if Homebrew.args.debug?
-        puts "Possible GNOME package [#{package}] detected at #{url}"
-      end
+      puts "Possible GNOME package [#{package}] detected at #{url}" if Homebrew.args.debug?
 
       # Restrict versions to even numbered minor versions (except x.90+)
       if gnome_devel_whitelist.include?(package)

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -146,10 +146,10 @@ def version_heuristic(livecheckable, urls, regex = nil)
       puts "Possible GNOME package [#{package}] detected at #{url}" if Homebrew.args.debug?
 
       # Restrict versions to even numbered minor versions (except x.90+)
-      if gnome_devel_whitelist.include?(package)
-        regex ||= /#{Regexp.escape(package)}-(\d+(?:\.\d+)+)\.t/
+      regex ||= if gnome_devel_whitelist.include?(package)
+        /#{Regexp.escape(package)}-(\d+(?:\.\d+)+)\.t/
       else
-        regex ||= /#{Regexp.escape(package)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/
+        /#{Regexp.escape(package)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/
       end
 
       page_matches(page_url, regex).each do |match|

--- a/livecheck/utils.rb
+++ b/livecheck/utils.rb
@@ -13,9 +13,7 @@ end
 # Check if upstream only does 'debian/' prefixed tags
 def git_tags_only_debian?(tags)
   tags.each do |tag|
-    unless tag.match?(%r{^debian/})
-      return false
-    end
+    return false unless tag.match?(%r{^debian/})
   end
   true
 end


### PR DESCRIPTION
- [`Layout/LineLength`](https://github.com/Homebrew/brew/commit/cd3ced48e97f8fdab67b0737ba5441d4057457e9) was decreased and [`Layout/IfUnlessModifier`](https://github.com/Homebrew/brew/commit/cd3ced48e97f8fdab67b0737ba5441d4057457e9) and [`Style/ConditionalAssignment`](https://github.com/Homebrew/brew/commit/4498303f9a347184d9fc0bb6e93351bbfc4d1091) were enabled this weekend in Homebrew/brew (and hence `brew style` surfaces them here).
- This doesn't fix Livecheckables as they're annoyingly mostly _just_ above the LineLength limit. I'll leave those to people more experienced with livecheck regex syntax.