### PR TITLE
ocproxy: add livecheckable

### DIFF
--- a/Livecheckables/ocproxy.rb
+++ b/Livecheckables/ocproxy.rb
@@ -1,0 +1,4 @@
+class Ocproxy
+  livecheck :url   => "https://github.com/cernekee/ocproxy.git",
+            :regex => /^v?(\d+(?:\.\d{1,3})+)$/
+end


### PR DESCRIPTION
### before the change

```
$ brew livecheck ocproxy
ocproxy (guessed) : 1.60 ==> 1.20121120160713
```

<details>
<summary>debug log</summary>

```
Trying with url https://github.com/cernekee/ocproxy.git
Possible git repo detected at https://github.com/cernekee/ocproxy.git
1.20121120160713 => #<Version:0x00007fc054142c80 @version="1.20121120160713", @tokens=[#<Version::NumericToken 1>, #<Version::NumericToken 20121120160713>]>
v1.50 => #<Version:0x00007fc054142898 @version="1.50", @tokens=[#<Version::NumericToken 1>, #<Version::NumericToken 50>]>
v1.60 => #<Version:0x00007fc054142230 @version="1.60", @tokens=[#<Version::NumericToken 1>, #<Version::NumericToken 60>]>
ocproxy (guessed) : 1.60 ==> 1.20121120160713
```

</details>

### after the change

```
$ brew livecheck ocproxy
ocproxy : 1.60 ==> 1.60
```
