### PR TITLE
micronaut: add livecheckable

### DIFF
--- a/Livecheckables/micronaut.rb
+++ b/Livecheckables/micronaut.rb
@@ -1,0 +1,6 @@
+class Micronaut
+  livecheck do
+    url "https://github.com/micronaut-projects/micronaut-core/releases/latest"
+    regex(%r{href=.+?/tag/v?(\d+(?:\.\d+)+)["']}i)
+  end
+end


### PR DESCRIPTION
The default check for `micronaut` was returning a newer version (`v2.0.0.M3`) than the one marked as "latest" on GitHub (`1.3.5`). This adds a livecheckable to check the "latest" release on GitHub to get the latest version.