### PR TITLE
avfs: update url and regex

### DIFF
--- a/Livecheckables/avfs.rb
+++ b/Livecheckables/avfs.rb
@@ -1,4 +1,4 @@
 class Avfs
-  livecheck :url   => "https://sourceforge.net/projects/avf/",
-            :regex => /avfs-([0-9\.]+)\.t/
+  livecheck :url   => "https://sourceforge.net/projects/avf/rss",
+            :regex => %r{url=.+?/avfs-v?(\d+(?:\.\d+)+)\.t}
 end


### PR DESCRIPTION
The current livecheckable for `avfs` correctly identifies the latest version but it simply checks the `avfs` SourceForge project page, which may not include the information we need. This updates the livecheckable to use the SourceForge RSS feed (the heuristic doesn't seem to select the SourceForge strategy for any existing URLs, so we have to force it for now) and caters the regex to this context.