### PR TITLE
unbound: update url and regex

### DIFF
--- a/Livecheckables/unbound.rb
+++ b/Livecheckables/unbound.rb
@@ -1,4 +1,7 @@
 class Unbound
-  livecheck :url   => "https://nlnetlabs.nl/downloads/unbound/",
-            :regex => /href=.+?unbound-v?(\d+(?:\.\d+)+)\.t/
+  # We check the GitHub repo tags instead of
+  # https://nlnetlabs.nl/downloads/unbound/ since the first-party site has a
+  # tendency to lead to an `execution expired` error.
+  livecheck :url   => "https://github.com/NLnetLabs/unbound.git",
+            :regex => /^(?:release-)?v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `softhsm` uses the [first-party downloads page](https://nlnetlabs.nl/downloads/unbound/), which is where the stable archive in the formula comes from. However, this site can sometimes take a long time to respond and lead to an `execution expired` error in livecheck.

This updates the URL to check the Git tags instead (updating the regex accordingly), which is more reliable and will avoid this error.