### PR TITLE
dpkg: update url

### DIFF
--- a/Livecheckables/dpkg.rb
+++ b/Livecheckables/dpkg.rb
@@ -1,4 +1,4 @@
 class Dpkg
-  livecheck :url   => "https://mirrors.ocf.berkeley.edu/debian/pool/main/d/dpkg/",
-            :regex => /href="dpkg_([0-9\.]+)\.t/
+  livecheck :url   => "https://deb.debian.org/debian/pool/main/d/dpkg/",
+            :regex => /href=.*?dpkg.v?(\d+(?:\.\d+)+)\.t/i
 end


### PR DESCRIPTION
The `url` has been changed to `http://ftp.debian.org/...` to prevent the urls cop from raising style errors on migration to homebrew-core. The new `url` does not break livecheck.