### PR TITLE
swagger-codegen@2: update regex

### DIFF
--- a/Livecheckables/swagger-codegen@2.rb
+++ b/Livecheckables/swagger-codegen@2.rb
@@ -1,4 +1,4 @@
 class SwaggerCodegenAT2
   livecheck :url   => "https://github.com/swagger-api/swagger-codegen.git",
-            :regex => /^v?2(?:\.\d+)+$/
+            :regex => /^v?(2(?:\.\d+)+)$/
 end


### PR DESCRIPTION
#563 was merged without being reviewed, so this PR updates the livecheckable with the changes that would have been requested during review. In this case, the regex diverged from the standard regex in that it was missing parentheses around the version part of the regex, which creates a capture group (and is used in the heuristic these days).