### PR TITLE
minidjvu: update url and regex

### DIFF
--- a/Livecheckables/minidjvu.rb
+++ b/Livecheckables/minidjvu.rb
@@ -1,4 +1,4 @@
 class Minidjvu
-  livecheck :url   => "http://minidjvu.sourceforge.net",
-            :regex => /href=.+?minidjvu-v?(\d+(?:\.\d+)+)\.t/
+  livecheck :url   => "https://sourceforge.net/projects/minidjvu/",
+            :regex => %r{url=.+?/minidjvu-v?((?!0\.33)\d+(?:\.\d+)+)\.t}
 end


### PR DESCRIPTION
Despite my efforts, the existing livecheckable for `minidjvu` broke when the SourceForge strategy update PR was merged (```Error: minidjvu: undefined method `[]' for nil:NilClass```).

The reason why this livecheckable checked the `minidjvu` homepage instead of the RSS feed was because there's a `0.33` version on SourceForge that livecheck will treat as newest until/unless a 1.0+ or 0.34+ version is released.

This updates the URL to one that will use the SourceForge strategy and updates the regex to specifically avoid matching the old `0.33` version (which isn't newer than the current `0.8` version).