### PR TITLE
checkbashisms: update url

### DIFF
--- a/Livecheckables/checkbashisms.rb
+++ b/Livecheckables/checkbashisms.rb
@@ -1,4 +1,4 @@
 class Checkbashisms
-  livecheck :url   => "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/devscripts/",
-            :regex => /href="devscripts_([0-9\.]+)\.t/
+  livecheck :url   => "https://deb.debian.org/debian/pool/main/d/devscripts/",
+            :regex => /href=.*?devscripts.v?(\d+(?:\.\d+)+)\.t/i
 end


### PR DESCRIPTION
The `url` has been changed to `http://ftp.debian.org/...` to prevent the urls cop from raising style errors on migration to homebrew-core. The new `url` does not break livecheck.