### PR TITLE
supertux: update url and regex

### DIFF
--- a/Livecheckables/supertux.rb
+++ b/Livecheckables/supertux.rb
@@ -1,4 +1,4 @@
 class Supertux
-  livecheck :url   => "https://github.com/SuperTux/supertux/releases",
-            :regex => %r{Latest.*?href="/SuperTux/supertux/tree/v?([0-9\.]+)}m
+  livecheck :url   => "https://github.com/SuperTux/supertux/releases/latest",
+            :regex => %r{href=.+/tag/v?(\d+(?:\.\d+)+)}
 end


### PR DESCRIPTION
#564 was merged without being reviewed, so this PR updates the livecheckable with the changes that would have been requested during review. As with other recent PRs, this one is better off using the GitHub "latest" URL as well as the general regex for getting the version number from the tag URL in the HTML.