### PR TITLE
bash-completion: add livecheckable

### DIFF
--- a/Livecheckables/bash-completion.rb
+++ b/Livecheckables/bash-completion.rb
@@ -1,0 +1,5 @@
+class BashCompletion
+  livecheck do
+    skip "1.x versions are no longer developed"
+  end
+end


### PR DESCRIPTION
We skip livecheck for `bash-completion` as `1.x` versions are not being released alongside `2.x` versions. The last `1.x` release was eight years ago, so it doesn't make sense to check for newer versions.

(macOS currently ships with Bash 3.2, while `bash-completion` versions `2.x` require Bash 4+. So, `bash-completion@2` is available as a versioned Formula in homebrew-core while `bash-completion` is the `1.x` version supported by default on Bash 3.2 on macOS.)