### PR TITLE
nwchem: add livecheckable

### DIFF
--- a/Livecheckables/nwchem.rb
+++ b/Livecheckables/nwchem.rb
@@ -1,0 +1,4 @@
+class Nwchem
+  livecheck :url   => "https://github.com/nwchemgit/nwchem.git",
+            :regex => /^v?(\d+(?:\.\d+)+)-release$/
+end


### PR DESCRIPTION
### before the change

```
$ brew livecheck nwchem
nwchem (guessed) : 7.0.0 ==> 22_2018
```

<details>
<summary>debug log</summary>

```
Trying with url https://github.com/nwchemgit/nwchem/releases/download/v7.0.0-release/nwchem-7.0.0-release.revision-2c9a1c7c-src.2020-02-26.tar.bz2
Possible git repo detected at https://github.com/nwchemgit/nwchem.git
6.8.1-release => #<Version:0x00007fc0c8262830 @version="6.8.1-release", @tokens=[#<Version::NumericToken 6>, #<Version::NumericToken 8>, #<Version::NumericToken 1>, #<Version::StringToken "release">]>
6.8.1-scorep => #<Version:0x00007fc0c8261e58 @version="6.8.1-scorep", @tokens=[#<Version::NumericToken 6>, #<Version::NumericToken 8>, #<Version::NumericToken 1>, #<Version::StringToken "scorep">]>
master-oct22_2018 => #<Version:0x00007fc0c8261868 @version="22_2018", @tokens=[#<Version::NumericToken 22>, #<Version::NumericToken 2018>]>
v6.8 => #<Version:0x00007fc0c8260990 @version="6.8", @tokens=[#<Version::NumericToken 6>, #<Version::NumericToken 8>]>
v6.8-release => #<Version:0x00007fc0c82600a8 @version="6.8-release", @tokens=[#<Version::NumericToken 6>, #<Version::NumericToken 8>, #<Version::StringToken "release">]>
v7.0.0-release => #<Version:0x00007fc0c826af58 @version="7.0.0-release", @tokens=[#<Version::NumericToken 7>, #<Version::NumericToken 0>, #<Version::NumericToken 0>, #<Version::StringToken "release">]>
nwchem (guessed) : 7.0.0 ==> 22_2018
```

</details>

### after the change

```
$ brew livecheck nwchem
nwchem : 7.0.0 ==> 7.0.0
```
