### PR TITLE
git-annex: add livecheckable

### DIFF
--- a/Livecheckables/git-annex.rb
+++ b/Livecheckables/git-annex.rb
@@ -1,0 +1,5 @@
+class GitAnnex
+  livecheck do
+    url :stable
+  end
+end


### PR DESCRIPTION
By default, livecheck checks the Git repo for `git-annex` and successfully finds the latest version (8.20200522). However, the Git repo is accessed over the insecure `git://` protocol, which we want to avoid if an `https` source is available.

The formula uses a stable archive from Hackage, so this simply adds a livecheckable with `url :stable` to check that URL instead (as this is over HTTPS).