### PR TITLE
plzip: update url and regex

### DIFF
--- a/Livecheckables/plzip.rb
+++ b/Livecheckables/plzip.rb
@@ -1,6 +1,6 @@
 class Plzip
   livecheck do
-    url "https://download.savannah.gnu.org/releases/lzip/plzip"
-    regex(/href="plzip-([0-9\.]+)\.t/)
+    url "https://download.savannah.gnu.org/releases/lzip/plzip/"
+    regex(/href=.*?plzip-v?(\d+(?:\.\d+)+)\.t/)
   end
 end


### PR DESCRIPTION
Fixes a `redirection-forbidden` error for `plzip`.