### PR TITLE
rtf2latex2e: add livecheckable

### DIFF
--- a/Livecheckables/rtf2latex2e.rb
+++ b/Livecheckables/rtf2latex2e.rb
@@ -1,0 +1,3 @@
+class Rtf2latex2e
+  livecheck :regex => %r{url=.+?/rtf2latex2e-v?(\d+(?:[-_.]\d+)+)\.t}
+end


### PR DESCRIPTION
The check for this formula doesn't return the correct latest version using the SourceForge strategy and this will continue to be the case after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.

As an aside, the returned version from this check contains hyphens in the version instead of dots (e.g., `2-2-3` vs. `2.2.3`). This is fine from the perspective of version comparison but we can tidy this up in the future with an "alterations" feature.