### PR TITLE
icoutils: update url and regex

### DIFF
--- a/Livecheckables/icoutils.rb
+++ b/Livecheckables/icoutils.rb
@@ -1,4 +1,4 @@
 class Icoutils
-  livecheck :url   => "http://www.nongnu.org/icoutils/",
-            :regex => /icoutils-(\d+\.\d+\.\d+)\.t/
+  livecheck :url   => "https://download.savannah.gnu.org/releases/icoutils/",
+            :regex => /href=.+icoutils-(\d+\.\d+\.\d+)\.t/
 end


### PR DESCRIPTION
This updates the existing livecheckable to use the index page where the stable archive used in the formula is hosted (which supports https). This also updates the regex to only match URLs in `href` attributes.