### PR TITLE
a52dec: add special case, update url and regex

### DIFF
--- a/Livecheckables/a52dec.rb
+++ b/Livecheckables/a52dec.rb
@@ -1,6 +1,6 @@
 class A52dec
   livecheck do
-    url "http://liba52.sourceforge.net"
-    regex(/a52dec-(\d+(?:\.\d+)+)/)
+    url "http://liba52.sourceforge.net/downloads.html"
+    regex(/href=.*?a52dec-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -34,6 +34,7 @@ SOURCEFORGE_SPECIAL_CASES = %w[
   /bashdb/
   /netpbm/
   opencore-amr
+  liba52.sourceforge.net/
 ].freeze
 
 def preprocess_url(url)


### PR DESCRIPTION
The existing livecheckable for `a52dec` defaults to the SourceForge strategy but isn't a compatible URL, so it's one of the few existing livecheckables that's broken.

This adds `liba52.sourceforge.net/` to the `SOURCEFORGE_SPECIAL_CASES` array (so the SourceForge strategy isn't used for that subdomain) and adds a livecheckable to check the first-party downloads page.