### PR TITLE
Allow livecheckables to filter matched versions

### DIFF
--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -244,6 +244,12 @@ def version_heuristic(livecheckable, urls, regex = nil)
       end
     end
 
+    if livecheck_args.is_a?(Hash) &&
+       livecheck_args.key?(:versions) &&
+       livecheck_args[:versions].is_a?(Hash)
+      filter_versions(match_version_map, livecheck_args[:versions])
+    end
+
     if Homebrew.args.debug?
       match_version_map.each do |match, version|
         puts "#{match} => #{version.inspect}"

--- a/livecheck/utils.rb
+++ b/livecheck/utils.rb
@@ -1,5 +1,86 @@
 require "open-uri"
 
+def filter_versions(match_version_map, versions_hash)
+  filter_parts = versions_hash.key?(:parts) ? versions_hash[:parts] : []
+
+  if filter_parts.empty?
+    has_major_part = versions_hash.key?(:major)
+    has_minor_part = versions_hash.key?(:minor)
+    has_patch_part = versions_hash.key?(:patch)
+    has_other_part = versions_hash.key?(:other)
+
+    filter_parts.push(has_major_part ? versions_hash[:major] : nil)
+
+    if has_minor_part
+      filter_parts.push(versions_hash[:minor])
+    elsif has_patch_part || has_other_part
+      filter_parts.push(nil)
+    end
+
+    filter_parts.push(versions_hash[:patch]) if has_patch_part
+
+    if has_other_part && versions_hash[:other].is_a?(Array)
+      versions_hash[:other].each { |other_part| filter_parts.push(other_part) }
+    elsif has_other_part
+      filter_parts.push(versions_hash[:other])
+    end
+  end
+
+  puts "filter_parts: #{filter_parts}" if Homebrew.args.debug?
+
+  match_version_map.select! do |_match, version|
+    comparison = versions_hash.key?(:comparison) ? versions_hash[:comparison] : nil
+
+    is_good_version = true
+    version.tokens.each_index do |i|
+      break if filter_parts.length < i + 1
+
+      part = filter_parts[i]
+      if part.is_a?(Hash)
+        part_comparison = part.key?(:comparison) ? part[:comparison] : nil
+        part_version = part.key?(:version) ? part[:version] : nil
+      else
+        part_comparison = nil
+        part_version = part
+      end
+      next if part_version.nil?
+
+      token = version.tokens[i]
+      result = case (!part_comparison.nil? ? part_comparison : comparison)
+      when :eq
+        token.value == part_version
+      when :lte
+        token.value <= part_version
+      when :gte
+        token.value >= part_version
+      when :lt
+        token.value < part_version
+      when :gt
+        token.value > part_version
+      when :neq
+        token.value != part_version
+      when :in
+        next unless part_version.is_a?(Array)
+
+        part_version.include?(token.value)
+      when :nin
+        next unless part_version.is_a?(Array)
+
+        !part_version.include?(token.value)
+      else
+        next
+      end
+
+      if result == false
+        is_good_version = false
+        break
+      end
+    end
+
+    is_good_version
+  end
+end
+
 def git_tags(repo_url, filter = nil)
   raw_tags = `git ls-remote --tags #{repo_url}`
   raw_tags.gsub!(%r{^.*\trefs/tags/}, "")


### PR DESCRIPTION
While working on livecheck's heuristic and livecheckables in the past, I noticed that there are a number of formulae that need to restrict matched versions based on a given major/minor/patch version (e.g., only matching major versions lower than 3).  I was hoping to work on this feature after others but there are a number of open PRs for some of the related formulae and it would be better to handle these using a version restriction feature (instead of a complex regex).

A full example would look something like:

```ruby
class Example
  livecheck :versions => {
              :comparison => :lte, # Default comparison for version parts
              :major      => 4,    # ...or { :comparison => :eq, :version => 4 }
              :minor      => 3,    # ...or { :comparison => :eq, :version => 3 }
              :patch      => 2,    # ...or { :comparison => :eq, :version => 2 }
              :other      => 1,    # ...or array of values/hashes
            }
end
```

`:comparison` is one of `:eq`, `:neq`, `:lt`, `:gt`, `:lte`, `:gte`, or `:in` and applies to all parts by default. `:major`/`:minor`/`:patch`/`:other` basically correspond to positions in the parsed version tokens (with `:other` being anything after the minor/patch version).  A majority of formulae use something like semantic versioning and I imagine most of the time we'll just be restricting major, minor, and/or patch, so this API makes things convenient.

Behind the scenes, these values are added to an array of the version parts and `nil` values are used as padding (where necessary) to have values in the appropriate position in comparison to a parsed `Version`'s tokens.  Major and minor values are expected to exist in the formula's version but patch is optional (since some formulae use major, minor, and an extension).

I initially tried to support versions with more than three parts using `:build` and `:extension` parts but it didn't work with some versions using unusual versioning schemes.  In the end, I decided to simply restrict the convenience API to major/minor/patch and anything else is handled by `:other`.  You can pass a single value to `:other` but it can also take an array instead, to handle versions of arbitrary length (so long as you pad with `nil` values, as appropriate).


## `:parts`

Alternatively, it's possible to manually specify the `parts` array in the livecheckable. For example, `imagemagick` uses a version format like `7.0.10-6`, so we could do the following to only match versions where the extension is 5 or below (i.e., <= x.x.x-5):

```ruby
class Example
  livecheck :versions => {
              :comparison => :lte,
              :parts      => [
               nil,
               nil,
               nil,
               5
              ]
end
```

If we used the convenience API instead, we would have to set `:patch` to `nil` (since it's optional and we need a third element in the array for positioning) and set `:other` to `5` to accomplish the same thing, which is maybe a little weird. There are probably better examples but I wanted to demonstrate at least one application of `:parts`.

Besides dealing with more complex/unusual version schemes, `:parts` could also be appropriate for versions where the semantics of `:major`, `:minor`, `:patch` don't make sense (e.g., versions that are just a date, like `20190702`).  Overall, I don't imagine we'll use `:parts` very often but it may be handy for unusual cases.


## Overriding `:comparison`

`:comparison` is used by default as the comparison method for all parts but it can be selectively overridden by supplying a hash with `:comparison` and `:version` values for a given part:

```ruby
class Example
  livecheck :versions => {
              :comparison => :eq,
              :major      => 4,
              :minor      => { :comparison => :lte, :version => 3 }
            }
end
```

I imagine this won't be used very often but I wanted to allow for the flexibility in case it's ever needed.


## Closing

The only other thing to note is that this feature requires making `Version.tokens` accessible (so we can access a version's tokens and use them for comparison), so I'll be opening a related PR in homebrew/brew for this change.

Beyond that, I'm sure aspects of this idea and implementation can be improved, so please provide feedback/review if you have the time.