### PR TITLE
jrtplib: skip

### DIFF
--- a/Livecheckables/jrtplib.rb
+++ b/Livecheckables/jrtplib.rb
@@ -1,4 +1,3 @@
 class Jrtplib
-  livecheck :url   => "https://research.edm.uhasselt.be/jori/page/CS/Jrtplib.html",
-            :regex => /latest version of the library is ([0-9\.]+) /
+  livecheck :skip => "No longer developed"
 end


### PR DESCRIPTION
The existing livecheckable for `jrtplib ` is broken, now that the [JRTPLIB page](https://research.edm.uhasselt.be/jori/page/CS/Jrtplib.html) has been replaced with a notice that the library is no longer being developed. The longer explanation can be found on [the project's GitHub repo](https://github.com/j0r1/JRTPLIB), which makes it clear that development has ended.

We can still technically check the GitHub repo releases but it seems like a waste of effort since the developer has publicly stated that development has ended. Skipping the check for the foreseeable future seems fine to me, as we would have to update the livecheckable if the repo is handed off to someone else anyway.