### PR TITLE
kde-extra-cmake-modules: add livecheckable

### DIFF
--- a/Livecheckables/kde-extra-cmake-modules.rb
+++ b/Livecheckables/kde-extra-cmake-modules.rb
@@ -1,0 +1,6 @@
+class KdeExtraCmakeModules
+  livecheck do
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
The default check for `kde-extra-cmake-modules` checks the Git repo tags but it picks up at least one tag that we don't want (`plasma2tp`). The check works fine for now but this adds a livecheckable to restrict matching to versions like `v1.2.3`, so we don't inadvertently match an undesirable tag in the future.