### PR TITLE
chordii: remove url and update regex

### DIFF
--- a/Livecheckables/chordii.rb
+++ b/Livecheckables/chordii.rb
@@ -1,4 +1,3 @@
 class Chordii
-  livecheck :url   => "https://sourceforge.net/projects/chordii/files/chordii/4.5/",
-            :regex => %r{files/chordii/4.5/chordii-(4\.5[0-9\.]+)\.}
+  livecheck :regex => %r{url=.+?/chordii-v?(\d+(?:\.\d+)+[a-z]?)\.t}
 end


### PR DESCRIPTION
The latest version in the `chordii` formula was `4.5.3b` but the existing livecheckable didn't match beta(?) versions, so the main change here is to update the regex to allow for this (while also improving it in general).

The restriction to the 4.5 series of releases may not be absolutely necessary at this point (the file names for the 5.0 releases aren't matched by this regex), so I've removed it for now. We can revisit it in the future if it becomes a problem.