### PR TITLE
telnet: add livecheckable

### DIFF
--- a/Livecheckables/telnet.rb
+++ b/Livecheckables/telnet.rb
@@ -1,0 +1,6 @@
+class Telnet
+  livecheck do
+    url "https://opensource.apple.com/tarballs/remote_cmds/"
+    regex(/href=.*?remote_cmds-v?(\d+(?:\.\d+)*)\.t/i)
+  end
+end


### PR DESCRIPTION
Adding a Livecheckable for `telnet`. Important note: homebrew-core lists the version for `telnet` as that of Apple's `remote_cmd` version (currently 63). This Livecheckable considers the version of `remote_cmd` to be `telnet`'s version as well.