### PR TITLE
pijul: remove livecheckable

### DIFF
--- a/Livecheckables/pijul.rb
+++ b/Livecheckables/pijul.rb
@@ -1,4 +1,0 @@
-class Pijul
-  livecheck :url   => "https://pijul.org/downloads/",
-            :regex => /pijul-([0-9\.]+)\./
-end


### PR DESCRIPTION
The `pijul` formula was removed in Homebrew/homebrew-core#52730 and we'll need to remove the livecheckable here, so that it doesn't pose a problem for the migration from livecheckables to `livecheck` blocks in formulae.