### PR TITLE
mpw: update regex

### DIFF
--- a/Livecheckables/mpw.rb
+++ b/Livecheckables/mpw.rb
@@ -1,4 +1,4 @@
 class Mpw
   livecheck :url   => "https://gitlab.com/MasterPassword/MasterPassword.git",
-            :regex => /^v?(\d+(?:\.\d+)+(?:.?cli.?\d+))$/
+            :regex => /^v?(\d+(?:\.\d+)+.?cli.?\d+)$/
 end


### PR DESCRIPTION
In my review of #591, I was busy explaining that we didn't need the `-cli1`/`-cli-1` group to repeat and I forgot to explain that we didn't need to group this part at all as a result.

The livecheckable is functionally identical before/after this change and I've just modified the regex to remove the parentheses here for the sake of simplification.