### PR TITLE
marathon-swift: skipCheck due to deprecation and open compilation issue

### DIFF
--- a/Livecheckables/marathon-swift.rb
+++ b/Livecheckables/marathon-swift.rb
@@ -1,0 +1,6 @@
+class MarathonSwift
+  # repo deprecated in favor of official swift package manager
+  # see https://github.com/JohnSundell/Marathon/issues/208
+  # also there is un-fixed compilation issue, https://github.com/JohnSundell/Marathon/issues/151
+  livecheck :skip => "Not maintained"
+end


### PR DESCRIPTION
skipCheck due to deprecation and open compilation issue