### PR TITLE
fakeroot: update url

### DIFF
--- a/Livecheckables/fakeroot.rb
+++ b/Livecheckables/fakeroot.rb
@@ -1,4 +1,4 @@
 class Fakeroot
-  livecheck :url   => "https://mirrors.ocf.berkeley.edu/debian/pool/main/f/fakeroot/",
-            :regex => /href="fakeroot_([0-9\.]+).orig\.t/
+  livecheck :url   => "https://deb.debian.org/debian/pool/main/f/fakeroot/",
+            :regex => /href=.*?fakeroot.v?(\d+(?:\.\d+)+)\.orig\.t/i
 end


### PR DESCRIPTION
The `url` has been changed to `http://ftp.debian.org/...` to prevent the urls cop from raising style errors on migration to homebrew-core. The new `url` does not break livecheck.