### PR TITLE
libsodium: add livecheckable

### DIFF
--- a/Livecheckables/libsodium.rb
+++ b/Livecheckables/libsodium.rb
@@ -1,0 +1,4 @@
+class Libsodium
+  livecheck :url   => "https://download.libsodium.org/libsodium/releases/",
+            :regex => /href=.*?libsodium-v?(\d+(?:\.\d+)+)\.t/
+end


### PR DESCRIPTION
The `libsodium` Git tags typically have a format like `1.0.18` but the latest release also has a `1.0.18-RELEASE` tag, which is being presented as a new version (in comparison to `1.0.18`). The `libsodium` formula uses an archive from https://download.libsodium.org/libsodium/releases/, so this adds a livecheckable to look for new versions on that index page instead.