### PR TITLE
bigloo: update livecheckable

### DIFF
--- a/Livecheckables/bigloo.rb
+++ b/Livecheckables/bigloo.rb
@@ -1,4 +1,4 @@
 class Bigloo
   livecheck :url   => "https://www-sop.inria.fr/indes/fp/Bigloo/",
-            :regex => /Current version is .*>([0-9a-z\.]+)</
+            :regex => />\s*?version v?(\d+(?:\.\d+)+[a-z]?)\s*?</i
 end


### PR DESCRIPTION
The `bigloo` homepage has evidently changed since the existing livecheckable was created, so the check is currently failing (`Error: bigloo: Unable to get versions`).

This updates the livecheckable's regex to identify the latest version but this too could break in the future if the page's HTML significantly changes. Unfortunately, I don't think there's a better way to handle this check, since this is the only place where the latest version is posted and their archives are fetched over FTP.