### PR TITLE
unbound: update url and regex

### DIFF
--- a/Livecheckables/unbound.rb
+++ b/Livecheckables/unbound.rb
@@ -1,4 +1,4 @@
 class Unbound
-  livecheck :url   => "https://www.unbound.net/downloads/",
-            :regex => /href="unbound-([0-9,\.]+)\.tar/
+  livecheck :url   => "https://nlnetlabs.nl/downloads/unbound/",
+            :regex => /href=.+?unbound-v?(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
The URL in the existing `unbound` livecheckable redirects to https://nlnetlabs.nl/downloads/unbound/, so this updates the URL to avoid the redirection. I've also updated the regex to bring it in line with more recent standards.