### PR TITLE
mikutter: add livecheckable

### DIFF
--- a/Livecheckables/mikutter.rb
+++ b/Livecheckables/mikutter.rb
@@ -1,0 +1,6 @@
+class Mikutter
+  livecheck do
+    url "https://mikutter.hachune.net/download"
+    regex(/href=.*?mikutter.?v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
Livecheck checks the Git repo tags for `mikutter` and successfully finds the latest version (4.0.5). However, the Git repo is accessed over the insecure `git://` protocol, which we want to avoid if an `https` source is available.

The [first-party download page](https://mikutter.hachune.net/download) can be accessed over HTTPS and it's also where the stable archive comes from, so this adds a livecheckable to check this instead.