### PR TITLE
geos: update url and regex

### DIFF
--- a/Livecheckables/geos.rb
+++ b/Livecheckables/geos.rb
@@ -1,4 +1,4 @@
 class Geos
-  livecheck :url   => "https://trac.osgeo.org/geos",
-            :regex => %r{href="http://download.osgeo.org/geos/geos-(\d+.\d+.\d+).tar.bz2"}
+  livecheck :url   => "https://download.osgeo.org/geos/",
+            :regex => /href=.+geos-v?(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
This updates the existing livecheckable for `geos` to use the index page where the stable archive used in the formula is hosted. This also updates the regex to avoid matching against the full URL for archive files,  use the standard regex, loosen the extension matching (looking for `.t` instead of `.tar.bz2` specifically), and properly escape periods.