### PR TITLE
libgit2: update url and regex

### DIFF
--- a/Livecheckables/libgit2.rb
+++ b/Livecheckables/libgit2.rb
@@ -1,4 +1,4 @@
 class Libgit2
-  livecheck :url   => "https://github.com/libgit2/libgit2/releases",
-            :regex => %r{href="/libgit2/libgit2/tree/v?(0\.2[789]\.[0-9\.]+)}
+  livecheck :url   => "https://github.com/libgit2/libgit2/releases/latest",
+            :regex => %r{href=.+?/tag/v?(\d+(?:\.\d+)+)}
 end


### PR DESCRIPTION
The existing livecheckable for `libgit2` restricts matching to a version with a major of 0 and minor of 27-29, so livecheck reported the latest version to be 0.28.5 instead of 1.0.0.

The formula is currently using the 1.0.0 release, so this reworks the livecheckable to check the "latest" release on GitHub (updating the regex accordingly).