### PR TITLE
urdfdom: add livecheckable

### DIFF
--- a/Livecheckables/urdfdom.rb
+++ b/Livecheckables/urdfdom.rb
@@ -1,0 +1,6 @@
+class Urdfdom
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
The default check for `urdfdom` was picking up an unrelated Git tag, leading to the latest version being wrongly reported as `1.7.1` instead of `1.0.4`. This adds a livecheckable to restrict matching to Git tags like `1.2.3` (excluding ones like `robot_model-1.7.1`).