### PR TITLE
libspatialite: add livecheckable

### DIFF
--- a/Livecheckables/libspatialite.rb
+++ b/Livecheckables/libspatialite.rb
@@ -1,0 +1,6 @@
+class Libspatialite
+  livecheck do
+    url "http://www.gaia-gis.it/gaia-sins/libspatialite-sources/"
+    regex(/href=.*?libspatialite-v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+  end
+end


### PR DESCRIPTION
They happen to have just one version (the latest) with an `a` affixed, so instead of using `\d` I used `[0-9a-z]` for the patch part alone, but it could possibly be improved.