### PR TITLE
geoserver: update url and regex

### DIFF
--- a/Livecheckables/geoserver.rb
+++ b/Livecheckables/geoserver.rb
@@ -1,6 +1,8 @@
 class Geoserver
-  livecheck :url   => "https://sourceforge.net/projects/geoserver/",
-            # exclude 2.17-RC
-            # also rss feeds does not have 2.16.2-bin.zip
-            :regex => /geoserver-(\d+(?:\.\d+)+)-[^RC]/
+  # GeoServer releases contain a large number of files for each version, so the
+  # SourceForge RSS feed may only contain the latest version (which may have a
+  # different major/minor version than the latest stable). We check the GitHub
+  # repo tags here instead, to make sure we get all the latest versions.
+  livecheck :url   => "https://github.com/geoserver/geoserver",
+            :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
#514 added a livecheckable for `geoserver` to work around the issue with the SourceForge RSS feed not being reliable for this particular software (due to the RSS feed containing a large number of different files for each release, resulting in older releases being pushed out of the RSS feed and not being found by livecheck). This resolves the issue in a different manner, using the GitHub repo tags to look for new versions, which is much more reliable in this scenario.

Usually we prefer to check for versions from a similar location as the stable archive but it makes sense to make an exception here.