### PR TITLE
mosquitto: update url and regex

### DIFF
--- a/Livecheckables/mosquitto.rb
+++ b/Livecheckables/mosquitto.rb
@@ -1,6 +1,6 @@
 class Mosquitto
   livecheck do
-    url "https://mosquitto.org/download/"
-    regex(%r{href=".*?/mosquitto-([0-9.]+)\.t})
+    url "https://mosquitto.org/files/source/"
+    regex(/href=.*?mosquitto-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
The earlier `url` was that of the Download page which hadn't been updated to show the latest version. Updated the `url` to that of the source index page and also modified the `regex` to current standards.