### PR TITLE
dex2jar: add livecheckable

### DIFF
--- a/Livecheckables/dex2jar.rb
+++ b/Livecheckables/dex2jar.rb
@@ -1,0 +1,3 @@
+class Dex2jar
+  livecheck :regex => %r{url=.+?/dex2jar-v?(\d+(?:\.\d+)+)\.(?:t|z)}
+end


### PR DESCRIPTION
The check for this formula doesn't return a proper version using the SourceForge strategy and this will continue to be the case after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.