### PR TITLE
wv2: add livecheckable

### DIFF
--- a/Livecheckables/wv2.rb
+++ b/Livecheckables/wv2.rb
@@ -1,0 +1,3 @@
+class Wv2
+  livecheck :regex => %r{url=.+?/wv2-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
The check for this formula doesn't return a proper version using the SourceForge strategy and this will continue to be the case after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.