### PR TITLE
sonarqube-lts: add livecheckable

### DIFF
--- a/Livecheckables/sonarqube-lts.rb
+++ b/Livecheckables/sonarqube-lts.rb
@@ -1,0 +1,7 @@
+class SonarqubeLts
+  # The regex below should only match the LTS release archive on the Sonarqube
+  # downloads page. This is necessary because the usual index page for releases
+  # doesn't distinguish between current and LTS releases.
+  livecheck :url   => "https://www.sonarqube.org/downloads/",
+            :regex => /downloads-lts.+?href=.+?sonarqube-v?(\d+(?:\.\d+)+)\.(?:z|t)/m
+end


### PR DESCRIPTION
As discussed in #560, the `sonarqube` [index page for archives](https://binaries.sonarsource.com/Distribution/sonarqube/) doesn't distinguish between current and LTS releases. Instead, we have to check the [Sonarqube downloads page](https://www.sonarqube.org/downloads/) and use a complicated regex to only match the LTS release archive.

I've tried to make the regex only as specific as it needs to be to match, in hopes that it doesn't break easily in the future. However, any notable changes to how the upstream downloads page formats this information will break this check. Unfortunately, there doesn't seem to be an easy way to deal with this. If anyone finds a better way of handling this, feel free to create a PR to update this livecheckable.

Closes #560.