### PR TITLE
zabbix: add url and update regex

### DIFF
--- a/Livecheckables/zabbix.rb
+++ b/Livecheckables/zabbix.rb
@@ -1,3 +1,9 @@
 class Zabbix
-  livecheck :regex => /url=.*?zabbix-(\d+(?:\.\d+)+)\.t/
+  # As of writing, the Zabbix SourceForge repository is missing the latest
+  # version (4.4.8), so we have to check for the newest version on the Zabbix
+  # CDN index page instead. Unfortunately, the versions are separated into
+  # folders for a given major/minor version, so this will quietly stop being
+  # a proper check sometime in the future and need to be updated.
+  livecheck :url   => "https://cdn.zabbix.com/zabbix/sources/stable/4.4/",
+            :regex => /href=.+?zabbix-(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
The existing livecheckable for `zabbix` was broken (`Error: zabbix: 404 Not Found`) but unfortunately the upstream Zabbix situation is a bit dodgy. The Zabbix SourceForge project doesn't have the latest version (4.4.8) and instead only goes up to 4.4.7.

The formula uses an archive file from the Zabbix CDN, so this PR updates the livecheckable to use an index page on the Zabbix CDN but the trouble is that the archive files are organized into folders based on the major/minor version (e.g., 4.4). As a result, this livecheckable will eventually quietly fail to give the newest version when there's a new major/minor version folder and will need to be updated to work again.

It's not a great solution but it seems to be the only available option at the moment due to the upstream situation.