### PR TITLE
jsoncpp: add livecheckable

### DIFF
--- a/Livecheckables/jsoncpp.rb
+++ b/Livecheckables/jsoncpp.rb
@@ -1,0 +1,6 @@
+class Jsoncpp
+  livecheck do
+    url "https://github.com/open-source-parsers/jsoncpp/releases/latest"
+    regex(%r{href=.+?/tag/v?(\d+(?:\.\d+)+)["']}i)
+  end
+end


### PR DESCRIPTION
The upstream Git repo for `jsoncpp` releases versions that appear to be stable releases but are marked as pre-release on the GitHub releases page (e.g., `1.9.2`). This adds a livecheckable to check the "latest" release page on GitHub to get the latest version.