### PR TITLE
shibboleth-sp: add livecheckable

### DIFF
--- a/Livecheckables/shibboleth-sp.rb
+++ b/Livecheckables/shibboleth-sp.rb
@@ -1,0 +1,4 @@
+class ShibbolethSp
+  livecheck :url   => "https://shibboleth.net/downloads/service-provider/latest/",
+            :regex => /href="shibboleth-sp-(\d+(?:\.\d+)+)\.t/
+end


### PR DESCRIPTION
### after the change

```
$ brew livecheck shibboleth-sp
shibboleth-sp : 3.0.4 ==> 3.1.0
```

---

relates to https://github.com/Homebrew/homebrew-core/pull/53422