### PR TITLE
naturaldocs: add livecheckable

### DIFF
--- a/Livecheckables/naturaldocs.rb
+++ b/Livecheckables/naturaldocs.rb
@@ -1,0 +1,3 @@
+class Naturaldocs
+  livecheck :regex => %r{url=.+?/Natural.?Docs.v?(\d+(?:\.\d+)+)\.(?:t|z)}i
+end


### PR DESCRIPTION
The check for this formula doesn't return a proper version using the SourceForge strategy and this will continue to be the case after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.