### PR TITLE
synfig: add livecheckable

### DIFF
--- a/Livecheckables/synfig.rb
+++ b/Livecheckables/synfig.rb
@@ -1,0 +1,4 @@
+class Synfig
+  livecheck :url   => "https://sourceforge.net/projects/synfig/",
+            :regex => %r{url=.+?/synfig-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
The check for this formula is currently broken and it won't be fully fixed when the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.