### PR TITLE
simutrans: add livecheckable

### DIFF
--- a/Livecheckables/simutrans.rb
+++ b/Livecheckables/simutrans.rb
@@ -1,0 +1,4 @@
+class Simutrans
+  livecheck :url   => "https://sourceforge.net/projects/simutrans/rss",
+            :regex => %r{url=.+?/simutrans-src-v?(\d+(?:[-_.]\d+)+)\.(?:t|z)}
+end


### PR DESCRIPTION
The default check for `simutrans` uses the Git strategy but the repo doesn't contain tags for the latest versions. This adds a livecheckable to check the SourceForge RSS feed (since that's where the formula's stable archive is hosted) and adds an appropriate regex.

Related to #539 in a way.