### PR TITLE
w3m: add livecheckable

### DIFF
--- a/Livecheckables/w3m.rb
+++ b/Livecheckables/w3m.rb
@@ -1,0 +1,4 @@
+class W3m
+  livecheck :url   => "https://sourceforge.net/projects/w3m/rss",
+            :regex => %r{url=.+?/w3m-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
The check for this formula currently defaults to the Git strategy but the tags contain more information than we need (`0.5.3+git20200502`) and the formula uses archive files from SourceForge anyway. This PR adds a livecheckable to check the SourceForge RSS feed and adds an appropriate regex, such that we get clean versions like `0.5.3` instead.

Related to #539 in a way.