### PR TITLE
ant@1.9: update url and regex

### DIFF
--- a/Livecheckables/ant@1.9.rb
+++ b/Livecheckables/ant@1.9.rb
@@ -1,3 +1,4 @@
 class AntAT19
-  livecheck :url => "https://www.apache.org/dist/ant/", :regex => /RELEASE\-NOTES\-(1\.9.*?)\.html/
+  livecheck :url   => "https://downloads.apache.org/ant/binaries/",
+            :regex => /href=.+?apache-ant-v?(1\.9(?:\.\d+)*)(?:-bin)?\.t/
 end


### PR DESCRIPTION
LIke #696, the existing `ant@1.9` livecheckable needed to be updated to split the `:url` and `:regex` onto separate lines (for later migration purposes) but I also reworked it in the process. The existing livecheckable looked for release note files, whereas it's perhaps more appropriate to get the versions from the same binaries that the formula uses. This updates the URL and regex accordingly.