### PR TITLE
spice-protocol: update regex

### DIFF
--- a/Livecheckables/spice-protocol.rb
+++ b/Livecheckables/spice-protocol.rb
@@ -1,6 +1,6 @@
 class SpiceProtocol
   livecheck do
     url "https://www.spice-space.org/download/releases/"
-    regex(/spice-protocol-([\d.]+)\.tar\.bz2/)
+    regex(/href=.*?spice-protocol-v?(\d+(?:\.\d+)+)\.t/)
   end
 end


### PR DESCRIPTION
The earlier regex was too specific w.r.t the extension and was not matching the latest version (as they had updated their compression format). Updated the regex to be more loose w.r.t the extension, while also updating the version number matching to our preferred regex.