### PR TITLE
qrupdate: add livecheckable

### DIFF
--- a/Livecheckables/qrupdate.rb
+++ b/Livecheckables/qrupdate.rb
@@ -1,0 +1,4 @@
+class Qrupdate
+  livecheck :url   => "https://sourceforge.net/projects/qrupdate/",
+            :regex => %r{url=.+?/qrupdate-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
The check for this formula doesn't work at all currently but it won't be fixed by the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.