### PR TITLE
scala: add livecheckable

### DIFF
--- a/Livecheckables/scala.rb
+++ b/Livecheckables/scala.rb
@@ -1,0 +1,6 @@
+class Scala
+  livecheck do
+    url "https://www.scala-lang.org/files/archive"
+    regex(/href=.*?scala-v?(\d+(?:\.\d+)+)(?:.final)?\.t/i)
+  end
+end


### PR DESCRIPTION
Adding a Livecheckable for `scala` using the `url` https://www.scala-lang.org/files/archive.