### PR TITLE
metis: add livecheckable

### DIFF
--- a/Livecheckables/metis.rb
+++ b/Livecheckables/metis.rb
@@ -1,0 +1,6 @@
+class Metis
+  livecheck do
+    url "http://glaros.dtc.umn.edu/gkhome/metis/metis/download"
+    regex(%r{href=.*?/metis.v?(\d+(?:\.\d+)+)\.t}i)
+  end
+end


### PR DESCRIPTION
Using the `homepage` as `url` and matching text. There doesn't seem to be a proper index page of *all* versions, although a tree of some versions does exist.