### PR TITLE
coq: update url and regex

### DIFF
--- a/Livecheckables/coq.rb
+++ b/Livecheckables/coq.rb
@@ -1,6 +1,6 @@
 class Coq
   livecheck do
-    url "https://coq.inria.fr/download"
-    regex(%r{<a href="https://github.com/coq/coq/releases/tag/V(\d+(?:\.\w+)*)">})
+    url "https://github.com/coq/coq.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end


### PR DESCRIPTION
The upstream `coq` developers have created a release (8.11.2) that doesn't adhere to how they've been doing releases in the past and the `coq` formula has been updated to use it. That is to say, the release isn't the "latest" on GitHub, there are no release artifacts (just the source), and the version wasn't announced on the [first-party website](https://coq.inria.fr/).

It would have been helpful to resolve this ambiguity before the homebrew-core PR was merged (e.g., discussing it with the upstream developers to understand if the version should be used and to request that they adhere to good release standards). As it stands, the formula's using the 8.11.2 "release" from GitHub, so this updates the existing livecheckable to check the Git tags for versions.