### PR TITLE
openjdk: add livecheckable

### DIFF
--- a/Livecheckables/openjdk.rb
+++ b/Livecheckables/openjdk.rb
@@ -1,0 +1,6 @@
+class Openjdk
+  livecheck do
+    url "http://hg.openjdk.java.net/jdk-updates/jdk14u/tags"
+    regex(/jdk-v?(\d+(?:\.\d+)+(?:\+\d+|-ga)?)/i)
+  end
+end


### PR DESCRIPTION
Adding a Livecheckable for `openjdk` using http://hg.openjdk.java.net/jdk-updates/jdk13u/tags; the regex probably needs changes.