### PR TITLE
sdedit: add livecheckable

### DIFF
--- a/Livecheckables/sdedit.rb
+++ b/Livecheckables/sdedit.rb
@@ -1,0 +1,3 @@
+class Sdedit
+  livecheck :regex => %r{url=.+?/sdedit-v?(\d+(?:\.\d+)+)\.jar}
+end


### PR DESCRIPTION
The check for this formula doesn't return the correct latest version using the SourceForge strategy and this will continue to be the case after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.