### PR TITLE
autoconf: update url and regex

### DIFF
--- a/Livecheckables/autoconf.rb
+++ b/Livecheckables/autoconf.rb
@@ -1,3 +1,4 @@
 class Autoconf
-  livecheck :url => "git://git.sv.gnu.org/autoconf", :regex => /^v(.*)$/
+  livecheck :url   => "https://git.savannah.gnu.org/git/autoconf.git",
+            :regex => /^(?:autoconf-)?v?(\d+(?:\.\d+)+)$/i
 end


### PR DESCRIPTION
The existing livecheckable for `autoconf` was the only formula/livecheckable using the Git protocol. This updates the URL to use the https URL for the Git repo and also updates the regex to only work with tags relating to [stable] autoconf releases.