### PR TITLE
qhull: add livecheckable

### DIFF
--- a/Livecheckables/qhull.rb
+++ b/Livecheckables/qhull.rb
@@ -1,0 +1,6 @@
+class Qhull
+  livecheck do
+    url "https://github.com/qhull/qhull.git"
+    regex(/^v?(\d{4}(?:\.\d+)+)$/i)
+  end
+end

--- a/Livecheckables/qhull.rb
+++ b/Livecheckables/qhull.rb
@@ -1,6 +1,6 @@
 class Qhull
   livecheck do
-    url "https://github.com/qhull/qhull.git"
+    url :head
     regex(/^v?(\d{4}(?:\.\d+)+)$/i)
   end
 end


### PR DESCRIPTION
Adding Livecheckable for `qhull`. I match only the `year.version` versions like `2020.1` (current latest) or `2009.1.1`. Here's their GitHub repo (https://github.com/qhull/qhull), if there are any changes to make, let me know!