### PR TITLE
i386-elf-gdb: add livecheckable

### DIFF
--- a/Livecheckables/i386-elf-gdb.rb
+++ b/Livecheckables/i386-elf-gdb.rb
@@ -1,0 +1,4 @@
+class I386ElfGdb
+  livecheck :url   => "https://ftp.gnu.org/gnu/gdb/?C=M&O=D",
+            :regex => /href="gdb-(\d+(?:\.\d+)+)\.t/
+end


### PR DESCRIPTION
# before the change

```
$ brew livecheck i386-elf-gdb
i386-elf-gdb (guessed) : 9.1 ==> 20131001
```

<details>
<summary>brew livecheck gtksourceviewmm --debug</summary>

```
w32api-2_2 => #<Version:0x00007ff7cc802fc0 @version="32api-2_2", @tokens=[#<Version::NumericToken 32>, #<Version::StringToken "api">, #<Version::NumericToken 2>, #<Version::NumericToken 2>]>
x86_64versiong3 => #<Version:0x00007ff7cc802a20 @version="86_64versiong3", @tokens=[#<Version::NumericToken 86>, #<Version::NumericToken 64>, #<Version::StringToken "versiong3">]>
i386-elf-gdb (guessed) : 9.1 ==> 20131001
```

</details>

# after the change

```
$ brew livecheck i386-elf-gdb
i386-elf-gdb : 9.1 ==> 9.1
```
