### PR TITLE
sdl: update regex

### DIFF
--- a/Livecheckables/sdl.rb
+++ b/Livecheckables/sdl.rb
@@ -1,6 +1,6 @@
 class Sdl
   livecheck do
     url "https://www.libsdl.org/release/"
-    regex(/href=.*?SDL-v?(1(?:\.\d+)+)\.t/i)
+    regex(/href=.*?SDL-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
As seen in #833, apparently parts of SDL (that is, not SDL2) can go above a major version of 1. I thought it was appropriate to restrict matching for the `sdl` livecheckable to a major version of 1 but apparently that may not be the right way to go.

Restricting to a major version of 1 isn't necessary to match the correct versions and was simply a "better safe than sorry" approach, so it's fine to just use `\d+` like we normally do.