### PR TITLE
node@12: add livecheckable

### DIFF
--- a/Livecheckables/node@12.rb
+++ b/Livecheckables/node@12.rb
@@ -1,0 +1,4 @@
+class NodeAT12
+  livecheck :url   => "https://nodejs.org/dist/",
+            :regex => %r{href=.*?v?(12(?:\.\d+){2})/?['"]}
+end


### PR DESCRIPTION
#528 adds a livecheckable for the `node@12` formula, which is currently skipped due to being versioned. This is an alternative implementation that uses the https://nodejs.org/dist/ index, so the check is in line with where the formula gets archives.

Closes #528.