### PR TITLE
watchman: add livecheckable

### DIFF
--- a/Livecheckables/watchman.rb
+++ b/Livecheckables/watchman.rb
@@ -1,0 +1,5 @@
+class Watchman
+  # The Git repo contains a few tags like `2020.05.18.00`, so we have to
+  # restrict matching to versions with two to three parts (e.g., 1.2, 1.2.3).
+  livecheck :regex => /^v?(\d+(?:\.\d+){,2})$/i
+end


### PR DESCRIPTION
The `watchman` Git repo contains a couple tags like `2020.05.18.00`, whereas the newest stable version is `4.9.0`. This adds a livecheckable with a regex to restrict matching to versions with two to three parts (e.g., `1.2`, `1.2.3`), which omits the versions that use a date.

If a stable version appears in the future with four parts (e.g., `1.2.3.4`), we'll have to restrict the length of the first part to fewer than four digits instead.