### PR TITLE
Fix Livecheck object instantiation

### DIFF
--- a/livecheck/extend/formula.rb
+++ b/livecheck/extend/formula.rb
@@ -21,7 +21,7 @@ class Formula
     end
 
     def livecheck(&block)
-      @livecheck ||= Livecheck.new
+      @livecheck ||= Livecheck.new(self)
       return @livecheck if livecheckable? || !block_given?
 
       @livecheckable = true


### PR DESCRIPTION
The PR (Homebrew/brew#7668) adding the ability to reference Formula URLs in the `livecheck` DSL has been merged. It changes the `Livecheck` class constructor to accept the `Formula` object as a parameter, to be able to access the URLs for `head`, `stable`, `devel` and `homepage`.

The `Livecheck` object instantiation in livecheck/extend/formula.rb has been updated in this PR to reflect that change.