### PR TITLE
media-info: add livecheckable

### DIFF
--- a/Livecheckables/media-info.rb
+++ b/Livecheckables/media-info.rb
@@ -1,6 +1,6 @@
 class MediaInfo
   livecheck do
-    url "https://old.mediaarea.net/download/binary/mediainfo/"
-    regex(/href=.*?v?(\d+(?:\.\d+)+)/i)
+    url "https://mediaarea.net/download/binary/mediainfo/"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?[ '">]}i)
   end
 end

--- a/Livecheckables/media-info.rb
+++ b/Livecheckables/media-info.rb
@@ -1,0 +1,6 @@
+class MediaInfo
+  livecheck do
+    url "https://old.mediaarea.net/download/binary/mediainfo/"
+    regex(/href=.*?v?(\d+(?:\.\d+)+)/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `media-info`. The Formula's `url` gives an idea of where all the sources may be listed, and it redirects to the `old.` subdomain. The main website (`homepage`) has a project page and a section dedicated to macOS versions of the project, but it lists only one version (the current latest `20.03`).

The link to the page is https://mediaarea.net/en/MediaInfo/Download/Mac_OS and the download URL given is https://mediaarea.net/download/binary/mediainfo/20.03/MediaInfo_CLI_20.03_Mac.dmg (the URL is very similar to the one in the Formula, except for the `dmg` being downloaded instead).

If the latter is preferred, I'll update the Livecheckable's URL.