### PR TITLE
Rename Formula#livecheckable to livecheckable?

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -96,7 +96,7 @@ module Homebrew
   end
 
   def print_latest_version(formula)
-    if formula.to_s.include?("@") && !formula.livecheckable
+    if formula.to_s.include?("@") && !formula.livecheckable?
       puts "#{Tty.red}#{formula_name(formula)}#{Tty.reset} : versioned" unless Homebrew.args.quiet?
       return
     end
@@ -147,11 +147,11 @@ module Homebrew
             "latest"                 => latest.to_s,
             "is_outdated"            => is_outdated,
             "is_newer_than_upstream" => is_newer_than_upstream,
-            "guessed"                => !formula.livecheckable,
+            "guessed"                => !formula.livecheckable?,
           },
         }
       else
-        formula_s += " (guessed)" unless formula.livecheckable
+        formula_s += " (guessed)" unless formula.livecheckable?
         current_s =
           if is_newer_than_upstream
             "#{Tty.red}#{current}#{Tty.reset}"

--- a/livecheck/extend/formula.rb
+++ b/livecheck/extend/formula.rb
@@ -9,8 +9,8 @@ class Formula
     self.class.livecheck_args
   end
 
-  def livecheckable
-    self.class.livecheckable
+  def livecheckable?
+    self.class.livecheckable == true
   end
 
   class << self


### PR DESCRIPTION
We're using a `#skip?` method to access the `@skip` instance variable boolean in the livecheck PR (Homebrew/brew#7179), so I wanted to similarly update the `Formula#livecheckable` method to `#livecheckable?`. This makes it clear that the variable is a boolean instead of, say, a hash/object containing the livecheckable information (e.g., url, regex, etc.). [Currently that information is in `Formula#livecheck_args` and will be accessible at `Formula#livecheck` in the future.]

I will be proposing `#livecheckable?` as an addition to the livecheck DSL's implementation, so this PR helps to keep Homebrew/homebrew-livecheck's `Formula` class extension closer to the Homebrew/brew implementation. Eventually the livecheck command will migrate to Homebrew/brew, so this is one small step towards making that process as simple as possible.