### PR TITLE
Remove commands/cat.rb

### DIFF
--- a/livecheck/commands/cat.rb
+++ b/livecheck/commands/cat.rb
@@ -1,2 +1,0 @@
-# Ignores all formulae but first (this is by design)
-puts (LIVECHECKABLES_PATH/"#{Homebrew.args.named[1]}.rb").read


### PR DESCRIPTION
I'm not sure if there's value in keeping this around and removing it means there's one less thing to migrate to Homebrew/brew in the future.

Are there any objections to this?