### PR TITLE
gnu-prolog: update url and regex

### DIFF
--- a/Livecheckables/gnu-prolog.rb
+++ b/Livecheckables/gnu-prolog.rb
@@ -1,4 +1,4 @@
 class GnuProlog
-  livecheck :url   => "http://gprolog.univ-paris1.fr",
-            :regex => /Current stable version is gprolog-([0-9\.]+)</
+  livecheck :url   => "http://www.gprolog.org/",
+            :regex => /href=.+gprolog-v?(\d+(?:\.\d+)+)\.t/i
 end


### PR DESCRIPTION
The `gnu-prolog` formula uses the http://www.gprolog.org/ website, so this update the existing livecheckable's URL to bring it in line. This also modifies the regex, so it will find the `tar.gz` file link on the page even if the "Current stable version is" text changes in the future.