### PR TITLE
putmail-queue: add livecheckable

### DIFF
--- a/Livecheckables/putmail-queue.rb
+++ b/Livecheckables/putmail-queue.rb
@@ -1,0 +1,3 @@
+class PutmailQueue
+  livecheck :regex => %r{url=.+?/putmail-queue-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
The check for this formula doesn't return a proper version using the SourceForge strategy and this will continue to be the case after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.