### PR TITLE
cvsync: update regex

### DIFF
--- a/Livecheckables/cvsync.rb
+++ b/Livecheckables/cvsync.rb
@@ -1,4 +1,4 @@
 class Cvsync
   livecheck :url   => "https://www.cvsync.org",
-            :regex => %r{href="http://www.cvsync.org/dist/cvsync-([0-9\.]+)\.t}
+            :regex => /href=.+cvsync-v?(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
This updates the regex for the existing `cvsync` livecheckable to not use a full URL when matching the cvsync archive file, making it a little more resilient to potential changes in the future. This also replaces the old `[0-9\.]+` style regex with the standard regex we use these days.