### PR TITLE
aacgain, imap-uw: remove livecheckable

### DIFF
--- a/Livecheckables/aacgain.rb
+++ b/Livecheckables/aacgain.rb
@@ -1,4 +1,0 @@
-class Aacgain
-  livecheck :url   => "https://aacgain.altosdesign.com/alvarez/",
-            :regex => /href=.+?aacgain-(\d+(?:\.\d+)+)\.t/
-end

--- a/Livecheckables/imap-uw.rb
+++ b/Livecheckables/imap-uw.rb
@@ -1,3 +1,0 @@
-class ImapUw
-  livecheck :skip => "Not maintained"
-end


### PR DESCRIPTION
The `aacgain` and `imap-uw` livecheckables were migrated to `livecheck` blocks in their respective formulae (Homebrew/homebrew-core#54595, Homebrew/homebrew-core#54597), as initial tests before a wide-scale migration of livecheckables. Now that `brew livecheck` supports the new livecheck DSL (#555), we can safely remove these livecheckables.