### PR TITLE
Update language used for GNOME_DEVEL list (again)

### DIFF
--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -1,4 +1,4 @@
-GNOME_DEVEL_SKIP_LIST = [
+GNOME_DEVEL_ALLOWLIST = [
   "gcab",
   "gtk-doc",
   "gtk-mac-integration",
@@ -81,7 +81,7 @@ def gnome_strategy(url, regex = nil)
   puts "Possible GNOME package [#{package}] detected at #{url}" if Homebrew.args.debug?
 
   # Restrict versions to even numbered minor versions (except x.90+)
-  regex ||= if GNOME_DEVEL_SKIP_LIST.include?(package)
+  regex ||= if GNOME_DEVEL_ALLOWLIST.include?(package)
     /#{Regexp.escape(package)}-(\d+(?:\.\d+)+)\.t/
   else
     /#{Regexp.escape(package)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/


### PR DESCRIPTION
Thinking about this some more after #812, `GNOME_DEVEL_ALLOWLIST` makes more sense than `GNOME_DEVEL_SKIP_LIST`, since the list is for formulae (based on GNOME package name) that don't use the GNOME version scheme (and shouldn't use the more restrictive regex). Naming this in a way that describes the purpose well is kind of tricky, so this will work for now.

Pardon the PRs/commits one after another, due to my indecisiveness about variable naming.