### PR TITLE
acme: add livecheckable

### DIFF
--- a/Livecheckables/acme.rb
+++ b/Livecheckables/acme.rb
@@ -1,6 +1,7 @@
 class Acme
   livecheck do
-    url :homepage
-    regex(/acme(\d+(?:\.\d+)+)win/i)
+    url "https://sourceforge.net/p/acme-crossass/code-0/HEAD/tree/trunk/docs/Changes.txt?format=raw"
+    strategy :page_match
+    regex(/New in release v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/acme.rb
+++ b/Livecheckables/acme.rb
@@ -1,0 +1,6 @@
+class Acme
+  livecheck do
+    url :homepage
+    regex(/acme(\d+(?:\.\d+)+)win/i)
+  end
+end


### PR DESCRIPTION
Need help with this one @samford. Their [Changes.txt](https://sourceforge.net/p/acme-crossass/code-0/HEAD/tree/trunk/docs/Changes.txt) file shows a version `0.96.5`, but that doesn't show up in the RSS. Also, I think the RSS shows only Windows versions. What do we do for this Formula?