### PR TITLE
gl2ps: update url and regex

### DIFF
--- a/Livecheckables/gl2ps.rb
+++ b/Livecheckables/gl2ps.rb
@@ -1,4 +1,4 @@
 class Gl2ps
-  livecheck :url   => "http://www.geuz.org/gl2ps/",
-            :regex => %r{latest stable version.*?/gl2ps-([0-9\.]+)\.t}m
+  livecheck :url   => "http://geuz.org/gl2ps/src/",
+            :regex => /href=.+gl2ps-v?(\d+(?:\.\d+)+)\.t/i
 end


### PR DESCRIPTION
In testing whether the URL in the existing livecheckable supported https, I found that the server redirects to https://geuz.org/gl2ps/, so this updates the livecheckable to the more canonical URL without the www subdomain. This also updates the URL to use the http://geuz.org/gl2ps/src/ index page (which is in line with where the formula downloads the stable archive) and updates the regex accordingly.