### PR TITLE
livecheck: remove support for hash format

### DIFF
--- a/livecheck/extend/formula.rb
+++ b/livecheck/extend/formula.rb
@@ -20,18 +20,12 @@ class Formula
       urls.compact
     end
 
-    def livecheck(arg = {}, &block)
+    def livecheck(&block)
       @livecheck ||= Livecheck.new
-      return @livecheck if livecheckable? || (!block_given? && arg.empty?)
+      return @livecheck if livecheckable? || !block_given?
 
       @livecheckable = true
-      if block_given?
-        @livecheck.instance_eval(&block)
-      else
-        arg.each do |key, value|
-          @livecheck.send(key.to_s, value)
-        end
-      end
+      @livecheck.instance_eval(&block)
     end
 
     def _latest


### PR DESCRIPTION
This PR removes support for the older hash format for Livecheckables, retaining support for the block format alone. All Livecheckables have already been converted to the block format in #764.