### PR TITLE
x264: add livecheckable

### DIFF
--- a/Livecheckables/x264.rb
+++ b/Livecheckables/x264.rb
@@ -1,0 +1,7 @@
+class X264
+  # There's no guarantee that the versions we find on the `release-macos` index
+  # page are stable but there didn't appear to be a different way of getting
+  # the version information at the time of writing.
+  livecheck :url   => "https://artifacts.videolan.org/x264/release-macos/",
+            :regex => /href=.+?x264-(r\d+)-/i
+end


### PR DESCRIPTION
The `x264` upstream Git repository doesn't tag releases and the only way I found to get version numbers like `r1234` is to check the [binaries index page](https://artifacts.videolan.org/x264/) for a given platform (even though we don't use the binaries in the formula). Sometimes one platform will have a binary for a newer version and a different platform won't yet have that version available (and it may never before the next release) but I had to pick some platform for the purposes of this check, so I went with macOS.

Another issue is that the binaries aren't always for stable versions (e.g., the binary might have been built on a commit that's not yet in the `stable` branch of the upstream repo), so livecheck may report a newer version that's not yet appropriate to use in the formula. However, I wasn't able to find an alternative way of identifying the latest version (let alone the latest _stable_ version), so I think we just have to live with this for the time being. The formula has a comment at the top of the `stable` block saying, `# the latest commit on the stable branch`, so anyone updating the formula will just have to make sure to identify the latest stable release, as always.

It's unfortunate that upstream doesn't tag stable releases in the Git repo (or any releases for that matter) but this _may_ be better than not being able to check for a new version at all.