### PR TITLE
clang-format: update url and regex

### DIFF
--- a/Livecheckables/clang-format.rb
+++ b/Livecheckables/clang-format.rb
@@ -1,4 +1,4 @@
 class ClangFormat
-  livecheck :url   => "https://llvm.org/svn/llvm-project/llvm/tags/google/stable/",
-            :regex => /(\d+-\d+-\d+)/
+  livecheck :url   => "https://github.com/llvm/llvm-project/releases/latest",
+            :regex => %r{href=.+?/tag/llvmorg-v?(\d+(?:\.\d+)+)}i
 end


### PR DESCRIPTION
The existing `clang-format` livecheckable is finding and returning versions that use a date, like YYYY-MM-DD. However, the `clang-format` formula has moved to using `llvm` archive files from GitHub, so the formula's version is like 10.0.0.

This updates the livecheckable to check the "latest" release page on GitHub and extract the version from the release's tag.