### PR TITLE
irrlicht: add livecheckable

### DIFF
--- a/Livecheckables/irrlicht.rb
+++ b/Livecheckables/irrlicht.rb
@@ -1,0 +1,4 @@
+class Irrlicht
+  livecheck :url   => "https://sourceforge.net/projects/irrlicht/rss",
+            :regex => %r{url=.+?/irrlicht-v?(\d+(?:\.\d+)+)\.(?:t|z)}
+end


### PR DESCRIPTION
The default check for the `irrlicht` formula doesn't work (`Error: irrlicht: undefined method `[]' for nil:NilClass`). The formula downloads the stable archive from the SourceForge project, so this adds a livecheckable to check the SourceForge RSS feed using an appropriate regex.