### PR TITLE
itpp: add livecheckable

### DIFF
--- a/Livecheckables/itpp.rb
+++ b/Livecheckables/itpp.rb
@@ -1,0 +1,4 @@
+class Itpp
+  livecheck :url   => "https://sourceforge.net/projects/itpp/rss",
+            :regex => %r{url=.+?/itpp-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
The default check for `itpp` uses the Git repo but it doesn't have a tag for the latest version. This adds a livecheckable to search for versions in the SourceForge project RSS feed instead, as the stable archive is hosted on SourceForge.

Related to #539 in a way.