### PR TITLE
autopsy: add livecheckable

### DIFF
--- a/Livecheckables/autopsy.rb
+++ b/Livecheckables/autopsy.rb
@@ -1,0 +1,4 @@
+class Autopsy
+  livecheck :url   => "https://github.com/sleuthkit/autopsy/releases/latest",
+            :regex => %r{href=.+?/tag/autopsy-v?(\d+(?:\.\d+)+)}
+end


### PR DESCRIPTION
The [Autopsy website's downloads page](https://www.autopsy.com/download/) lists 4.15.0 as newest and the GitHub repo reports the same. The formula currently uses an old version from SourceForge but Autopsy moved to GitHub, so checking SourceForge isn't useful here.

This adds a livecheckable to check the "latest" release on GitHub and get the version from the tag URL.