### PR TITLE
slashem: add livecheckable

### DIFF
--- a/Livecheckables/slashem.rb
+++ b/Livecheckables/slashem.rb
@@ -1,0 +1,3 @@
+class Slashem
+  livecheck :regex => %r{url=.+?/slashem-source/([^/]+)/[^\.]+\.t}
+end


### PR DESCRIPTION
This check for this formula doesn't return a proper version using the SourceForge strategy and this will continue to be the case after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.