### PR TITLE
tmux: update url and regex

### DIFF
--- a/Livecheckables/tmux.rb
+++ b/Livecheckables/tmux.rb
@@ -1,4 +1,4 @@
 class Tmux
-  livecheck :url   => "https://github.com/tmux/tmux/releases",
-            :regex => %r{Latest.*?href="/tmux/tmux/tree/v?([0-9\.]+[0-9a-z])}m
+  livecheck :url   => "https://github.com/tmux/tmux/releases/latest",
+            :regex => %r{href=.+/tag/v?(\d+(?:\.\d+)+[a-z]?)}i
 end


### PR DESCRIPTION
#562 was merged without being reviewed, so this PR updates the livecheckable with the changes that would have been requested during review. As with other recent PRs, this one is better off using the GitHub "latest" URL as well as the general regex for getting the version number from the tag URL in the HTML (with the addition of `[a-z]?`, since `tmux` has releases like `3.1a`).