### PR TITLE
getdns: update url and regex

### DIFF
--- a/Livecheckables/getdns.rb
+++ b/Livecheckables/getdns.rb
@@ -1,4 +1,7 @@
 class Getdns
-  livecheck :url   => "https://getdnsapi.net/releases/",
-            :regex => /getdns-([0-9\.]+) release/
+  # We check the GitHub releases instead of https://getdnsapi.net/releases/,
+  # since the aforementioned first-party URL has a tendency to lead to an
+  # `execution expired` error.
+  livecheck :url   => "https://github.com/getdnsapi/getdns/releases/latest",
+            :regex => %r{href=.+?/tag/v?(\d+(?:\.\d+)+)["']}
 end


### PR DESCRIPTION
The existing livecheckable for `getdns` uses the [first-party releases page](https://getdnsapi.net/releases/), which is where the stable archive in the formula comes from. However, this page can sometimes take a long time to respond and often leads to an `execution expired` error in livecheck.

This updates the URL to check the "latest" release on GitHub instead (updating the regex accordingly), which is more reliable and will avoid this error.