### PR TITLE
dbus: add livecheckable

### DIFF
--- a/Livecheckables/dbus.rb
+++ b/Livecheckables/dbus.rb
@@ -1,0 +1,3 @@
+class Dbus
+  livecheck :regex => /^dbus-v?(\d+\.\d*?[02468](?:\.\d+)*)$/
+end


### PR DESCRIPTION
As surfaced in #461, [`dbus` uses even-numbered minor versions to indicate stable releases](https://wiki.freedesktop.org/www/Software/dbus/#index5h1) and odd-numbered minor versions to indicate development releases. We only want to use stable releases, so this adds a livecheckable to restrict matching to versions with an even-numbered minor version.