### PR TITLE
rebar3: remove url and update regex

### DIFF
--- a/Livecheckables/rebar3.rb
+++ b/Livecheckables/rebar3.rb
@@ -1,4 +1,3 @@
 class Rebar3
-  livecheck :url   => "https://www.rebar3.org/",
-            :regex => %r{rebar3">Download \(v([0-9,\.]+)\)</a>}
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `rebar3` checks rebar3.org for the latest version but currently this page is outdated with respect to the latest version (displaying 3.13.1 instead of 3.13.2).

The formula uses a release from GitHub, so this removes the URL (allowing the heuristic to default to checking the Git tags) and updates the regex accordingly (using the "standard" regex for matching versions in Git tags).