### PR TITLE
Fix assumption of WATCHLIST_PATH existence

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -69,7 +69,7 @@ module Homebrew
         Formula.names.map { |name| Formula[name] }
       elsif !Homebrew.args.formulae.empty?
         Homebrew.args.formulae
-      else
+      elsif File.exist?(WATCHLIST_PATH)
         Enumerator.new do |enum|
           File.open(WATCHLIST_PATH).each do |line|
             next if line.match?(/^#/)
@@ -82,6 +82,7 @@ module Homebrew
           onoe e
         end
       end
+    return unless formulae_to_check
 
     formulae_checked = formulae_to_check.sort.map do |formula|
       print_latest_version formula


### PR DESCRIPTION
Livecheck has apparently long-assumed that `WATCHLIST_PATH` (`~/.brew_livecheck_watchlist`) will definitely exist, which isn't guaranteed to be true.

The following related error has been appearing in the `brew livecheck` step of our GitHub Actions checks: `Error: No such file or directory @ rb_sysopen - /Users/runner/.brew_livecheck_watchlist`. This modification will resolve this error but we may need to do more to fix the `brew livecheck` step, if it doesn't go back to running checks for added/modified livecheckables.