### PR TITLE
rsyslog: update url and regex

### DIFF
--- a/Livecheckables/rsyslog.rb
+++ b/Livecheckables/rsyslog.rb
@@ -1,4 +1,4 @@
 class Rsyslog
   livecheck :url   => "https://www.rsyslog.com/",
-            :regex => /Current Version.*?>([0-9\.]+)</
+            :regex => /Current Version.+?v?(\d+(?:\.\d+)+)/m
 end


### PR DESCRIPTION
The `rsyslog` homepage must have changed a bit, as the assumptions included in this livecheckable's regex don't seem to be true anymore. The check is currently broken (`Error: rsyslog: Unable to get versions`), so this PR updates the regex to work with the current situation. It's looser than I would like but works for now.

One alternative is matching versions on the [stable download page](https://www.rsyslog.com/downloads/download-v8-stable/) but the URL path contains the major version (i.e., `.../download-v8-stable/`), so we would need to manually update the URL in the future if there's a major release. This isn't appealing, so we'll just have to live with this regex for now.