### PR TITLE
mpg123: update url and regex

### DIFF
--- a/Livecheckables/mpg123.rb
+++ b/Livecheckables/mpg123.rb
@@ -1,4 +1,4 @@
 class Mpg123
-  livecheck :url   => "https://www.mpg123.de/download/",
-            :regex => /href="mpg123-([0-9,\.]+)\.tar/
+  livecheck :url   => "https://sourceforge.net/projects/mpg123/rss",
+            :regex => %r{url=.+?/mpg123-v?(\d+(?:\.\d+)+)\.t}
 end


### PR DESCRIPTION
The existing livecheckable for `mpg123` was checking the first-party download page but this was timing out in testing. This PR updates the URL to one that will use the SourceForge strategy (as the stable archive is downloaded from SourceForge) and updates the regex accordingly.