### PR TITLE
libmagic: add livecheckable

### DIFF
--- a/Livecheckables/libmagic.rb
+++ b/Livecheckables/libmagic.rb
@@ -1,0 +1,6 @@
+class Libmagic
+  livecheck do
+    url "https://astron.com/pub/file/"
+    regex(/href=.*?file-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `libmagic` using the `url` https://astron.com/pub/file/.