### PR TITLE
git-crypt: add livecheckable

### DIFF
--- a/Livecheckables/git-crypt.rb
+++ b/Livecheckables/git-crypt.rb
@@ -1,0 +1,6 @@
+class GitCrypt
+  livecheck do
+    url "https://github.com/AGWA/git-crypt.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+end

--- a/Livecheckables/git-crypt.rb
+++ b/Livecheckables/git-crypt.rb
@@ -1,6 +1,6 @@
 class GitCrypt
   livecheck do
-    url "https://github.com/AGWA/git-crypt.git"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url :homepage
+    regex(/href=.*?git-crypt-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
Adding Livecheckable for `git-crypt`. Using their GitHub repository rather than the homepage.