### PR TITLE
vim: add livecheckable

### DIFF
--- a/Livecheckables/vim.rb
+++ b/Livecheckables/vim.rb
@@ -1,0 +1,4 @@
+class Vim
+  livecheck :url   => "https://github.com/vim/vim.git",
+            :regex => /^v?(\d+(?:\.\d+)+\d{2}(?<=00|50))$/
+end


### PR DESCRIPTION
As stated in the [Formula for vim](https://github.com/Homebrew/homebrew-core/blob/master/Formula/vim.rb):
```
# vim should only be updated every 50 releases on multiples of 50
```

This `Livecheckables` file will only output those `version`'s whose last two digits are either `00` or `50`, which I confirmed using the `--debug` flag.

Output before:
```
-bash-5.0.17- /Users/miccal (32) [> brew livecheck vim
vim : 8.2.0654 ==> 8.2.0695
```

Output after:
```
-bash-5.0.17- /Users/miccal (32) [> brew livecheck vim
vim : 8.2.0654 ==> 8.2.0650
```

Note that currently the Formula for `vim` is at `8.2.0654` because of a [problem with `8.2.0650`](https://github.com/Homebrew/homebrew-core/pull/53849), and I quote:

> Build is broken in 8.2.0650, fixed in 8.2.0654. Next bump should resume normal schedule with 8.2.0700.