### PR TITLE
kettle: add livecheckable

### DIFF
--- a/Livecheckables/kettle.rb
+++ b/Livecheckables/kettle.rb
@@ -1,0 +1,3 @@
+class Kettle
+  livecheck :regex => %r{url=.+?/pdi-ce-v?(\d+(?:\.\d+)+(?:-\d+)?)\.(?:z|t)}
+end


### PR DESCRIPTION
The check for this formula doesn't return a proper version using the SourceForge strategy (giving `files` as the newest version. This will be fixed after the SourceForge strategy update in #539 is merged into master but this could use a livecheckable with a more specific regex to restrict matching a bit and potentially avoid issues in the future.