### PR TITLE
closure-compiler: update url

### DIFF
--- a/Livecheckables/closure-compiler.rb
+++ b/Livecheckables/closure-compiler.rb
@@ -1,4 +1,4 @@
 class ClosureCompiler
-  livecheck :url   => "https://repo1.maven.org/maven2/com/google/javascript/closure-compiler/",
+  livecheck :url   => "https://search.maven.org/remotecontent?filepath=com/google/javascript/closure-compiler/",
             :regex => /href=.*?v?(\d{8})/i
 end


### PR DESCRIPTION
Updates the `url` for `closure-compiler` to one compliant with the `urls` cop in Homebrew/brew. The update is due to style issues raised by the `urls` cop during migration to homebrew-core.