### PR TITLE
frege: update url and regex

### DIFF
--- a/Livecheckables/frege.rb
+++ b/Livecheckables/frege.rb
@@ -1,4 +1,4 @@
 class Frege
-  livecheck :url   => "https://github.com/Frege/frege/releases",
-            :regex => %r{public\/frege([0-9\.]+)}i
+  livecheck :url   => "https://github.com/Frege/frege/releases/latest",
+            :regex => /href=.+?frege(\d+(?:\.\d+)+)\.jar/
 end


### PR DESCRIPTION
#512 added a livecheckable for `frege` but used the GitHub releases page. In the case of `frege`, there are a number of unstable releases which could push the latest stable release off of the first page at some point, breaking the check.

This modifies the livecheckable to use the URL for the `latest` release and updates the regex to be a little more loose in one way (not just matching releases ending with `public`) and more specific in others (more specific version regex and looking for URLs for `.jar` files only).