### PR TITLE
freetds: update url

### DIFF
--- a/Livecheckables/freetds.rb
+++ b/Livecheckables/freetds.rb
@@ -1,4 +1,4 @@
 class Freetds
-  livecheck :url   => "https://fossies.org/linux/privat/",
-            :regex => /HREF="freetds-([\d.]+)\.tar/
+  livecheck :url   => "http://www.freetds.org/files/stable/",
+            :regex => /href=.*?freetds-v?(\d+(?:\.\d+)+)\.t/i
 end


### PR DESCRIPTION
The `url` in `freetds.rb`, earlier a `fossies.org` url, caused a style issue when migrated to a `livecheck` block in `homebrew-core`.

The `url` in the Livecheckable has been updated to http://www.freetds.org/files/stable/, which works with `livecheck` and does not cause a style issue when migrated to `homebrew-core`.