### PR TITLE
cppunit: update regex

### DIFF
--- a/Livecheckables/cppunit.rb
+++ b/Livecheckables/cppunit.rb
@@ -1,4 +1,4 @@
 class Cppunit
   livecheck :url   => "https://wiki.freedesktop.org/www/Software/cppunit/",
-            :regex => %r{href="http://dev-www.libreoffice.org/src/cppunit-([0-9,\.]+)\.tar}
+            :regex => /href=.+cppunit-v?(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
This updates the regex for the existing `cppunit` livecheckable to not use a full URL when matching the cppunit archive files, making it a little more resilient to potential changes in the future. This also replaces the old `[0-9\.]+` style regex with the standard regex we use these days.