### PR TITLE
aacgain: update regex

### DIFF
--- a/Livecheckables/aacgain.rb
+++ b/Livecheckables/aacgain.rb
@@ -1,4 +1,4 @@
 class Aacgain
   livecheck :url   => "https://aacgain.altosdesign.com/alvarez/",
-            :regex => /aacgain-(\d+(?:\.\d+)+)\.tar/
+            :regex => /href=.+?aacgain-(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
We're looking for a few livecheckables to migrate for testing purposes in Homebrew/homebrew-core#54565 and `aacgain` was the next livecheckable in line after `a52dec` alphabetically.

This PR simply updates the regex in the existing livecheckable for `aacgain`, to bring it up to current standards before it can be migrated as a test case.