### PR TITLE
epsilon: add livecheckable

### DIFF
--- a/Livecheckables/epsilon.rb
+++ b/Livecheckables/epsilon.rb
@@ -1,0 +1,3 @@
+class Epsilon
+  livecheck :regex => %r{/epsilon-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
This is a formula where the heuristic uses the SourceForge strategy but returns `files` as the latest version and needs a regex to restrict matching. This adds a livecheckable with a regex to properly match versions in the RSS output.