### PR TITLE
libusb-compat: add livecheckable

### DIFF
--- a/Livecheckables/libusb-compat.rb
+++ b/Livecheckables/libusb-compat.rb
@@ -1,0 +1,3 @@
+class LibusbCompat
+  livecheck :regex => %r{/libusb-compat-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
This is a formula where the heuristic uses the SourceForge strategy but returns `files` as the latest version and needs a regex to restrict matching. This adds a livecheckable with a regex to properly match versions in the RSS output.