### PR TITLE
wapm: add url and update regex

### DIFF
--- a/Livecheckables/wapm.rb
+++ b/Livecheckables/wapm.rb
@@ -1,5 +1,4 @@
 class Wapm
-  # There is a "3.2" tag in the Git repo that we avoid by only matching versions
-  # with 3+ parts (e.g., 0.1.2)
-  livecheck :regex => /^v?(\d+(?:\.\d+){2,})/
+  livecheck :url   => "https://github.com/wasmerio/wapm-cli/releases/latest",
+            :regex => %r{href=.+?/tag/v?(\d+(?:\.\d+)+)["']}i
 end


### PR DESCRIPTION
The existing livecheckable for `wapm` was restricting matching to versions with three parts (e.g., `1.2.3`), to avoid a problematic `3.2` version in the Git tags.

This updates the livecheckable to check the "latest" release on GitHub instead, so it will continue to work if there's ever a version with only two parts.