### PR TITLE
ant: update url and regex

### DIFF
--- a/Livecheckables/ant.rb
+++ b/Livecheckables/ant.rb
@@ -1,3 +1,4 @@
 class Ant
-  livecheck :url => "https://www.apache.org/dist/ant/", :regex => /RELEASE\-NOTES\-(.*?)\.html/
+  livecheck :url   => "https://downloads.apache.org/ant/binaries/",
+            :regex => /href=.+?apache-ant-v?(\d+(?:\.\d+)+)(?:-bin)?\.t/
 end


### PR DESCRIPTION
The existing `ant` livecheckable needed to be updated to split the `:url` and `:regex` onto separate lines (for later migration purposes) but I also reworked it in the process. The existing livecheckable looked for release note files, whereas it's more appropriate to get the versions from the same binaries that the formula uses. This updates the URL and regex accordingly.