### PR TITLE
e2fsprogs: fix url

### DIFF
--- a/Livecheckables/e2fsprogs.rb
+++ b/Livecheckables/e2fsprogs.rb
@@ -1,4 +1,4 @@
 class E2fsprogs
-  livecheck :url   => "http://e2fsprogs.sourceforge.net/",
+  livecheck :url   => "https://sourceforge.net/projects/e2fsprogs/",
             :regex => /e2fsprogs-([0-9\.]+)\.t/
 end


### PR DESCRIPTION
### before the change

```
$ brew livecheck e2fsprogs
Error: e2fsprogs: Failed to open TCP connection to e2fsprogs.sourceforge.net:443 (Connection refused - connect(2) for "e2fsprogs.sourceforge.net" port 443)
```


### after the change

```
$ brew livecheck e2fsprogs
e2fsprogs : 1.45.5 ==> 1.45.6
```

---

relates to https://github.com/Homebrew/homebrew-core/pull/53428