### PR TITLE
mu: update url and regex

### DIFF
--- a/Livecheckables/mu.rb
+++ b/Livecheckables/mu.rb
@@ -1,6 +1,9 @@
 class Mu
+  # We restrict matching to versions with an even-numbered minor version number,
+  # as an odd-numbered minor version number indicates a development version:
+  # https://github.com/djcb/mu/commit/23f4a64bdcdee3f9956a39b9a5a4fd0c5c2370ba
   livecheck do
-    url "https://github.com/djcb/mu/releases"
-    regex(%r{latest.*?href="/djcb/mu/tree/([0-9\.]+)}m)
+    url "https://github.com/djcb/mu.git"
+    regex(/^v?(\d+\.\d*[02468](?:\.\d+)*)$/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `mu` checks the "latest" release on the [GitHub releases page](https://github.com/djcb/mu/releases). Unfortunately, the tag for the latest release at the moment has a typo in it (`1,4.7` instead of `1.4.7`), which breaks matching and leads to a development version (1.3.10) being reported as newest.

This updates the livecheckable to check the Git repo tags instead and restricts matching to versions with an even-numbered minor version number (as an odd-numbered minor version indicates a development version).