### PR TITLE
msdl: add livecheckable

### DIFF
--- a/Livecheckables/msdl.rb
+++ b/Livecheckables/msdl.rb
@@ -1,0 +1,3 @@
+class Msdl
+  livecheck :regex => %r{url=.+?/msdl-v?(\d+(?:\.\d+)+(?:-r\d+)?)\.t}i
+end


### PR DESCRIPTION
The default check for `msdl` (using the SourceForge strategy) doesn't match the trailing `-r#` part of the version string. This adds a livecheckable with a regex that optionally matches this additional part of the version.