### PR TITLE
gradle: add livecheckable

### DIFF
--- a/Livecheckables/gradle.rb
+++ b/Livecheckables/gradle.rb
@@ -1,0 +1,6 @@
+class Gradle
+  livecheck do
+    url "https://services.gradle.org/distributions/"
+    regex(/href=.*?gradle-v?(\d+(?:\.\d+)+)-all\.(?:[tz])/i)
+  end
+end


### PR DESCRIPTION
Add a Livecheckable for `gradle`, using their GitHub repository `url` to check for newer versions.