### PR TITLE
embulk: livecheck against 0.9.x release line

### DIFF
--- a/Livecheckables/embulk.rb
+++ b/Livecheckables/embulk.rb
@@ -1,4 +1,4 @@
 class Embulk
   livecheck :url   => "https://github.com/embulk/embulk.git",
-            :regex => /^v?(\d+(?:\.\d+)+)$/
+            :regex => /^v?(0\.9(?:\.\d+)+)$/
 end


### PR DESCRIPTION
Fixes #549

### before the change

```
$ brew livecheck embulk
embulk : 0.9.23 ==> 0.10.1
```

### after the change

```
$ brew livecheck embulk
embulk : 0.9.23 ==> 0.9.23
```