### PR TITLE
mecab: add livecheckable

### DIFF
--- a/Livecheckables/mecab.rb
+++ b/Livecheckables/mecab.rb
@@ -1,0 +1,6 @@
+class Mecab
+  livecheck do
+    url :homepage
+    regex(/mecab-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
The source code for `mecab` was originally part of `code.google.com` and was later migrated to GitHub when Google Code was shut down. I checked [their archives](https://code.google.com/archive/p/mecab/) and it says that the repository had been moved to https://taku910.github.io/mecab (`:homepage`).

The GitHub repository doesn't have version tags and based on my rudimentary Japanese skills I think there's no list of versions anywhere on the page except the ["Updates" section](http://taku910.github.io/mecab/#news) and the ["Download" section](http://taku910.github.io/mecab/#download).

There is a [Google Drive link](https://drive.google.com/drive/folders/0B4y35FiV1wh7fjQ5SkJETEJEYzlqcUY4WUlpZmR4dDlJMWI5ZUlXN2xZN2s2b0pqT3hMbTQ) which contains all the source archives (and also the bindings for Ruby, Python, etc.) but that isn't reliable enough to check for versions. There's also a [SourceForge](https://sourceforge.net/projects/mecab) project but that hasn't been updated since 2009, and has only the Windows executables and bindings.

The alternative is to use the Debian index page (https://deb.debian.org/debian/pool/main/m/mecab/), or skip livecheck for the formula. Thoughts, @samford?