### PR TITLE
monkeysphere: add livecheckable

### DIFF
--- a/Livecheckables/monkeysphere.rb
+++ b/Livecheckables/monkeysphere.rb
@@ -1,0 +1,6 @@
+class Monkeysphere
+  livecheck do
+    url "https://deb.debian.org/debian/pool/main/m/monkeysphere/"
+    regex(/href=.*?monkeysphere.?v?(\d+(?:\.\d+)+)(?:\.orig)?\.t/i)
+  end
+end


### PR DESCRIPTION
Livecheck checks the Git repo tags for `monkeysphere` and successfully finds the latest version (0.44). However, the Git repo is accessed over the insecure `git://` protocol, which we want to avoid if an `https` source is available.

The formula uses an archive from Debian, presumably because it uses HTTPS and the first-party website has an expired certificate. This adds a livecheckable that checks the [Debian index page](https://deb.debian.org/debian/pool/main/m/monkeysphere/) where the stable archive is found, as it's accessible over HTTPS.