### PR TITLE
scamper: update regex

### DIFF
--- a/Livecheckables/scamper.rb
+++ b/Livecheckables/scamper.rb
@@ -1,4 +1,4 @@
 class Scamper
   livecheck :url   => "https://www.caida.org/tools/measurement/scamper/code/?C=M&O=D",
-            :regex => /href="scamper-cvs-([0-9\.]+)\.t/
+            :regex => /href=.+?scamper(?:-cvs)?-v?(\d+[a-z]?)\.t/
 end


### PR DESCRIPTION
The existing livecheckable for `scamper` was finding versions properly but missing versions with a letter at the end (e.g., `20191102b` instead of `20191102`).

This updates the regex to allow for these maintenance versions while also making some changes to potentially reduce the chance of breaking in the future and to be a little more clear about the version format.