### PR TITLE
zabbix: update url

### DIFF
--- a/Livecheckables/zabbix.rb
+++ b/Livecheckables/zabbix.rb
@@ -4,6 +4,6 @@ class Zabbix
   # CDN index page instead. Unfortunately, the versions are separated into
   # folders for a given major/minor version, so this will quietly stop being
   # a proper check sometime in the future and need to be updated.
-  livecheck :url   => "https://cdn.zabbix.com/zabbix/sources/stable/4.4/",
+  livecheck :url   => "https://cdn.zabbix.com/zabbix/sources/stable/5.0/",
             :regex => /href=.+?zabbix-(\d+(?:\.\d+)+)\.t/
 end


### PR DESCRIPTION
The URL in the `zabbix` livecheckable has to be updated when a new major/minor version is released, so this simply updates the check to use 5.0 (instead of 4.4).