### PR TITLE
transmission-cli: add livecheckable

### DIFF
--- a/Livecheckables/transmission-cli.rb
+++ b/Livecheckables/transmission-cli.rb
@@ -1,0 +1,4 @@
+class TransmissionCli
+  livecheck :url   => "https://github.com/transmission/transmission-releases/",
+            :regex => /href=.+transmission-v?(\d+(?:\.\d+)+)\.t/i
+end

--- a/Livecheckables/transmission-cli.rb
+++ b/Livecheckables/transmission-cli.rb
@@ -1,4 +1,4 @@
 class TransmissionCli
   livecheck :url   => "https://github.com/transmission/transmission-releases/",
-            :regex => /href=.+transmission-v?(\d+(?:\.\d+)+)\.t/i
+            :regex => /href=.+?transmission-v?(\d+(?:\.\d+)+)\.t/i
 end


### PR DESCRIPTION
Output before:
```
-bash-5.0.17- /Users/miccal (32) [> brew livecheck transmission-cli
Error: transmission-cli: Unable to get versions
```
Output after:
```
-bash-5.0.17- /Users/miccal (32) [> brew livecheck transmission-cli
transmission-cli : 2.94 ==> 2.94
```

The `url` at `https://github.com/transmission/transmission-releases/` simply lists several different releases and formats. Using `https://github.com/transmission/transmission-releases.git` did not seem to work.

There are some old ones with `Transmission` and newer ones with `transmission`, so to be safe I added the case-insensitive `i` flag.