### PR TITLE
theora: add url and update regex

### DIFF
--- a/Livecheckables/theora.rb
+++ b/Livecheckables/theora.rb
@@ -1,3 +1,4 @@
 class Theora
-  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
+  livecheck :url   => "https://www.theora.org/downloads/",
+            :regex => /href=.+?libtheora-v?(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
The existing livecheckable for `theora` checked the Git tags (by default) but unfortunately https://git.xiph.org has been unresponsive for quite some time, so all of the checks for related formulae are failing:

```
fatal: unable to access 'https://git.xiph.org/theora.git/': Failed to connect to git.xiph.org port 443: Operation timed out
Error: theora: Unable to get versions
```

This updates the existing livecheckable to check the [`theora` downloads page](https://www.theora.org/downloads/) instead and modifies the regex accordingly.