### PR TITLE
saxon: add livecheckable

### DIFF
--- a/Livecheckables/saxon.rb
+++ b/Livecheckables/saxon.rb
@@ -1,0 +1,3 @@
+class Saxon
+  livecheck :regex => %r{url=.+?/SaxonHE(\d+(?:[-.]\d+)+)J?\.(?:t|z)}i
+end


### PR DESCRIPTION
The check for this formula doesn't return a proper version using the SourceForge strategy and this will continue to be the case (to a certain extent) after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.

In the future, this will benefit from an "alterations" feature, since the returned version uses hyphens instead of periods (e.g., `9-9-1-7` instead of `9.9.1.7`). However, these are identical from a version comparison standpoint, so it's fine for now.