### PR TITLE
libelf: add livecheckable to skip

### DIFF
--- a/Livecheckables/libelf.rb
+++ b/Livecheckables/libelf.rb
@@ -1,0 +1,5 @@
+class Libelf
+  livecheck do
+    skip "Not actively developed or maintained"
+  end
+end

--- a/Livecheckables/libelf.rb
+++ b/Livecheckables/libelf.rb
@@ -1,5 +1,11 @@
 class Libelf
+  # The formula uses archive.org for the homepage and a mirrored version of the
+  # last available archive. There seems to be some newer development in the
+  # ELF Tool Chain project (https://sourceforge.net/p/elftoolchain/wiki/Home/)
+  # but they don't create separate libelf releases. Altogether, there's nothing
+  # we can currently check for a new version, so we're skipping this until
+  # something changes.
   livecheck do
-    skip "Not actively developed or maintained"
+    skip "No version information available to check"
   end
 end


### PR DESCRIPTION
Adding Livecheckable to skip livecheck for `libelf`. The last release was in 2009 and the homebrew-core Formula uses a WayBack Machine URL as the website has been down for a while.

There seems to be a related project called `elftools` which is being developed and `libelf` is a part of it. However, that doesn't have a Formula and I think skipping this seems to be the best way forward.

The skip message _probably_ needs work though. Or a comment.
