### PR TITLE
apache-zeppelin: remove livecheckable

### DIFF
--- a/Livecheckables/apache-zeppelin.rb
+++ b/Livecheckables/apache-zeppelin.rb
@@ -1,3 +1,0 @@
-class ApacheZeppelin
-  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
-end


### PR DESCRIPTION
`apache-zeppelin` was [removed from homebrew-core](https://github.com/Homebrew/homebrew-core/pull/50688).