### PR TITLE
anttweakbar: skip livecheck

### DIFF
--- a/Livecheckables/anttweakbar.rb
+++ b/Livecheckables/anttweakbar.rb
@@ -1,5 +1,5 @@
 class Anttweakbar
   livecheck do
-    regex(%r{url=.+?/AntTweakBar.v?(\d+(?:\.\d+)*)\.(?:t|z)}i)
+    skip "Not maintained"
   end
 end


### PR DESCRIPTION
As the [website](http://anttweakbar.sourceforge.net/doc/tools:anttweakbar:download) states, this Formula is no longer being maintained, and so we must skip `livecheck` for this Formula. Also, `livecheck` was earlier reporting an incorrect "new version" (1.16 ==> 116) - probably because the URL to the source had 116 in it.