### PR TITLE
wp-cli: add livecheckable

### DIFF
--- a/Livecheckables/wp-cli.rb
+++ b/Livecheckables/wp-cli.rb
@@ -1,0 +1,4 @@
+class WpCli
+  livecheck :url   => "https://github.com/wp-cli/wp-cli/releases/latest",
+            :regex => /href=".*?v?(\d+(?:\.\d+)+)"/
+end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -20,6 +20,8 @@ def version_heuristic(livecheckable, urls, regex = nil)
 
     puts "Trying with url #{url}" if Homebrew.args.debug?
     if url.include?("github.com") &&
+       !url.include?("api.github.com") &&
+       !url.include?("/latest") &&
        !url.include?("menhir") &&
        !url.include?("mednafen") &&
        !url.include?("camlp5") &&


### PR DESCRIPTION
This adds a livecheckable for `wp-cli` that makes it only check the release that's marked as "latest" on GitHub. There's a `2.4.1` version on GitHub (which livecheck is reporting as newest) but the ["latest" release](https://github.com/wp-cli/wp-cli/releases/latest) is currently 2.4.0 and [the README on GitHub](https://github.com/wp-cli/wp-cli/blob/master/README.md#wp-cli) corroborates that this is the latest stable version.

For what it's worth, to make this work, it was necessary to exclude URLs that contain `/latest` from using the Git strategy by default, otherwise we're unable to do a page match. I tested the other formulae containing `/latest` URLs (`kotlin`, `prometheus`, `pyenv-virtualenv`, `sysdig`) and they continue to work fine.