### PR TITLE
eigen: remove livecheckable

### DIFF
--- a/Livecheckables/eigen.rb
+++ b/Livecheckables/eigen.rb
@@ -1,4 +1,0 @@
-class Eigen
-  livecheck :url   => "http://eigen.tuxfamily.org/",
-            :regex => /Eigen (\d+(\.\d+)+) released/
-end


### PR DESCRIPTION
Since GitLab support was added in #507, the existing `eigen` livecheckable is no longer necessary, as the heuristic is fully capable of finding the latest version.