### PR TITLE
asymptote: add livecheckable

### DIFF
--- a/Livecheckables/asymptote.rb
+++ b/Livecheckables/asymptote.rb
@@ -1,0 +1,3 @@
+class Asymptote
+  livecheck :regex => %r{url=.+?/asymptote-v?(\d+(?:\.\d+)+)\.src\.t}
+end


### PR DESCRIPTION
The check for this formula doesn't return a proper version using the SourceForge strategy and this will continue to be the case (to a certain extent) after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.