### PR TITLE
simgrid: update url and regex

### DIFF
--- a/Livecheckables/simgrid.rb
+++ b/Livecheckables/simgrid.rb
@@ -1,6 +1,6 @@
 class Simgrid
   livecheck do
-    url "https://simgrid.org/"
-    regex(/href=".*?SimGrid-([0-9\.]+)\.t/)
+    url "https://framagit.org/simgrid/simgrid.git"
+    regex(/^v?(\d+(?:[_.]\d+)+)$/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `simgrid` checks the [first-party website](https://simgrid.org/) but it apparently went down recently for a brief period of time. The formula is using an archive from the Git repository, so this PR updates the livecheckable to check the Git repo tags instead. This should be more reliable but it's also good to align the check with the source of the stable archive in the formula, when appropriate.