### PR TITLE
jbig2dec: update url and regex

### DIFF
--- a/Livecheckables/jbig2dec.rb
+++ b/Livecheckables/jbig2dec.rb
@@ -1,4 +1,4 @@
 class Jbig2dec
-  livecheck :url   => "https://jbig2dec.com",
-            :regex => /href="[^"]*?jbig2dec-v?(\d+(?:\.\d+)+)\.t/
+  livecheck :url   => "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/latest",
+            :regex => %r{href=.+?/jbig2dec-v?(\d+(?:\.\d+)+)\.t}
 end


### PR DESCRIPTION
The existing livecheckable for `jbig2dec` uses the [first-party homepage](https://jbig2dec.com) but unfortunately it hasn't been updated for the latest release (displaying 0.17 instead of 0.18). The formula uses the 0.18 release from GitHub, so this updates the livecheckable to check the "latest" release on GitHub and get the version from the `jbig2dec` archive.