### PR TITLE
net-snmp: add livecheckable

### DIFF
--- a/Livecheckables/net-snmp.rb
+++ b/Livecheckables/net-snmp.rb
@@ -1,0 +1,4 @@
+class NetSnmp
+  livecheck :url   => "https://sourceforge.net/projects/net-snmp/",
+            :regex => %r{/net-snmp-([0-9\.]+)\.t}
+end

--- a/Livecheckables/net-snmp.rb
+++ b/Livecheckables/net-snmp.rb
@@ -1,4 +1,4 @@
 class NetSnmp
   livecheck :url   => "https://sourceforge.net/projects/net-snmp/",
-            :regex => %r{/net-snmp-([0-9\.]+)\.t}
+            :regex => %r{url=.+?/net-snmp-v?(\d+(?:\.\d+)+)\.t}
 end


### PR DESCRIPTION
# before the change

```
$ brew livecheck net-snmp
net-snmp (guessed) : 5.8 ==> 5.8.1
```

<details>
<summary>debug log</summary>

```
Trying with url https://downloads.sourceforge.net/project/net-snmp/net-snmp/5.8/net-snmp-5.8.tar.gz
Possible SourceForge project [net-snmp] detectedat https://downloads.sourceforge.net/project/net-snmp/net-snmp/5.8/net-snmp-5.8.tar.gz
Using page_match("https://sourceforge.net/projects/net-snmp/rss", "(?i-mx:\/net-snmp\/([a-zA-Z0-9.]+(?:\.[a-zA-Z0-9.]+)*))")
5.8.1, files, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, files, 5.8.1, 5.8.1, files, 5.8.1, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, 5.8, files, 5.8, files, 5.8, 5.8, files, 5.8, files, files, files, files, files, files, files, files, files, files, files, files, files, files, files, files, files, files, files, files, files, files, files, files, 5.4.5, files, 5.4.5, files, 5.4.5, 5.4.5, files, 5.4.5, 5.4.5, files, 5.4.5, files, 5.4.5, 5.4.5, files, 5.4.5, 5.4.5, files, 5.4.5, files, 5.4.5, 5.4.5, files, 5.4.5, 5.4.5, files, 5.4.5, files, 5.4.5, 5.4.5, files, 5.4.5, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.2.1, files, 5.7.2.1, files, 5.7.2.1, 5.7.2.1, files, 5.7.2.1, 5.7.2.1, files, 5.7.2.1, files, 5.7.2.1, 5.7.2.1, files, 5.7.2.1, 5.7.2.1, files, 5.7.2.1, files, 5.7.2.1, 5.7.2.1, files, 5.7.2.1, 5.7.2.1, files, 5.7.2.1, files, 5.7.2.1, 5.7.2.1, files, 5.7.2.1, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.5.2.1, files, 5.5.2.1, files, 5.5.2.1, 5.5.2.1, files, 5.5.2.1, 5.5.2.1, files, 5.5.2.1, files, 5.5.2.1, 5.5.2.1, files, 5.5.2.1, 5.5.2.1, files, 5.5.2.1, files, 5.5.2.1, 5.5.2.1, files, 5.5.2.1, 5.5.2.1, files, 5.5.2.1, files, 5.5.2.1, 5.5.2.1, files, 5.5.2.1, 5.6.2.1, files, 5.6.2.1, files, 5.6.2.1, 5.6.2.1, files, 5.6.2.1, 5.6.2.1, files, 5.6.2.1, files, 5.6.2.1, 5.6.2.1, files, 5.6.2.1, 5.6.2.1, files, 5.6.2.1, files, 5.6.2.1, 5.6.2.1, files, 5.6.2.1, 5.6.2.1, files, 5.6.2.1, files, 5.6.2.1, 5.6.2.1, files, 5.6.2.1, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, files, 5.7.3, 5.7.3, files, 5.7.3, 5.7.2, files, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2, files, 5.7.2, 5.7.2, files, 5.7.2
5.8.1 => #<Version:0x00007fa8c4ba22b8 @version="5.8.1", @tokens=[#<Version::NumericToken 5>, #<Version::NumericToken 8>, #<Version::NumericToken 1>]>
files => #<Version:0x00007fa8c4ba2268 @version="files", @tokens=[#<Version::StringToken "files">]>
5.8 => #<Version:0x00007fa8c4ba2218 @version="5.8", @tokens=[#<Version::NumericToken 5>, #<Version::NumericToken 8>]>
5.4.5 => #<Version:0x00007fa8c4ba21c8 @version="5.4.5", @tokens=[#<Version::NumericToken 5>, #<Version::NumericToken 4>, #<Version::NumericToken 5>]>
5.7.3 => #<Version:0x00007fa8c4ba2178 @version="5.7.3", @tokens=[#<Version::NumericToken 5>, #<Version::NumericToken 7>, #<Version::NumericToken 3>]>
5.7.2.1 => #<Version:0x00007fa8c4ba2128 @version="5.7.2.1", @tokens=[#<Version::NumericToken 5>, #<Version::NumericToken 7>, #<Version::NumericToken 2>, #<Version::NumericToken 1>]>
5.5.2.1 => #<Version:0x00007fa8c4ba20b0 @version="5.5.2.1", @tokens=[#<Version::NumericToken 5>, #<Version::NumericToken 5>, #<Version::NumericToken 2>, #<Version::NumericToken 1>]>
5.6.2.1 => #<Version:0x00007fa8c4ba2060 @version="5.6.2.1", @tokens=[#<Version::NumericToken 5>, #<Version::NumericToken 6>, #<Version::NumericToken 2>, #<Version::NumericToken 1>]>
5.7.2 => #<Version:0x00007fa8c4ba2010 @version="5.7.2", @tokens=[#<Version::NumericToken 5>, #<Version::NumericToken 7>, #<Version::NumericToken 2>]>
net-snmp (guessed) : 5.8 ==> 5.8.1
```

</details>

# after the change

```
$ brew livecheck net-snmp
net-snmp : 5.8 ==> 5.8
```
