### PR TITLE
libtorrent-rasterbar: remove url and update regex

### DIFF
--- a/Livecheckables/libtorrent-rasterbar.rb
+++ b/Livecheckables/libtorrent-rasterbar.rb
@@ -1,4 +1,3 @@
 class LibtorrentRasterbar
-  livecheck :url   => "https://libtorrent.org/",
-            :regex => %r{<tr><th class="docinfo-name">Version:</th>\n<td>([0-9\.]+)</td></tr>}
+  livecheck :regex => /^libtorrent.v?(\d+(?:[-_.]\d+)+)$/i
 end


### PR DESCRIPTION
The existing livecheckable for `libtorrent-rasterbar` checks the `libtorrent` homepage for the latest version but currently this page is outdated with respect to the latest version (displaying 1.2.5 instead of 1.2.6).

The formula uses a release from GitHub, so this removes the URL (allowing the heuristic to default to checking the Git tags) and updates the regex accordingly (using a modification of the "standard" regex for matching versions in Git tags). The only caveat is that the matched versions in tags are like `1_2_6` instead of `1.2.6`. These two are the same from the standpoint of version comparison but I'll come back and address this cosmetic issue in the future if/when I implement an "alterations" feature.