### PR TITLE
exiv2: add livecheckable

### DIFF
--- a/Livecheckables/exiv2.rb
+++ b/Livecheckables/exiv2.rb
@@ -1,0 +1,6 @@
+class Exiv2
+  livecheck do
+    url "https://www.exiv2.org/builds/"
+    regex(/href=.*?exiv2-v?(\d+(?:\.\d+)+)-Source\.t/i)
+  end
+end


### PR DESCRIPTION
The default check for `exiv2` was checking the Git tags and reporting an unstable version as newest (`0.27.3-RC2`). This adds a livecheckable to check the [first-party "builds" index page](https://www.exiv2.org/builds/) (where the stable archive comes from) and restricts matching to stable versions.