### PR TITLE
algol68g: add livecheckable

### DIFF
--- a/Livecheckables/algol68g.rb
+++ b/Livecheckables/algol68g.rb
@@ -1,4 +1,8 @@
 class Algol68g
+  # The homepage hasn't been updated for the latest release (2.8.5), even though
+  # the related archive is available on the site. Until the website is updated
+  # (and seems like it will continue to be updated for new releases), we're
+  # checking a third-party source for new releases as an interim solution.
   livecheck do
     url "https://openports.se/lang/algol68g"
     regex(/href=.*?algol68g-v?(\d+(?:\.\d+)+)\.t/i)

--- a/Livecheckables/algol68g.rb
+++ b/Livecheckables/algol68g.rb
@@ -1,0 +1,6 @@
+class Algol68g
+  livecheck do
+    url "https://openports.se/lang/algol68g"
+    regex(/href=.*?algol68g-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
The `homepage` doesn't list the version available in homebrew-core (2.8.5) and only some Linux distributions seemed to be using this version. The source for this version is however, downloadable from the `homepage`.

I've created this Livecheckable using a URL from OpenBSD instead, as it's the only thing I found which we could check reliably.