### PR TITLE
agda: add livecheckable

### DIFF
--- a/Livecheckables/agda.rb
+++ b/Livecheckables/agda.rb
@@ -1,0 +1,5 @@
+class Agda
+  livecheck do
+    url :stable
+  end
+end


### PR DESCRIPTION
The default check for `agda` looks for versions in the Git repo tags but there are a number of tags that we don't want to match. It's possible to add a livecheckable with a regex to only match tags like `1_2_3`, `v1.2.3`, or `v1.2.3.4` (not `1.2.3.20200607`).

However, the formula's stable archive comes from Hackage, so it's better to simply create a livecheckable that checks the stable URL instead.

Closes #814.