### PR TITLE
libcaca: add livecheckable

### DIFF
--- a/Livecheckables/libcaca.rb
+++ b/Livecheckables/libcaca.rb
@@ -1,0 +1,6 @@
+class Libcaca
+  livecheck do
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+(?:\.beta\d+)?)$/i)
+  end
+end

--- a/Livecheckables/libcaca.rb
+++ b/Livecheckables/libcaca.rb
@@ -1,6 +1,11 @@
 class Libcaca
+  # The regex here matches unstable releases and is loose about it (`.*`), as
+  # there are currently only beta releases and we don't know if there will be
+  # releases candidates, etc. before there's a stable release. Hopefully we can
+  # restrict this to stable releases in the future but it has to be loose for
+  # the moment.
   livecheck do
     url :head
-    regex(/^v?(\d+(?:\.\d+)+(?:\.beta\d+)?)$/i)
+    regex(/^v?(\d+(?:\.\d+)+.*)/i)
   end
 end


### PR DESCRIPTION
Adding Livecheckable for `libcaca` using `:head`. The homebrew-core Formula is for a `beta` version so I've allowed for matching of those tags in the `regex`.