### PR TITLE
avrdude: add livecheckable

### DIFF
--- a/Livecheckables/avrdude.rb
+++ b/Livecheckables/avrdude.rb
@@ -1,0 +1,6 @@
+class Avrdude
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/avrdude/"
+    regex(/href=.*?avrdude-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -21,6 +21,7 @@ GNU_SPECIAL_CASES = %w[
   numdiff
   icoutils
   dvdrtools
+  avrdude
 ].freeze
 
 SOURCEFORGE_SPECIAL_CASES = %w[


### PR DESCRIPTION
Adding livecheckable for `avrdude`, and adding it to the special cases for GNU urls.