### PR TITLE
mupen64plus: add livecheckable

### DIFF
--- a/Livecheckables/mupen64plus.rb
+++ b/Livecheckables/mupen64plus.rb
@@ -1,0 +1,4 @@
+class Mupen64plus
+  livecheck :url   => "https://github.com/mupen64plus/mupen64plus-core/releases/latest",
+            :regex => %r{href=.+/tag/v?(\d+(?:\.\d+)+)}
+end


### PR DESCRIPTION
### before the change

```
$ brew livecheck mupen64plus
mupen64plus (guessed) : 2.5 ==> 2.5.9
```

<details>
<summary>debug log</summary>

```
Trying with url https://github.com/mupen64plus/mupen64plus-core/releases/download/2.5/mupen64plus-bundle-src-2.5.tar.gz
Possible git repo detected at https://github.com/mupen64plus/mupen64plus-core.git
1.99.1 => #<Version:0x00007fe755838be8 @version="1.99.1", @tokens=[#<Version::NumericToken 1>, #<Version::NumericToken 99>, #<Version::NumericToken 1>]>
1.99.2 => #<Version:0x00007fe755838788 @version="1.99.2", @tokens=[#<Version::NumericToken 1>, #<Version::NumericToken 99>, #<Version::NumericToken 2>]>
1.99.3 => #<Version:0x00007fe755838580 @version="1.99.3", @tokens=[#<Version::NumericToken 1>, #<Version::NumericToken 99>, #<Version::NumericToken 3>]>
1.99.4 => #<Version:0x00007fe7558383a0 @version="1.99.4", @tokens=[#<Version::NumericToken 1>, #<Version::NumericToken 99>, #<Version::NumericToken 4>]>
1.99.5 => #<Version:0x00007fe7558381c0 @version="1.99.5", @tokens=[#<Version::NumericToken 1>, #<Version::NumericToken 99>, #<Version::NumericToken 5>]>
2.0 => #<Version:0x00007fe754943f98 @version="2.0", @tokens=[#<Version::NumericToken 2>, #<Version::NumericToken 0>]>
2.5 => #<Version:0x00007fe754943ae8 @version="2.5", @tokens=[#<Version::NumericToken 2>, #<Version::NumericToken 5>]>
2.5.9 => #<Version:0x00007fe7549437f0 @version="2.5.9", @tokens=[#<Version::NumericToken 2>, #<Version::NumericToken 5>, #<Version::NumericToken 9>]>
v1.999-milestone-1 => #<Version:0x00007fe7549435e8 @version="1.999-milestone-1", @tokens=[#<Version::NumericToken 1>, #<Version::NumericToken 999>, #<Version::StringToken "milestone">, #<Version::NumericToken 1>]>
mupen64plus (guessed) : 2.5 ==> 2.5.9
```

</details>

### after the change

```
$ brew livecheck mupen64plus
mupen64plus : 2.5 ==> 2.5
```
