### PR TITLE
zint: add livecheckable

### DIFF
--- a/Livecheckables/zint.rb
+++ b/Livecheckables/zint.rb
@@ -1,0 +1,4 @@
+class Zint
+  livecheck :url   => "https://sourceforge.net/projects/zint/rss",
+            :regex => %r{url=.+?/zint-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
The default check for `zint` uses the Git strategy but the repo doesn't contain version tags, so it's not usable. This adds a livecheckable to check the SourceForge RSS feed (since that's where the formula's stable archive is hosted) and adds an appropriate regex.