### PR TITLE
readline: add livecheckable

### DIFF
--- a/Livecheckables/readline.rb
+++ b/Livecheckables/readline.rb
@@ -1,0 +1,6 @@
+class Readline
+  livecheck do
+    url "http://ravenports.ironwolf.systems/catalog/bucket_2D/readline/standard/"
+    regex(%r{<td id="pkgversion">v?(\d+(?:\.\d+)+)(?:_\d+)?</td>})
+  end
+end


### PR DESCRIPTION
Output before:
```
-bash-5.0.17- /Users/miccal (28) [> brew livecheck readline
readline (guessed) : 8.0.4 ==> 8.0
```
Output after:
```
-bash-5.0.17- /Users/miccal (28) [> brew livecheck readline
readline : 8.0.4 ==> 8.0.4
```
Inspired by https://github.com/Homebrew/homebrew-livecheck/pull/808 and discussion [here](https://github.com/Homebrew/homebrew-livecheck/issues/806), as `readline` is like `bash` with its versions and patches.