### PR TITLE
Add support for livecheck DSL

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -109,14 +109,11 @@ module Homebrew
       return
     end
 
-    has_hash_arg_with_skip =
-      formula.livecheck_args.is_a?(Hash) && formula.livecheck_args.key?(:skip)
     is_gist = formula.stable.url.include?("gist.github.com")
-    if has_hash_arg_with_skip || formula.livecheck_args == :skip || is_gist
-      skip_msg = if has_hash_arg_with_skip &&
-                    formula.livecheck_args[:skip].is_a?(String) &&
-                    !formula.livecheck_args[:skip].empty?
-        " - #{formula.livecheck_args[:skip]}"
+    if formula.livecheck.skip? || is_gist
+      skip_msg = if formula.livecheck.skip_msg.is_a?(String) &&
+                    !formula.livecheck.skip_msg.blank?
+        " - #{formula.livecheck.skip_msg}"
       elsif is_gist
         " - Stable URL is a GitHub Gist"
       else


### PR DESCRIPTION
This PR aims to add fallback code to livecheck, in order to handle the livecheck Formula DSL (Homebrew/brew#7027) for `skip`.

With this addition, any `skip` added to `some-formula.rb` in homebrew/core as part of the livecheck DSL will be handled properly. See Homebrew/brew#7179 for more details.

Example:
some-formula.rb in homebrew/core:
```ruby
...
  livecheck do
    skip "Not maintained"
  end
...
```
Output of `brew livecheck some-formula`:
```bash
some-formula: skipped - Not maintained
```