### PR TITLE
mafft: update regex

### DIFF
--- a/Livecheckables/mafft.rb
+++ b/Livecheckables/mafft.rb
@@ -1,4 +1,6 @@
 class Mafft
+  # The regex below is intended to avoid releases with trailing "Experimental"
+  # text after the link for the archive.
   livecheck :url   => "https://mafft.cbrc.jp/alignment/software/source.html",
-            :regex => /mafft-([0-9\.]+)-/
+            :regex => %r{href=.+?mafft-v?(\d+(?:\.\d+)+)-with-extensions-src\.t.+?\</a\>\s*?\<(?:br[^>]*?|/li|/ul)\>}i
 end


### PR DESCRIPTION
As discussed in #558, the existing livecheckable for `mafft` is also picking up releases that are listed as "Experimental" on the upstream [Source](https://mafft.cbrc.jp/alignment/software/source.html) page. This updates the regex to painstakingly avoid matching the experimental releases.

I tried to write the regex as loosely as possible (such that it will accommodate some minor changes) but any notable changes to how the page lists experimental versions can potentially break this. Unfortunately, it doesn't seem like there's a better way of dealing with this issue at the moment.

Closes #558.