### PR TITLE
liblqr: add livecheckable

### DIFF
--- a/Livecheckables/liblqr.rb
+++ b/Livecheckables/liblqr.rb
@@ -1,0 +1,5 @@
+class Liblqr
+  livecheck do
+    url "https://github.com/carlobaldassi/liblqr.git"
+  end
+end


### PR DESCRIPTION
Output before:
```
-bash-5.0.17- /Users/miccal (28) [> brew livecheck liblqr
liblqr (guessed) : 0.4.2 ==> 0.4.1
```
Output after:
```
-bash-5.0.17- /Users/miccal (28) [> brew livecheck liblqr
liblqr : 0.4.2 ==> 0.4.2
```
I noticed on the `homepage` for `liblqr` an [announcement concerning code hosting being moved to GitHub](http://liblqr.wikidot.com/forum/t-905211/code-hosting-moved-to-github) and assumed the `heuristic` would take care of the rest.