### PR TITLE
dterm: update regex

### DIFF
--- a/Livecheckables/dterm.rb
+++ b/Livecheckables/dterm.rb
@@ -1,4 +1,4 @@
 class Dterm
   livecheck :url   => "http://www.knossos.net.nz/resources/free-software/dterm/",
-            :regex => %r{href="http://www.knossos.net.nz/downloads/dterm-([0-9\.]+)\.t}
+            :regex => /href=.+dterm-v?(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
This updates the regex for the existing `dterm` livecheckable to not use a full URL when matching the dterm archive file, making it a little more resilient to potential changes in the future. This also replaces the old `[0-9\.]+` style regex with the standard regex we use these days.