### PR TITLE
nsd: update url and regex

### DIFF
--- a/Livecheckables/nsd.rb
+++ b/Livecheckables/nsd.rb
@@ -1,4 +1,4 @@
 class Nsd
-  livecheck :url   => "https://www.nlnetlabs.nl/projects/nsd/",
-            :regex => %r{Most Recent Version.*?href=".*?/nsd-([0-9\.]+)\.t}m
+  livecheck :url   => "https://github.com/NLnetLabs/nsd.git",
+            :regex => /^NSD.v?(\d+(?:[-_.]\d+)+).REL$/i
 end


### PR DESCRIPTION
The existing livecheckable for `nsd` uses the [first-party project page](https://www.nlnetlabs.nl/projects/nsd/), which is close to where the stable archive in the formula comes from. However, this site can sometimes take a long time to respond and often leads to an `execution expired` error in livecheck.

This updates the URL to check the Git tags instead (updating the regex accordingly), which is more reliable and will avoid this error.