### PR TITLE
vde: add livecheckable

### DIFF
--- a/Livecheckables/vde.rb
+++ b/Livecheckables/vde.rb
@@ -1,0 +1,3 @@
+class Vde
+  livecheck :regex => %r{/vde\d*?-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
This is a formula where the heuristic uses the SourceForge strategy but returns `files` as the latest version and needs a regex to restrict matching. This adds a livecheckable with a regex to properly match versions in the RSS output.