### PR TITLE
dfu-programmer: add livecheckable

### DIFF
--- a/Livecheckables/dfu-programmer.rb
+++ b/Livecheckables/dfu-programmer.rb
@@ -1,0 +1,4 @@
+class DfuProgrammer
+  livecheck :url   => "https://sourceforge.net/projects/dfu-programmer/rss",
+            :regex => %r{url=.+?/dfu-programmer-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
The default check for the `dfu-programmer` formula uses the Git strategy but the latest version (0.7.2) isn't tagged there. The formula download the stable archive from the SourceForge project, so this adds a livecheckable to check the SourceForge RSS feed using an appropriate regex.