### PR TITLE
chadwick: add livecheckable

### DIFF
--- a/Livecheckables/chadwick.rb
+++ b/Livecheckables/chadwick.rb
@@ -1,0 +1,3 @@
+class Chadwick
+  livecheck :regex => %r{url=.+?/chadwick-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
The check for this formula doesn't return a proper version using the SourceForge strategy and this will continue to be the case after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.