### PR TITLE
ttf2pt1: add livecheckable

### DIFF
--- a/Livecheckables/ttf2pt1.rb
+++ b/Livecheckables/ttf2pt1.rb
@@ -1,0 +1,4 @@
+class Ttf2pt1
+  livecheck :url   => "https://sourceforge.net/projects/ttf2pt1/rss",
+            :regex => %r{url=.+?/ttf2pt1-v?(\d+(?:\.\d+)+)\.t}
+end


### PR DESCRIPTION
The check for this formula doesn't return a proper version using the SourceForge strategy and this will continue to be the case (to a certain extent) after the SourceForge strategy update in #539 is merged into master.

This PR adds a livecheckable with a regex that will properly identify versions in the SourceForge project's RSS feed. This ensures the check for the formula will work properly both before and after the forthcoming SourceForge strategy update.