### PR TITLE
Update name used for list of items to skip

### DIFF
--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -1,4 +1,4 @@
-GNOME_DEVEL_WHITELIST = [
+GNOME_DEVEL_SKIP_LIST = [
   "gcab",
   "gtk-doc",
   "gtk-mac-integration",
@@ -81,7 +81,7 @@ def gnome_strategy(url, regex = nil)
   puts "Possible GNOME package [#{package}] detected at #{url}" if Homebrew.args.debug?
 
   # Restrict versions to even numbered minor versions (except x.90+)
-  regex ||= if GNOME_DEVEL_WHITELIST.include?(package)
+  regex ||= if GNOME_DEVEL_SKIP_LIST.include?(package)
     /#{Regexp.escape(package)}-(\d+(?:\.\d+)+)\.t/
   else
     /#{Regexp.escape(package)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/


### PR DESCRIPTION
This updates the variable name for the list of GNOME formulae to skip (based on the package name) to `GNOME_DEVEL_SKIP_LIST`, which better explains the purpose of the constant but also avoids language that may reduce inclusivity or cause harm in some way.