### PR TITLE
nload: add livecheckable

### DIFF
--- a/Livecheckables/nload.rb
+++ b/Livecheckables/nload.rb
@@ -1,0 +1,4 @@
+class Nload
+  livecheck :url   => "http://www.roland-riegel.de/nload/",
+            :regex => /href=.+?nload-v?(\d+(?:\.\d+)+)\.t/
+end


### PR DESCRIPTION
The default check for the `nload` formula doesn't work properly (`Error: nload : Unable to get versions`), so this adds a livecheckable with a url and regex to identify the newest version at the same place the stable archive comes from.