### PR TITLE
flac: add livecheckable

### DIFF
--- a/Livecheckables/flac.rb
+++ b/Livecheckables/flac.rb
@@ -1,0 +1,6 @@
+class Flac
+  livecheck do
+    url "https://downloads.xiph.org/releases/flac/"
+    regex(/href=.*?flac-v?(\d+(?:\.\d+)+)\.t/)
+  end
+end


### PR DESCRIPTION
The default check for `flac` looks at the Git repo tags but https://gitlab.xiph.org/xiph/flac.git doesn't have a tag for the latest release (1.3.3). This adds a livecheckable to check the first-party release index (which is currently redirecting to [the release index at the OSU Open Source Lab](https://ftp.osuosl.org/pub/xiph/releases/flac/)).