### PR TITLE
jed: add livecheckable

### DIFF
--- a/Livecheckables/jed.rb
+++ b/Livecheckables/jed.rb
@@ -1,0 +1,6 @@
+class Jed
+  livecheck do
+    url "https://www.jedsoft.org/releases/jed/"
+    regex(/href=.*?jed.?v?(\d+(?:\.\d+)+(?:-\d+)?)\.t/i)
+  end
+end


### PR DESCRIPTION
Livecheck checks the Git repo tags for `jed` and successfully finds the latest version (0.99-19), granted it's the only version in the tags. The Git repo is accessed over the insecure `git://` protocol, which we want to avoid if an `https` source is available.

The first-party [releases index page](https://www.jedsoft.org/releases/jed/) can be accessed over HTTPS and it's also where the stable archive comes from, so this adds a livecheckable to check this instead.