### PR TITLE
armadillo: remove url and update regex

### DIFF
--- a/Livecheckables/armadillo.rb
+++ b/Livecheckables/armadillo.rb
@@ -1,4 +1,3 @@
 class Armadillo
-  livecheck :url   => "http://bit.ly/2kLBPoS", # http://arma.sourceforge.net/download.html
-            :regex => /armadillo-(\d+.\d+.\d+).tar.xz/m
+  livecheck :regex => %r{url=.+?/armadillo-v?(\d+(?:\.\d+)+)\.t}
 end


### PR DESCRIPTION
The existing livecheckable for `armadillo` needed to be updated to ease future migration (i.e., moving the comment onto a separate line) and I simply reworked it in the process. This removes the PR, allowing the heuristic to use the SourceForge strategy, and adds an appropriate regex to match versions in the project's SourceForge RSS feed.