### PR TITLE
qscintilla2: update regex

### DIFF
--- a/Livecheckables/qscintilla2.rb
+++ b/Livecheckables/qscintilla2.rb
@@ -1,4 +1,4 @@
 class Qscintilla2
   livecheck :url   => "https://www.riverbankcomputing.com/software/qscintilla/download",
-            :regex => /href="[^"]*?QScintilla[^"]*?(\d+(?:\.\d+)+)\.t/i
+            :regex => /href=.*?QScintilla(?:.gpl)?-(\d+(?:\.\d+)+)\.t/i
 end


### PR DESCRIPTION
The livecheckable for `qscintilla2` assumed `href` values would be in double quotes but the [QScintilla2 download page](https://www.riverbankcomputing.com/software/qscintilla/download) isn't using quotes around the value at all, so the regex isn't matching anymore. This assumption was valid at the time the livecheckable was created but isn't anymore, sadly.

This updates the regex to avoid the assumption that there will be any quotes around the attribute at all. The vast majority of sites rightly use double quotes around attributes and every now and again you get single quotes but no quotes is beyond the pale, ahah.