### PR TITLE
Update PyPI livecheck urls

### DIFF
--- a/Livecheckables/ansible-lint.rb
+++ b/Livecheckables/ansible-lint.rb
@@ -1,4 +1,4 @@
 class AnsibleLint
-  livecheck :url   => "https://pypi.python.org/simple/ansible-lint/",
+  livecheck :url   => "https://pypi.org/simple/ansible-lint/",
             :regex => %r{href=".*?/ansible-lint-([0-9\.]+)\.t}
 end

--- a/Livecheckables/aws-elasticbeanstalk.rb
+++ b/Livecheckables/aws-elasticbeanstalk.rb
@@ -1,4 +1,4 @@
 class AwsElasticbeanstalk
-  livecheck :url   => "https://pypi.python.org/simple/awsebcli/",
+  livecheck :url   => "https://pypi.org/simple/awsebcli/",
             :regex => %r{href=".*?/awsebcli-([0-9\.]+)\.t}
 end

--- a/Livecheckables/bzt.rb
+++ b/Livecheckables/bzt.rb
@@ -1,4 +1,4 @@
 class Bzt
-  livecheck :url   => "https://pypi.python.org/simple/bzt/",
+  livecheck :url   => "https://pypi.org/simple/bzt/",
             :regex => %r{href=".*?/bzt-([0-9\.]+)\.t}
 end

--- a/Livecheckables/ccm.rb
+++ b/Livecheckables/ccm.rb
@@ -1,4 +1,4 @@
 class Ccm
-  livecheck :url   => "https://pypi.python.org/pypi/ccm",
+  livecheck :url   => "https://pypi.org/simple/ccm",
             :regex => %r{/ccm-([0-9,\.]+)\.t}
 end

--- a/Livecheckables/charm-tools.rb
+++ b/Livecheckables/charm-tools.rb
@@ -1,4 +1,4 @@
 class CharmTools
-  livecheck :url   => "https://pypi.python.org/simple/charm-tools/",
+  livecheck :url   => "https://pypi.org/simple/charm-tools/",
             :regex => %r{href=".*?/charm-tools-([0-9\.]+)\.t}
 end

--- a/Livecheckables/codemod.rb
+++ b/Livecheckables/codemod.rb
@@ -1,4 +1,4 @@
 class Codemod
-  livecheck :url   => "https://pypi.python.org/simple/codemod/",
+  livecheck :url   => "https://pypi.org/simple/codemod/",
             :regex => %r{href=".*?/codemod-([0-9\.]+)\.t}
 end

--- a/Livecheckables/csvkit.rb
+++ b/Livecheckables/csvkit.rb
@@ -1,4 +1,4 @@
 class Csvkit
-  livecheck :url   => "https://pypi.python.org/simple/csvkit/",
+  livecheck :url   => "https://pypi.org/simple/csvkit/",
             :regex => %r{href=".*?/csvkit-([0-9\.]+)\.t}
 end

--- a/Livecheckables/cython.rb
+++ b/Livecheckables/cython.rb
@@ -1,4 +1,4 @@
 class Cython
-  livecheck :url   => "https://pypi.python.org/simple/cython/",
+  livecheck :url   => "https://pypi.org/simple/cython/",
             :regex => %r{href=".*?/Cython-([0-9\.]+)\.t}
 end

--- a/Livecheckables/diffoscope.rb
+++ b/Livecheckables/diffoscope.rb
@@ -1,4 +1,4 @@
 class Diffoscope
-  livecheck :url   => "https://pypi.python.org/pypi/diffoscope",
+  livecheck :url   => "https://pypi.org/simple/diffoscope",
             :regex => %r{/diffoscope-([0-9,\.]+)\.t}
 end

--- a/Livecheckables/doitlive.rb
+++ b/Livecheckables/doitlive.rb
@@ -1,4 +1,4 @@
 class Doitlive
-  livecheck :url   => "https://pypi.python.org/simple/doitlive/",
+  livecheck :url   => "https://pypi.org/simple/doitlive/",
             :regex => %r{href=".*?/doitlive-([0-9\.]+)\.t}
 end

--- a/Livecheckables/dxpy.rb
+++ b/Livecheckables/dxpy.rb
@@ -1,4 +1,4 @@
 class Dxpy
-  livecheck :url   => "https://pypi.python.org/simple/dxpy/",
+  livecheck :url   => "https://pypi.org/simple/dxpy/",
             :regex => %r{href=".*?/dxpy-([0-9\.]+)\.t}
 end

--- a/Livecheckables/eralchemy.rb
+++ b/Livecheckables/eralchemy.rb
@@ -1,4 +1,4 @@
 class Eralchemy
-  livecheck :url   => "https://pypi.python.org/pypi/ERAlchemy/",
+  livecheck :url   => "https://pypi.org/simple/ERAlchemy/",
             :regex => /href=".*ERAlchemy-([0-9,\.]+)\.t/
 end

--- a/Livecheckables/jenkins-job-builder.rb
+++ b/Livecheckables/jenkins-job-builder.rb
@@ -1,4 +1,4 @@
 class JenkinsJobBuilder
-  livecheck :url   => "https://pypi.python.org/simple/jenkins-job-builder/",
+  livecheck :url   => "https://pypi.org/simple/jenkins-job-builder/",
             :regex => %r{href=".*?/jenkins-job-builder-([0-9\.]+)\.t}
 end

--- a/Livecheckables/keepassc.rb
+++ b/Livecheckables/keepassc.rb
@@ -1,4 +1,4 @@
 class Keepassc
-  livecheck :url   => "https://pypi.python.org/simple/keepassc/",
+  livecheck :url   => "https://pypi.org/simple/keepassc/",
             :regex => %r{href=".*?/keepassc-([0-9\.]+)\.t}
 end

--- a/Livecheckables/keepkey-agent.rb
+++ b/Livecheckables/keepkey-agent.rb
@@ -1,4 +1,4 @@
 class KeepkeyAgent
-  livecheck :url   => "https://pypi.python.org/simple/keepkey_agent/",
+  livecheck :url   => "https://pypi.org/simple/keepkey_agent/",
             :regex => %r{href=".*?/keepkey_agent-([0-9\.]+)\.t}
 end

--- a/Livecheckables/ocrmypdf.rb
+++ b/Livecheckables/ocrmypdf.rb
@@ -1,4 +1,4 @@
 class Ocrmypdf
-  livecheck :url   => "https://pypi.python.org/simple/ocrmypdf/",
+  livecheck :url   => "https://pypi.org/simple/ocrmypdf/",
             :regex => %r{href=".*?/ocrmypdf-([0-9\.]+)\.t}
 end

--- a/Livecheckables/pgcli.rb
+++ b/Livecheckables/pgcli.rb
@@ -1,4 +1,4 @@
 class Pgcli
-  livecheck :url   => "https://pypi.python.org/pypi/pgcli/",
+  livecheck :url   => "https://pypi.org/simple/pgcli/",
             :regex => /href=".*pgcli-([0-9,\.]+)\.tar/
 end

--- a/Livecheckables/pipenv.rb
+++ b/Livecheckables/pipenv.rb
@@ -1,4 +1,4 @@
 class Pipenv
-  livecheck :url   => "https://pypi.python.org/pypi/pipenv",
+  livecheck :url   => "https://pypi.org/simple/pipenv",
             :regex => %r{/pipenv-([0-9,\.]+)\.t}
 end

--- a/Livecheckables/tox.rb
+++ b/Livecheckables/tox.rb
@@ -1,4 +1,4 @@
 class Tox
-  livecheck :url   => "https://pypi.python.org/pypi/tox",
+  livecheck :url   => "https://pypi.org/simple/tox",
             :regex => %r{/tox-([0-9,\.]+)\.t}
 end

--- a/Livecheckables/vsts-cli.rb
+++ b/Livecheckables/vsts-cli.rb
@@ -1,4 +1,4 @@
 class VstsCli
-  livecheck :url   => "https://pypi.python.org/simple/vsts-cli/",
+  livecheck :url   => "https://pypi.org/simple/vsts-cli/",
             :regex => %r{href=".*?/vsts-cli-([0-9a-z\.]+)\.t}
 end


### PR DESCRIPTION
Updating PyPI livecheck `url`s to `https://pypi.org/simple/formula`.