### PR TITLE
libewf: add livecheckable

### DIFF
--- a/Livecheckables/libewf.rb
+++ b/Livecheckables/libewf.rb
@@ -1,0 +1,5 @@
+class Libewf
+  livecheck do
+    url :stable
+  end
+end


### PR DESCRIPTION
[The main repository for `libewf`](https://github.com/libyal/libewf) only contains experimental builds at this point and the stable archive is from the [libyal/libewf-legacy repo](https://github.com/libyal/libewf-legacy). This adds a livecheckable to restrict checking to the stable URL, which will check the libewf-legacy Git repo tags.