### PR TITLE
nuget: update url and regex

### DIFF
--- a/Livecheckables/nuget.rb
+++ b/Livecheckables/nuget.rb
@@ -1,4 +1,4 @@
 class Nuget
-  livecheck :url   => "https://dist.nuget.org/index.json",
-            :regex => /"displayName":\s*?"nuget.exe - recommended latest",\s*?"version":\s*?"v?(\d+(?:\.\d+)+)"/i
+  livecheck :url   => "https://dist.nuget.org/tools.json",
+            :regex => %r{"url":\s*?"[^"]+/v?(\d+(?:\.\d+)+)/nuget\.exe",\s*?"stage":\s*?"ReleasedAndBlessed"}i
 end


### PR DESCRIPTION
#519 updated the livecheckable for `nuget` to properly identify the newest version, rather than just finding the version that appears to be newest (w.r.t., [a discussion in a `nuget` update PR in homebrew-core](https://github.com/Homebrew/homebrew-core/pull/52939/files#r407134065)).

This modifies the previous method to look for `ReleasedAndBlessed` versions in https://dist.nuget.org/tools.json instead, which may be more reliable in the long run (as the previous check would break if the "recommended latest" text ever changes to something else). As a nice side effect, this will pick up all the previous `ReleasedAndBlessed` versions rather than just one version.