### PR TITLE
anttweakbar: add livecheckable

### DIFF
--- a/Livecheckables/anttweakbar.rb
+++ b/Livecheckables/anttweakbar.rb
@@ -1,0 +1,3 @@
+class Anttweakbar
+  livecheck :regex => %r{url=.+?/AntTweakBar.v?(\d+(?:\.\d+)*)\.(?:t|z)}i
+end


### PR DESCRIPTION
The check for this formula doesn't return a proper version using the SourceForge strategy and this will continue to be the case after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.

The caveat here is that the version in the formula is like "1.16" but the version we get from the file name is like "116". Unfortunately we can't address this issue until the forthcoming "alterations" feature is added.