### PR TITLE
popt: add livecheckable

### DIFF
--- a/Livecheckables/popt.rb
+++ b/Livecheckables/popt.rb
@@ -1,0 +1,11 @@
+class Popt
+  # Until rpm.org releases a new version beyond 1.16, it's unclear whether
+  # checking the rpm.org archive index (http://ftp.rpm.org/mirror/popt/) would
+  # give us the latest version. As of writing this, there's a 1.18 release
+  # candidate at: http://ftp.rpm.org/releases/testing/popt-1.18-rc1.tar.gz
+  # Checking the Git repo seems like a safe bet until we see how this plays out.
+  livecheck do
+    url "https://github.com/rpm-software-management/popt.git"
+    regex(/^(?:popt)?-v?(\d+(?:[._-]\d+)+)(?:-release)?$/i)
+  end
+end


### PR DESCRIPTION
The rpm5.org url is down (has been for a while probably, as apparent from the use of a Wayback Machine url in homebrew-core). They do have rpm.org now, I think, and this GitHub repository for `popt`. I tried not using a regex and it works too, so let me know if I should add one.