### PR TITLE
giflib: add livecheckable

### DIFF
--- a/Livecheckables/giflib.rb
+++ b/Livecheckables/giflib.rb
@@ -1,0 +1,3 @@
+class Giflib
+  livecheck :regex => %r{/giflib-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
This is a formula where the heuristic uses the SourceForge strategy but returns `files` as the latest version and needs a regex to restrict matching. This adds a livecheckable with a regex to properly match versions in the RSS output.

There are a number of other formulae that meet these same criteria and need to be fixed in the future but we're temporarily holding off on creating/editing a large number of livecheckables until I've implemented some forthcoming features. I'm just tackling a few of the more popular formulae (more than 10,000 installs over 90 days) since they've been bothering me.