### PR TITLE
Allow comments in .brew_livecheck_watchlist

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -66,6 +66,8 @@ module Homebrew
       else
         Enumerator.new do |enum|
           File.open(WATCHLIST_PATH).each do |line|
+            next if line.match?(/^#/)
+
             line.split.each do |word|
               enum.yield Formulary.factory(word)
             end


### PR DESCRIPTION
This is a very simple addition that skips lines beginning with `#` in the `~/.brew_livecheck_watchlist` file.

This allows users to comment out lines, rather than only being able to remove/replace lines. I often run livecheck on a subset of formulae and having to manage my watchlist without being able to comment things out can be a pain at times.