### PR TITLE
nuttcp: update url and regex

### DIFF
--- a/Livecheckables/nuttcp.rb
+++ b/Livecheckables/nuttcp.rb
@@ -1,4 +1,4 @@
 class Nuttcp
-  livecheck :url   => "http://nuttcp.net/nuttcp/",
-            :regex => /href="nuttcp-([0-9\.]+)\.t/
+  livecheck :url   => "https://www.nuttcp.net/nuttcp/",
+            :regex => /href=.+nuttcp-v?(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
This updates the URL for the existing `nuttcp` livecheckable to use an https URL (as found in the formula's stable URL) and updates the regex to bring it in line with more recent standards.