### PR TITLE
archey: update url

### DIFF
--- a/Livecheckables/archey.rb
+++ b/Livecheckables/archey.rb
@@ -1,4 +1,4 @@
 class Archey
-  livecheck :url   => "https://github.com/obihann/archey-osx.git",
+  livecheck :url   => "https://github.com/obihann/archey-osx/releases/",
             :regex => /^v?(\d+(?:\.\d+)+)$/
 end


### PR DESCRIPTION
The `url` in `archey.rb`, earlier `https://github.com/obihann/archey-osx.git`, caused a style issue when migrated to a `livecheck` block in `homebrew-core`, as it seemed like a binary package rather than a source package (although it is a source package).

The `url` in the Livecheckable has been updated to `https://github.com/obihann/archey-osx/releases/`, which works with `livecheck` and does not cause a style issue when migrated to `homebrew-core`.