### PR TITLE
qmmp: update url and regex

### DIFF
--- a/Livecheckables/qmmp.rb
+++ b/Livecheckables/qmmp.rb
@@ -1,4 +1,4 @@
 class Qmmp
-  livecheck :url   => "https://qmmp.ylsoftware.com/downloads.php",
-            :regex => /href=".*?qmmp-([0-9\.]+)\.t/
+  livecheck :url   => "https://sourceforge.net/projects/qmmp-dev/rss",
+            :regex => %r{url=.+?/qmmp-v?(\d+(?:\.\d+)+)\.t}
 end


### PR DESCRIPTION
The existing livecheckable for `qmmp` was checking the first-party downloads page but this was timing out locally. This PR updates the URL to one that will use the SourceForge strategy (as the stable archive is downloaded from SourceForge) and updates the regex accordingly.

Related to #539 in a way.