### PR TITLE
lmdb: add livecheckable

### DIFF
--- a/Livecheckables/lmdb.rb
+++ b/Livecheckables/lmdb.rb
@@ -1,0 +1,6 @@
+class Lmdb
+  livecheck do
+    url :head
+    regex(/^LMDB.v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
The default check for `lmdb` checks the Git tags but they include tags for more than just `lmdb`. This adds a livecheckable that uses the `head` URL (Git repo) and restricts matching to the tags like `LMDB_1.2.3`.

This uses the recently-added support for referencing specific formula URLs in `url` (namely, `:head`, `:stable`, `:devel`, and `:homepage`). This allows us to avoid explicitly duplicating these URLs in the livecheckable (and keeping them in sync).