### PR TITLE
libngspice: add livecheckable

### DIFF
--- a/Livecheckables/libngspice.rb
+++ b/Livecheckables/libngspice.rb
@@ -1,0 +1,4 @@
+class Libngspice
+  livecheck :url   => "https://sourceforge.net/projects/ngspice/rss",
+            :regex => %r{url=.+?/ngspice-v?(\d+(?:\.\d+)*)\.t}
+end


### PR DESCRIPTION
The default check for `libngspice` uses the Git repo but the repo contains tags like `32.2`, whereas the versions on SourceForge that we use are only like `32`. This adds a livecheckable to check for versions in the SourceForge RSS feed instead, so we get a proper version. [Just to be clear, this livecheckable is basically a duplicate of `ngspice`.]

Related to #539 in a way.