### PR TITLE
mysql-client: add livecheckable

### DIFF
--- a/Livecheckables/mysql-client.rb
+++ b/Livecheckables/mysql-client.rb
@@ -1,0 +1,6 @@
+class MysqlClient
+  livecheck do
+    url "https://github.com/mysql/mysql-server.git"
+    regex(/^mysql-v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
Fixes `livecheck` error by adding a Livecheckable for `mysql-client`; using GitHub repo to match versions tagged as `mysql-x.x.x` and not the MySQL Cluster versions. Concerns: There's a version `mysql-client@5.7` formula as well. Do let me know if changes are required.