### PR TITLE
faad2: remove url and update regex

### DIFF
--- a/Livecheckables/faad2.rb
+++ b/Livecheckables/faad2.rb
@@ -1,4 +1,3 @@
 class Faad2
-  livecheck :url   => "http://sourceforge.net/projects/faac/files/faad2-src/",
-            :regex => /faad2-(\d+(?:\.\d+)*)\.t/
+  livecheck :regex => /url=.+faad2-(\d+(?:\.\d+)*)\.t/
 end


### PR DESCRIPTION
This removes the URL in the existing livecheckable for `faad2` (allowing the heuristic to take over and use the SourceForge strategy) and updates the regex to only match within `url` attributes in the SourceForge RSS feed.