### PR TITLE
jnethack: add livecheckable

### DIFF
--- a/Livecheckables/jnethack.rb
+++ b/Livecheckables/jnethack.rb
@@ -1,0 +1,4 @@
+class Jnethack
+  livecheck :url   => "https://osdn.net/projects/jnethack/releases/rss",
+            :regex => %r{url=.+?/jnethack-v?(\d+(?:\.\d+)+(?:-\d+(?:\.\d+)+)?)\.}
+end


### PR DESCRIPTION
The default check for `jnethack` was checking SourceForge, which doesn't contain the latest version. The [homepage](https://jnethack.osdn.jp/) points to releases on OSDN, which contains some newer versions that SourceForge doesn't have (e.g., `3.6.6-0.1`). This adds a livecheckable to check OSDN releases, so we properly find the latest versions.

Related to #539 in a way.