### PR TITLE
sdl: add livecheckable

### DIFF
--- a/Livecheckables/sdl.rb
+++ b/Livecheckables/sdl.rb
@@ -1,0 +1,6 @@
+class Sdl
+  livecheck do
+    url "https://www.libsdl.org/release/"
+    regex(/href=.*?SDL-v?(1(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
They do have a release page at https://www.libsdl.org/release/ but I used http://hg.libsdl.org/SDL/tags instead, to check the tags. An issue (?) I noticed when browsing through the first URL was that their 2+ versions are released as `SDL2-x.x.x` whereas their latest 1.x version, `1.2.5` (homebrew-core has this) is released as just `SDL-1.2.5`. Do let me know if I've got to change something here.