### PR TITLE
szip: add livecheckable

### DIFF
--- a/Livecheckables/szip.rb
+++ b/Livecheckables/szip.rb
@@ -1,0 +1,4 @@
+class Szip
+  livecheck :url   => "https://support.hdfgroup.org/ftp/lib-external/szip/",
+            :regex => %r{href=.+?v?(\d+(?:\.\d+)+)/?["']}
+end


### PR DESCRIPTION
Livecheck isn't able to find the newest release for `szip` by default (`Error: szip: Unable to get versions`). The upstream archive files are currently placed into folders based on the version (e.g., `2.1.1`) and this PR adds a livecheckable to get versions from the same place as the stable archive in the formula.

If this breaks in the future, it's also possible to get the latest version from the `szip` website like:

```ruby
class Szip
  livecheck :url   => "https://support.hdfgroup.org/doc_resource/SZIP/",
            :regex => /href=.+?szip-v?(\d+(?:\.\d+)+)\.t/
end
```