### PR TITLE
libxml++: add livecheckable

### DIFF
--- a/Livecheckables/libxml++.rb
+++ b/Livecheckables/libxml++.rb
@@ -1,0 +1,3 @@
+class Libxmlxx
+  livecheck :regex => /libxml\+\+-(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/
+end


### PR DESCRIPTION
The version-filtering feature (#536) is shelved for the moment, so we'll have to restrict matching for major/minor versions using the regex.

The regex used here is the one that was already being used for the formula in the GNOME strategy, with the simple modification of restricting the first digit of the version to `2`. The `libxml++` formula name doesn't give any indication but it should only use versions with a major version of 2. The version 3 series is handled by the `libxml++3` formula, as is common with GNOME formulae.

Closes #537.