### PR TITLE
py2cairo: add livecheckable

### DIFF
--- a/Livecheckables/py2cairo.rb
+++ b/Livecheckables/py2cairo.rb
@@ -1,0 +1,3 @@
+class Py2cairo
+  livecheck :regex => /^v?(1\.18(?:\.\d+)*)$/
+end


### PR DESCRIPTION
As seen in Homebrew/homebrew-core#50871, `py2cairo` should be restricted to versions below 1.19 (as newer versions only support Python 3). This formula may be deleted in the future but for now it would be good to restrict livecheck to only match versions below 1.19.