### PR TITLE
olsrd: remove url and update regex

### DIFF
--- a/Livecheckables/olsrd.rb
+++ b/Livecheckables/olsrd.rb
@@ -1,4 +1,3 @@
 class Olsrd
-  livecheck :url   => "http://www.olsr.org/releases/0.9/",
-            :regex => /href="olsrd-([0-9\.]+)\.t/
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The `olsrd` formula has a comment saying "olsr's website is 'ill' and does not contain the latest release." The formula is using a release from the GitHub repo, so this removes the existing livecheckable's URL (allowing the heuristic to use the Git repo) and updates the regex accordingly.

Closes #535.