### PR TITLE
zboy: add livecheckable

### DIFF
--- a/Livecheckables/zboy.rb
+++ b/Livecheckables/zboy.rb
@@ -1,0 +1,3 @@
+class Zboy
+  livecheck :regex => %r{url=.+?/zboy-v?(\d+(?:\.\d+)+)\.t}i
+end


### PR DESCRIPTION
The default check for `zboy` also matches versions like `2011-01-06`, whereas stable versions are like `0.71`. This adds a livecheckable with a regex to only match proper release versions.