### PR TITLE
detekt: update url

### DIFF
--- a/Livecheckables/detekt.rb
+++ b/Livecheckables/detekt.rb
@@ -1,6 +1,6 @@
 class Detekt
   livecheck do
-    url "https://github.com/arturbosch/detekt.git"
+    url "https://github.com/detekt/detekt.git"
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end


### PR DESCRIPTION
Formula `detekt` has been moved to a GitHub organisation named `detekt` and the author maintains a personal fork at the current url. Livecheck was not fetching the latest version, and was actually fetching a version older than the one currently available in homebrew-core.

The output before this change:
```
detekt: 1.9.1 ==> 1.9.0
```

The output after:
```
detekt: 1.9.1 ==> 1.9.1
```