### PR TITLE
mhash: add livecheckable

### DIFF
--- a/Livecheckables/mhash.rb
+++ b/Livecheckables/mhash.rb
@@ -1,0 +1,3 @@
+class Mhash
+  livecheck :regex => %r{url=.+?/mhash-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
The check for this formula currently works fine using the SourceForge strategy. However, once the SourceForge strategy update in #539 is merged into master, the check for this formula will no longer correctly identify the latest version due to the default regex for the strategy not being sufficient in this particular case.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.