### PR TITLE
softhsm: update url and regex

### DIFF
--- a/Livecheckables/softhsm.rb
+++ b/Livecheckables/softhsm.rb
@@ -1,4 +1,4 @@
 class Softhsm
-  livecheck :url   => "https://www.opendnssec.org/download/",
-            :regex => %r{href=".*?/softhsm-([0-9\.]+)\.t}
+  livecheck :url   => "https://dist.opendnssec.org/source/",
+            :regex => /href=.+?softhsm-v?(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
The existing livecheckable for `softhsm` checks the [OpenDNSSEC download page](https://www.opendnssec.org/download/) but unfortunately the latest version available there is 2.5.0 (instead of 2.6.1). The formula uses an archive at https://dist.opendnssec.org/source/, so this PR updates the URL to this index page and improves the regex in the process.