### PR TITLE
cataclysm: add url and update regex

### DIFF
--- a/Livecheckables/cataclysm.rb
+++ b/Livecheckables/cataclysm.rb
@@ -1,5 +1,6 @@
 class Cataclysm
   livecheck do
-    regex(/^(\d+(\.(?:\d+|[A-Z]+))+)$/)
+    url "https://github.com/CleverRaven/Cataclysm-DDA/releases/latest"
+    regex(%r{href=.*?/tag/([^"'>]+)["'>]}i)
   end
 end


### PR DESCRIPTION
Typically,`cataclysm` releases follow a `0.1`, `0.7.1`, or `0.E` format, where the minor version rolls over to letters after 9. [It could be hexadecimal but we haven't hit a minor version of 18 yet to find out.] Recent `cataclysm` releases also introduce a `0.E-2` format, where the `-2` is a point release.

Instead of updating the existing regex to match this additional version format when checking Git tags, I've simply reworked this livecheckable to check the "latest" release on GitHub. The way I've written the regex is loose enough that it will match any additional version formats that we encounter in the future.

Checking the "latest" GitHub release also avoids the version comparison issue that we discussed in #510 (i.e., number versions like `0.9` appearing as newer than letter versions like `0.E`). I won't get around to addressing the underlying version comparison issue for some time, so this improves the situation for the interim time, at least.