### PR TITLE
inspircd: update url and regex

### DIFF
--- a/Livecheckables/inspircd.rb
+++ b/Livecheckables/inspircd.rb
@@ -1,4 +1,4 @@
 class Inspircd
-  livecheck :url   => "https://github.com/inspircd/inspircd/releases",
-            :regex => %r{latest.*?href="/inspircd/inspircd/tree/v?([0-9\.]+)}m
+  livecheck :url   => "https://github.com/inspircd/inspircd.git",
+            :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The existing livecheckable for `inspircd` checks the [GitHub releases page](https://github.com/inspircd/inspircd/releases) but the regex only matches the version marked as "latest". Unfortunately, the "latest" version is set to `2.0.29`, even though the [upstream website](https://www.inspircd.org) describes v2 as deprecated and that users should upgrade to v3.

This updates the livecheckable to simply check the Git tags (updating the regex accordingly), to avoid this issue.