### PR TITLE
closure-compiler: update livecheckable

### DIFF
--- a/Livecheckables/closure-compiler.rb
+++ b/Livecheckables/closure-compiler.rb
@@ -1,5 +1,4 @@
 class ClosureCompiler
-  # livecheck :url => "https://github.com/google/closure-compiler/wiki/Binary-Downloads",
-  livecheck :url   => "https://bit.ly/2KeL7sF",
-            :regex => %r{href=".*?/compiler-([0-9\.]+)\.}
+  livecheck :url   => "https://repo1.maven.org/maven2/com/google/javascript/closure-compiler/",
+            :regex => /href=.*?v?(\d{8})/i
 end


### PR DESCRIPTION
The existing livecheckable for `closure-compiler` had to use a link shortener to get around an issue where the upstream URL wouldn't allow livecheck to check the URL.

This avoids the issue by updating the livecheckable to check the upstream index page where the formula's stable archive is located.