### PR TITLE
libdca: update url and regex

### DIFF
--- a/Livecheckables/libdca.rb
+++ b/Livecheckables/libdca.rb
@@ -1,6 +1,6 @@
 class Libdca
   livecheck do
-    url "https://www.videolan.org/developers/libdca.html"
-    regex(%r{Current release is <a href=".*?/libdca-([0-9\.]+)\.t})
+    url "https://download.videolan.org/pub/videolan/libdca/"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)[/"'>]}i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `libdca` was reporting `0.0.6` as the latest release instead of `0.0.7` (as found in the formula). The livecheckable checks the [libdca download page](https://www.videolan.org/developers/libdca.html) but this page hasn't been updated for the 0.0.7 release.

This updates the livecheckable to check the [libdca release folders index page](https://download.videolan.org/pub/videolan/libdca/), which aligns with the stable archive in the formula.