### PR TITLE
heuristic: move version_rejections out of function

### DIFF
--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -37,6 +37,17 @@ SOURCEFORGE_SPECIAL_CASES = %w[
   liba52.sourceforge.net/
 ].freeze
 
+UNSTABLE_VERSION_KEYWORDS = %w[
+  alpha
+  beta
+  bpo
+  dev
+  experimental
+  prerelease
+  preview
+  rc
+].freeze
+
 def preprocess_url(url)
   # Check for GitHub repos on github.com, not AWS
   url.sub!("github.s3.amazonaws.com", "github.com") if url.include?("github")
@@ -104,23 +115,12 @@ def version_heuristic(livecheckable, urls, regex = nil)
 
     match_version_map = Symbol.send(method, url, regex)
 
-    version_rejections = %w[
-      alpha
-      beta
-      bpo
-      dev
-      experimental
-      prerelease
-      preview
-      rc
-    ].freeze
-
     empty_version = Version.new("")
     match_version_map.delete_if do |_match, version|
       next true if version == empty_version
       next false if livecheckable
 
-      version_rejections.any? do |rejection|
+      UNSTABLE_VERSION_KEYWORDS.any? do |rejection|
         version.to_s.include?(rejection)
       end
     end


### PR DESCRIPTION
I moved most frozen arrays out of functions in previous PRs, so they're not allocated when the function is called. The only remaining array like this was `version_rejections` in the `version_heuristic` function.

This moves the array outside of the function and renames it to `UNSTABLE_VERSION_KEYWORDS` to reflect that it's a constant and better explain its purpose.