### PR TITLE
gplcver: add livecheckable

### DIFF
--- a/Livecheckables/gplcver.rb
+++ b/Livecheckables/gplcver.rb
@@ -1,0 +1,5 @@
+class Gplcver
+  # This regex intentionally matches seemingly unstable versions, as the only
+  # available version at the time of writing was `2.12a`.
+  livecheck :regex => %r{url=.+?/gplcver-v?(\d+(?:\.\d+)+[a-z]?)\.src\.}i
+end


### PR DESCRIPTION
The check for this formula currently works fine using the SourceForge strategy. However, once the SourceForge strategy update in #539 is merged into master, the check for this formula will no longer correctly identify the latest version due to the default regex for the strategy not being sufficient in this particular case.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.