### PR TITLE
root: add livecheckable

### DIFF
--- a/Livecheckables/root.rb
+++ b/Livecheckables/root.rb
@@ -1,0 +1,6 @@
+class Root
+  livecheck do
+    url "https://root.cern.ch/download/"
+    regex(/href=.*?root.v?(\d+(?:\.\d*[02468])+)\.source\.t/i)
+  end
+end


### PR DESCRIPTION
The default check for `root` is looking for versions in the tags of the upstream repo and the latest version is being reported as `6-23-01` instead of `6.20.04`.

This adds a livecheckable that checks the [first-party download index page](https://root.cern.ch/download/) (to align with the stable archive source) and restricts matching to production versions (those with an even-numbered minor version).