### PR TITLE
pstree: add livecheckable

### DIFF
--- a/Livecheckables/pstree.rb
+++ b/Livecheckables/pstree.rb
@@ -1,0 +1,6 @@
+class Pstree
+  livecheck do
+    url "http://www.thp.uni-duisburg.de/pstree/README"
+    regex(/This is pstree V (\d+(?:\.\d+)+)/i)
+  end
+end


### PR DESCRIPTION
The website http://www.thp.uni-duisburg.de/pstree/ is very minimal and the source file linked to doesn't have a version in the name. The alternative (which I've used) is to check the README at http://www.thp.uni-duisburg.de/pstree/README which lists the correct version.

Maybe not the best way to deal with this though, any suggestions?