### PR TITLE
gtkmm: add livecheckable

### DIFF
--- a/Livecheckables/gtkmm.rb
+++ b/Livecheckables/gtkmm.rb
@@ -1,0 +1,6 @@
+class Gtkmm
+  livecheck do
+    url :stable
+    regex(/gtkmm-v?(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
+  end
+end


### PR DESCRIPTION
The default check for `gtkmm` reports `3.24.2` as the newest version but this formula is only for versions with a major version of `2` (i.e., versions with a major version of `3` belong in `gtkmm3`). This adds a livecheckable to restrict matching to versions with a major version of `2` (while still respecting the stable/development GNOME version scheme).