### PR TITLE
livecheck: fix HEAD only formulae checking

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -109,7 +109,7 @@ module Homebrew
       return
     end
 
-    is_gist = formula&.stable&.url&.include?("gist.github.com")
+    is_gist = formula.stable&.url&.include?("gist.github.com")
     if formula.livecheck.skip? || is_gist
       skip_msg = if formula.livecheck.skip_msg.is_a?(String) &&
                     !formula.livecheck.skip_msg.blank?


### PR DESCRIPTION
before:
```
Error: forgit: Calling Formula#installed? is deprecated! Use Formula#latest_version_installed? (or Formula#any_version_installed? ) instead.
Please report this issue to the homebrew/livecheck tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-livecheck/cmd/livecheck.rb:104

Error: forgit: undefined method `url' for nil:NilClass
```

after:
```
forgit (guessed) : HEAD-ade7ca9 ==> HEAD-ade7ca9
```

after further fixes:
```
forgit (guessed) : ade7ca9 ==> 9faef0c
```