### PR TITLE
heuristic: add GitLab releases check

### DIFF
--- a/Livecheckables/frotz.rb
+++ b/Livecheckables/frotz.rb
@@ -1,4 +1,0 @@
-class Frotz
-  livecheck :url   => "https://gitlab.com/DavidGriffith/frotz.git",
-            :regex => /^v?(\d+(?:\.\d+)+)$/
-end

--- a/Livecheckables/menhir.rb
+++ b/Livecheckables/menhir.rb
@@ -1,4 +1,0 @@
-class Menhir
-  livecheck :url   => "https://github.com/ocaml/opam-repository/tree/master/packages/menhir",
-            :regex => %r{href="/ocaml/opam-repository/tree/master/packages/menhir/menhir.([0-9,\.]+)"}
-end

--- a/Livecheckables/ortp.rb
+++ b/Livecheckables/ortp.rb
@@ -1,4 +1,0 @@
-class Ortp
-  livecheck :url   => "https://www.linphone.org/releases/sources/ortp",
-            :regex => /href="ortp-(\d+(?:\.\d+)+)\.t/
-end

--- a/Livecheckables/sound-touch.rb
+++ b/Livecheckables/sound-touch.rb
@@ -1,3 +1,0 @@
-class SoundTouch
-  livecheck :url => "https://gitlab.com/soundtouch/soundtouch.git"
-end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -14,7 +14,6 @@ def version_heuristic(livecheckable, urls, regex = nil)
   github_special_cases = %w[
     api.github.com
     /latest
-    menhir
     mednafen
     camlp5
     kotlin

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -57,6 +57,7 @@ def version_heuristic(livecheckable, urls, regex = nil)
     url.sub!("github.s3.amazonaws.com", "github.com") if url.include?("github")
 
     puts "Trying with url #{url}" if Homebrew.args.debug?
+    # Use repo from GitHub or GitLab inferred from download URL
     if url.include?("github.com") && github_special_cases.none? { |sc| url.include? sc }
       if url.include? "archive"
         url = url.sub(%r{/archive/.*}, ".git") if url.include? "github"
@@ -73,6 +74,8 @@ def version_heuristic(livecheckable, urls, regex = nil)
 
         url += ".git"
       end
+    elsif url.include?("/-/archive/")
+      url = url.sub(%r{/-/archive/.*$}i, ".git")
     end
     match_version_map = {}
     if /hackage\.haskell\.org/.match?(url)


### PR DESCRIPTION
Finds URLs that match the pattern of GitLab-hosted downloads and checks the tags page for which tags correspond to released versions. (The releases page itself isn't checked because its content isn't delivered on the initial page load.) As it's only run for formulae that don't specify a `head` URL, the affected formulae are:
```
dav1d (guessed) : 0.6.0 ==> 0.6.0
libxc (guessed) : 4.3.4 ==> 5.0.0
mat2 (guessed) : 0.10.1 ==> 0.11.0
minipro (guessed) : 0.4 ==> 0.4
proteinortho (guessed) : 6.0.14 ==> 6.0.15
radamsa (guessed) : 0.6 ==> 0.6
```
Also removed the livecheckable for `frotz`, which was redundant.