### PR TITLE
libsoxr: add livecheckable

### DIFF
--- a/Livecheckables/libsoxr.rb
+++ b/Livecheckables/libsoxr.rb
@@ -1,0 +1,3 @@
+class Libsoxr
+  livecheck :regex => %r{/soxr-v?(\d+(?:\.\d+)+)(?:-Source)?\.t}i
+end


### PR DESCRIPTION
This is a formula where the heuristic uses the SourceForge strategy but returns `files` as the latest version and needs a regex to restrict matching. This adds a livecheckable with a regex to properly match versions in the RSS output.