### PR TITLE
libp11: add livecheckable

### DIFF
--- a/Livecheckables/libp11.rb
+++ b/Livecheckables/libp11.rb
@@ -1,0 +1,6 @@
+class Libp11
+  livecheck do
+    url :head
+    regex(/^libp11-v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
By default, livecheck picks up the `11` part of the `libp11` name and adds it to the matched version like `11-0.4.10` (whereas the version should be `0.4.10`). This adds a livecheckable with a regex to fix this issue.