### PR TITLE
little-cms: add livecheckable

### DIFF
--- a/Livecheckables/little-cms.rb
+++ b/Livecheckables/little-cms.rb
@@ -1,0 +1,3 @@
+class LittleCms
+  livecheck :regex => %r{url=.+?/lcms-v?(1(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
The `little-cms` formula is only for the version 1 series of releases, so this adds a livecheckable to restrict matching to versions with a major version of 1.