### PR TITLE
softhsm: update url and regex

### DIFF
--- a/Livecheckables/softhsm.rb
+++ b/Livecheckables/softhsm.rb
@@ -1,4 +1,7 @@
 class Softhsm
-  livecheck :url   => "https://dist.opendnssec.org/source/",
-            :regex => /href=.+?softhsm-v?(\d+(?:\.\d+)+)\.t/
+  # We check the GitHub repo tags instead of https://dist.opendnssec.org/source/
+  # since the aforementioned first-party URL has a tendency to lead to an
+  # `execution expired` error.
+  livecheck :url   => "https://github.com/opendnssec/SoftHSMv2.git",
+            :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `softhsm` uses the [first-party source archive index](https://dist.opendnssec.org/source/), which is where the stable archive in the formula comes from. However, this site can sometimes take a long time to respond and lead to an `execution expired` error in livecheck.

This updates the URL to check the Git tags instead (updating the regex accordingly), which is more reliable and will avoid this error.