### PR TITLE
libplctag: remove url and update regex

### DIFF
--- a/Livecheckables/libplctag.rb
+++ b/Livecheckables/libplctag.rb
@@ -1,4 +1,3 @@
 class Libplctag
-  livecheck :url   => "https://github.com/kyle-github/libplctag/releases",
-            :regex => %r{latest.*?href="/kyle-github/libplctag/tree/v?([0-9\.]+)}m
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `libplctag` used an overly-specific regex that failed to match once the `libplctag` repo moved from `kyle-github/libplctag` to `libplctag/libplctag` (`Error: libplctag: Unable to get versions`).

This removes the URL, allowing the heuristic to simply check the Git repo tags, and updates the regex to the standard one we use for matching Git tags like `1.2.3` or `v1.2.3`.