### PR TITLE
miniupnpc: update regex

### DIFF
--- a/Livecheckables/miniupnpc.rb
+++ b/Livecheckables/miniupnpc.rb
@@ -1,4 +1,6 @@
 class Miniupnpc
+  # We only match versions with only a major/minor since versions like 2.1 are
+  # stable and versions like 2.1.20191224 are unstable/development releases.
   livecheck :url   => "https://miniupnp.tuxfamily.org/files/",
-            :regex => /href='download\.php\?file=miniupnpc-([0-9]\.[0-9\.]+)\.t/
+            :regex => /href=.+?miniupnpc-v?(\d+\.\d+)\.t/
 end


### PR DESCRIPTION
The existing livecheckable for `miniupnpc` is finding versions properly but it's listing a development version as newest (`2.1.20191224`). Stable versions of this software only use a major and minor (e.g., `2.1`), so this updates the regex to only match these versions.