### PR TITLE
timidity: add livecheckable

### DIFF
--- a/Livecheckables/timidity.rb
+++ b/Livecheckables/timidity.rb
@@ -1,0 +1,3 @@
+class Timidity
+  livecheck :regex => %r{url=.+?/TiMidity%2B%2B-v?(\d+(?:\.\d+)+)\.t}i
+end


### PR DESCRIPTION
The check for this formula doesn't return a proper version using the SourceForge strategy and this will continue to be the case (to a certain extent) after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.
