### PR TITLE
akka: update livecheckable

### DIFF
--- a/Livecheckables/akka.rb
+++ b/Livecheckables/akka.rb
@@ -1,6 +1,4 @@
 class Akka
-  livecheck :url   => "https://github.com/akka/akka.git",
-            # single digit for major version since
-            # v2.6.4 is newer than v10.1.0
-            :regex => /^v?(\d(?:\.\d+)+)$/
+  livecheck :url   => "https://github.com/akka/akka/releases/latest",
+            :regex => %r{href=.+?/tag/v?(\d+(?:\.\d+)+)["']}i
 end


### PR DESCRIPTION
The existing livecheckable for `akka` checked the Git repo's tags and used a regex that only matched versions with a single digit major version (e.g., `2.6.4`). This was because there were some older tags like `v10.0.0` that will appear newer until the version numbers go past `v10.1.0`.

This updates the livecheckable to check the "latest" GitHub release, as this will continue to work if the `akka` versions ever reach `v10.0.0`.