### PR TITLE
Fix brew style in livecheck

### DIFF
--- a/Livecheckables/ats2-postiats.rb
+++ b/Livecheckables/ats2-postiats.rb
@@ -1,4 +1,3 @@
 class Ats2Postiats
-  livecheck :url   => "http://www.ats-lang.org/Downloads.html",
-            :regex => %r{The current <em>stable</em> release of ATS2 is at\n<a href="http://sourceforge.net/projects/ats2-lang/download">ATS2-([0-9\.]+)</a>}
+  livecheck :regex => /ATS2-Postiats-v?(\d+(?:\.\d+)+)\.t/i
 end

--- a/Livecheckables/berkeley-db.rb
+++ b/Livecheckables/berkeley-db.rb
@@ -1,4 +1,5 @@
 class BerkeleyDb
-  livecheck :url   => "https://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html",
-            :regex => %r{href="http://download\.oracle\.com/otn/berkeley-db/db-([0-9,\.]+)\.t}
+  livecheck :url   => "https://www.oracle.com/technetwork/database/" \
+                       "database-technologies/berkeleydb/downloads/index.html",
+            :regex => %r{href=.*?/berkeley-db/db-v?(\d+(?:\.\d+)+)\.t}
 end

--- a/Livecheckables/capstone.rb
+++ b/Livecheckables/capstone.rb
@@ -1,4 +1,0 @@
-class Capstone
-  livecheck :url   => "https://github.com/aquynh/capstone/releases",
-            :regex => %r{href="/aquynh/capstone/releases/latest">Latest release</a>.*?href="/aquynh/capstone/tree/([0-9\.]+)"}m
-end

--- a/Livecheckables/zabbix.rb
+++ b/Livecheckables/zabbix.rb
@@ -1,4 +1,3 @@
 class Zabbix
-  livecheck :url   => "https://www.zabbix.com/download_sources",
-            :regex => %r{href="https://sourceforge\.net/projects/zabbix/files/ZABBIX%20Latest%20Stable/([0-9,\.]+)/zabbix-.*\.tar\.gz/download}
+  livecheck :regex => /url=.*?zabbix-(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
`brew style .` was recently added to the livecheck CI but failed. This PR fixes the errors produced by `brew style .`

Notice that there is also one outstanding warning that I believe is bug we didn't spot before:
```
== cmd/livecheck.rb ==
W: 53: 12: Use == if you meant to do a comparison or wrap the expression in parentheses to indicate you meant to assign in a condition.
```

A value is assigned to the `cmd` variable in the conditional of an `if` statement. I didn't touch it yet since the code works this way for now.