### PR TITLE
bgpdump: update url and regex

### DIFF
--- a/Livecheckables/bgpdump.rb
+++ b/Livecheckables/bgpdump.rb
@@ -1,4 +1,4 @@
 class Bgpdump
-  livecheck :url   => "https://www.ris.ripe.net/source/bgpdump/?C=M&O=D",
-            :regex => /href="libbgpdump-(\d+(?:\.\d+)+)\.[^"]+"/
+  livecheck :url   => "https://github.com/RIPE-NCC/bgpdump.git",
+            :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `bgpdump` checks the [related ripe.net download index](https://www.ris.ripe.net/source/bgpdump/). The latest version (1.6.1) isn't available here but is instead found in the related [GitHub repo](https://github.com/RIPE-NCC/bgpdump/). The only release tagged here is 1.6.1, so this seems to be a new thing going forward.

This updates the livecheckable to check the GitHub repo, bringing it in line with the formula.