### PR TITLE
ddclient: remove url and update regex

### DIFF
--- a/Livecheckables/ddclient.rb
+++ b/Livecheckables/ddclient.rb
@@ -1,4 +1,3 @@
 class Ddclient
-  livecheck :url   => "https://sourceforge.net/projects/ddclient/",
-            :regex => /ddclient-(\d+(?:\.\d+)+)/
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
`ddclient` has moved from [SourceForge](https://sourceforge.net/p/ddclient/) to [GitHub](https://github.com/ddclient/ddclient), so the existing livecheckable needed to be updated to be able to find the latest version. Currently, the formula is using version 3.9.1 but the last version on SourceForge is 3.9.0.

This updates the livecheckable to check the GitHub repo and modifies the regex accordingly.