### PR TITLE
docker-swarm: remove url and update regex

### DIFF
--- a/Livecheckables/docker-swarm.rb
+++ b/Livecheckables/docker-swarm.rb
@@ -1,4 +1,3 @@
 class DockerSwarm
-  livecheck :url   => "https://github.com/docker/swarm/releases",
-            :regex => %r{href="/docker/swarm/tree/v?([0-9\.]+)"}
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `docker-swarm` doesn't work currently, since the repository name changed from `swarm` to `classicswarm` and the regex is explicit about the account and repo names when trying to find tag names in `href` attributes. Livecheck just checks the repo's Git tags by default, so this removes the URL to allow for that and updates the regex accordingly.

For anyone reading, this is a good example of why we try to only be as specific as necessary with a regex to match what we want. Unnecessary specificity, like the leading account/repo part of the URL here, can cause livecheckables to break when changes like this happen. Sometimes breaking is appropriate and other times it's unnecessary and just leads to more maintenance for us. There's a balance to be found between being too strict (and breaking more easily) and too loose (matching more than we intend).