### PR TITLE
oniguruma: update regex

### DIFF
--- a/Livecheckables/oniguruma.rb
+++ b/Livecheckables/oniguruma.rb
@@ -1,4 +1,4 @@
 class Oniguruma
   livecheck :url   => "https://github.com/kkos/oniguruma.git",
-            :regex => /^v?(\d+(?:\.\d+)+)$/
+            :regex => /^v?(\d+(?:\.\d+)+(?:.(?:mark|rev)\d+)?)$/i
 end


### PR DESCRIPTION
The latest version of `oniguruma` in the formula (as of writing) is `6.9.5-rev1` but the standard regex we're using in the livecheckable only matches versions like `1.2.3` or `v1.2.3` (with nothing behind it). The intention is to avoid matching prerelease versions, like `v6.9.5_rc1` in this repository.

This is the first `rev#` release but there was a `mark1` release for 6.9.4 before, which seems like a similar revision-after-release kind of deal. This appears to be becoming a regular occurrence, so this PR updates the regex to also match versions with trailing `mark#` or `rev#` extensions.