### PR TITLE
qca: add livecheckable

### DIFF
--- a/Livecheckables/qca.rb
+++ b/Livecheckables/qca.rb
@@ -1,0 +1,6 @@
+class Qca
+  livecheck do
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
The default check for `qca` checks the Git tags in the HEAD repo but there are also tags like `kde4.5` which result in livecheck reporting `4.5` as the latest version instead of `2.3.0`. This adds a livecheckable which restricts matching to versions like `v2.3.0`.

The check is also currently warning about a redirection (`warning: redirecting to https://invent.kde.org/libraries/qca.git/`) and this is being addressed in Homebrew/homebrew-core#56258.