### PR TITLE
castxml: update url

### DIFF
--- a/Livecheckables/castxml.rb
+++ b/Livecheckables/castxml.rb
@@ -1,4 +1,3 @@
 class Castxml
-  livecheck :url   => "https://mirrors.ocf.berkeley.edu/debian/pool/main/c/castxml/",
-            :regex => /href="castxml_([a-z0-9\.\+]+)\.orig\.t/
+  livecheck :regex => /^v?(\d+(?:\.\d+)+)$/i
 end


### PR DESCRIPTION
The `url` has been changed to `http://ftp.debian.org/...` to prevent the urls cop from raising style errors on migration to homebrew-core. The new `url` does not break livecheck.