### PR TITLE
onioncat: update url and regex

### DIFF
--- a/Livecheckables/onioncat.rb
+++ b/Livecheckables/onioncat.rb
@@ -1,4 +1,4 @@
 class Onioncat
-  livecheck :url   => "https://www.cypherpunk.at/ocat/download/Source/current/",
-            :regex => /href="onioncat-([0-9\.]+.*?)\.t/
+  livecheck :url   => "https://www.cypherpunk.at/ocat/download/Source/stable/",
+            :regex => /href=.+?onioncat-v?(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
The existing `onioncat` livecheckable checks a page that contains prerelease versions instead of stable. #534 resolves this by checking the Git repo tags instead and restricting matching to stable versions using the regex.

This PR resolves the issue by simply checking the `stable` page instead of `current`, which allows us to continue checking the same upstream location as the formula's stable URL. I've also updated the regex to bring it in line with current standards.

Closes #534.