### PR TITLE
Improve debug and JSON output

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -175,19 +175,24 @@ module Homebrew
 
     if is_outdated || !Homebrew.args.newer_only?
       if Homebrew.args.json?
-        return {
+        json_hash = {
           "formula" => formula_name(formula),
           "version" => {
             "current"             => current.to_s,
             "latest"              => latest.to_s,
             "outdated"            => is_outdated,
             "newer_than_upstream" => is_newer_than_upstream,
-            "livecheckable"       => formula.livecheckable?,
-            "head"                => !formula.stable?,
           },
         }
+
+        if Homebrew.args.verbose?
+          json_hash["head"] = !formula.stable?
+          json_hash["livecheckable"] = formula.livecheckable?
+        end
+
+        return json_hash
       else
-        formula_s += " (guessed)" unless formula.livecheckable?
+        formula_s += " (guessed)" if !formula.livecheckable? && Homebrew.args.verbose?
         current_s =
           if is_newer_than_upstream
             "#{Tty.red}#{current}#{Tty.reset}"

--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -44,6 +44,14 @@ module Homebrew
   def livecheck
     livecheck_args.parse
 
+    if Homebrew.args.debug? && Homebrew.args.verbose?
+      puts ARGV
+      puts Homebrew.args
+      puts ENV["HOMEBREW_LIVECHECK_WATCHLIST"]
+      puts Pathname.new(File.expand_path(__dir__)).basename
+      puts $LOAD_PATH
+    end
+
     if (cmd = Homebrew.args.named.first)
       require?("livecheck/commands/#{cmd}") && return
     end

--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -41,20 +41,8 @@ module Homebrew
     end
   end
 
-  def formula_name(formula)
-    Homebrew.args.full_name? ? formula.full_name : formula
-  end
-
   def livecheck
     livecheck_args.parse
-
-    if Homebrew.args.debug?
-      puts ARGV
-      puts Homebrew.args
-      puts ENV["HOMEBREW_LIVECHECK_WATCHLIST"]
-      puts Pathname.new(File.expand_path(__dir__)).basename
-      puts $LOAD_PATH
-    end
 
     if (cmd = Homebrew.args.named.first)
       require?("livecheck/commands/#{cmd}") && return
@@ -84,12 +72,22 @@ module Homebrew
       end
     return unless formulae_to_check
 
-    formulae_checked = formulae_to_check.sort.map do |formula|
+    formulae_checked = formulae_to_check.sort.map.with_index do |formula, i|
+      puts "\n----------\n" if Homebrew.args.debug? && i.positive?
       print_latest_version formula
     rescue => e
-      onoe "#{Tty.blue}#{formula_name(formula)}#{Tty.reset}: #{e}" unless Homebrew.args.quiet?
       Homebrew.failed = true
-      nil
+
+      if Homebrew.args.json?
+        {
+          "formula"  => formula_name(formula),
+          "status"   => "error",
+          "messages" => [e.to_s],
+        }
+      elsif !Homebrew.args.quiet?
+        onoe "#{Tty.blue}#{formula_name(formula)}#{Tty.reset}: #{e}"
+        nil
+      end
     end
 
     puts JSON.generate(formulae_checked.compact) if Homebrew.args.json?
@@ -97,37 +95,75 @@ module Homebrew
 
   def print_latest_version(formula)
     if formula.to_s.include?("@") && !formula.livecheckable?
-      puts "#{Tty.red}#{formula_name(formula)}#{Tty.reset} : versioned" unless Homebrew.args.quiet?
-      return
+      if Homebrew.args.json?
+        return {
+          "formula" => formula_name(formula),
+          "status"  => "versioned",
+        }
+      elsif !Homebrew.args.quiet?
+        puts "#{Tty.red}#{formula_name(formula)}#{Tty.reset} : versioned"
+        return
+      end
     end
 
     if !formula.stable? && !formula.any_version_installed?
-      unless Homebrew.args.quiet?
+      if Homebrew.args.json?
+        return {
+          "formula"  => formula_name(formula),
+          "status"   => "error",
+          "messages" => [
+            "HEAD only formula must be installed to be livecheckable",
+          ],
+        }
+      elsif !Homebrew.args.quiet?
         puts "#{Tty.red}#{formula_name(formula)}#{Tty.reset} : " \
           "HEAD only formula must be installed to be livecheckable"
+        return
       end
-      return
     end
 
     is_gist = formula.stable&.url&.include?("gist.github.com")
     if formula.livecheck.skip? || is_gist
       skip_msg = if formula.livecheck.skip_msg.is_a?(String) &&
                     !formula.livecheck.skip_msg.blank?
-        " - #{formula.livecheck.skip_msg}"
+        formula.livecheck.skip_msg.to_s
       elsif is_gist
-        " - Stable URL is a GitHub Gist"
+        "Stable URL is a GitHub Gist"
       else
         ""
       end
 
-      puts "#{Tty.red}#{formula_name(formula)}#{Tty.reset} : skipped#{skip_msg}" unless Homebrew.args.quiet?
-      return
+      if Homebrew.args.json?
+        json_hash = {
+          "formula" => formula_name(formula),
+          "status"  => "skipped",
+        }
+        json_hash["messages"] = [skip_msg] unless skip_msg.nil? || skip_msg.empty?
+        return json_hash
+      elsif !Homebrew.args.quiet?
+        puts "#{Tty.red}#{formula_name(formula)}#{Tty.reset} : skipped" \
+             "#{" - #{skip_msg}" unless skip_msg.empty?}"
+        return
+      end
     end
 
     formula.head.downloader.shutup! unless formula.stable?
 
     current = formula.stable? ? formula.version : formula.installed_version.version.commit
     latest = formula.stable? ? latest_version(formula) : formula.head.downloader.fetch_last_commit
+
+    if latest.nil?
+      if Homebrew.args.json?
+        return {
+          "formula"  => formula_name(formula),
+          "status"   => "error",
+          "messages" => ["Unable to get versions"],
+        }
+      else
+        raise TypeError, "Unable to get versions"
+      end
+    end
+
     if (m = latest.to_s.match(/(.*)-release$/)) && !current.to_s.match(/.*-release$/)
       latest = Version.new(m[1])
     end
@@ -142,12 +178,12 @@ module Homebrew
         return {
           "formula" => formula_name(formula),
           "version" => {
-            "current"                => current.to_s,
-            "latest"                 => latest.to_s,
-            "is_outdated"            => is_outdated,
-            "is_newer_than_upstream" => is_newer_than_upstream,
-            "guessed"                => !formula.livecheckable?,
-            "head"                   => !formula.stable?,
+            "current"             => current.to_s,
+            "latest"              => latest.to_s,
+            "outdated"            => is_outdated,
+            "newer_than_upstream" => is_newer_than_upstream,
+            "livecheckable"       => formula.livecheckable?,
+            "head"                => !formula.stable?,
           },
         }
       else

--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -208,9 +208,5 @@ module Homebrew
         puts "#{formula_s} : #{current_s} ==> #{latest_s}"
       end
     end
-
-    if is_newer_than_upstream && Homebrew.args.verbose?
-      opoo "#{formula_s} version is greater than the upstream version"
-    end
   end
 end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -89,6 +89,7 @@ def latest_version(formula)
 
   if Homebrew.args.debug?
     puts "Formula:         #{formula_name(formula)}"
+    puts "Head only?:      #{!formula.stable?}" unless formula.stable?
     puts "Livecheckable?:  #{has_livecheckable ? "Yes" : "No"}"
   end
 

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -154,7 +154,22 @@ def latest_version(formula)
 
     next if match_version_map.empty?
 
-    return Version.new(match_version_map.values.max)
+    version_info = {
+      "latest" => Version.new(match_version_map.values.max),
+    }
+
+    if Homebrew.args.json? && Homebrew.args.verbose?
+      version_info["meta"] = {
+        "url"      => {
+          "original" => original_url,
+        },
+        "strategy" => strategy.nil? ? nil : strategy.to_s.delete_suffix("_strategy"),
+      }
+      version_info["meta"]["url"]["processed"] = url if url != original_url
+      version_info["meta"]["regex"] = livecheck_regex.inspect unless livecheck_regex.nil?
+    end
+
+    return version_info
   end
 
   nil

--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -42,8 +42,6 @@ def bitbucket_strategy(url, regex = nil)
 end
 
 def git_strategy(url, regex = nil)
-  puts "Possible git repo detected at #{url}" if Homebrew.args.debug?
-
   match_version_map = {}
 
   tags = git_tags(url, regex)
@@ -79,8 +77,6 @@ def gnome_strategy(url, regex = nil)
   package = url.match(%r{/sources/(.*?)/})[1]
   page_url = "https://download.gnome.org/sources/#{package}/cache.json"
 
-  puts "Possible GNOME package [#{package}] detected at #{url}" if Homebrew.args.debug?
-
   # Restrict versions to even numbered minor versions (except x.90+)
   regex ||= if GNOME_DEVEL_ALLOWLIST.include?(package)
     /#{Regexp.escape(package)}-(\d+(?:\.\d+)+)\.t/
@@ -107,13 +103,11 @@ def gnu_strategy(url, regex = nil)
     url.match(r)
   end.compact
 
-  puts "Multiple project names found: #{match_list}" if match_list.length > 1
+  puts "Multiple project names found: #{match_list}" if match_list.length > 1 && Homebrew.args.debug?
 
   unless match_list.empty?
     project_name = match_list[0][1]
     page_url = "http://ftp.gnu.org/gnu/#{project_name}/?C=M&O=D"
-
-    puts "Possible GNU project [#{project_name}] detected at #{url}" if Homebrew.args.debug?
 
     regex ||= /#{project_name}-(\d+(?:\.\d+)*)/
 
@@ -204,13 +198,10 @@ def sourceforge_strategy(url, regex = nil)
   end
   page_url = "https://sourceforge.net/projects/#{project_name}/rss"
 
-  puts "Possible SourceForge project [#{project_name}] detected at #{url}" if Homebrew.args.debug?
-
   regex ||= %r{url=.+?/#{project_name}/files/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i
 
   page_matches(page_url, regex).each do |match|
     version = Version.new(match)
-    # puts "#{match} => #{version.inspect}" if Homebrew.args.debug?
     match_version_map[match] = version
   end
 

--- a/livecheck/utils.rb
+++ b/livecheck/utils.rb
@@ -12,6 +12,10 @@ def checkable_urls(formula)
   urls.compact
 end
 
+def formula_name(formula)
+  Homebrew.args.full_name? ? formula.full_name : formula
+end
+
 def git_tags(repo_url, filter = nil)
   raw_tags = `git ls-remote --tags #{repo_url}`
   raw_tags.gsub!(%r{^.*\trefs/tags/}, "")
@@ -23,9 +27,8 @@ def git_tags(repo_url, filter = nil)
 end
 
 def page_matches(url, regex)
-  puts %Q[Using page_match("#{url}", "#{regex}")] if Homebrew.args.debug?
   page = URI.open(url).read
   matches = page.scan(regex)
-  puts matches.join(", ") if Homebrew.args.debug?
+  puts "\nMatched Text on Page:\n", matches.join(", ") if Homebrew.args.debug? && !matches.empty?
   matches.map(&:first).uniq
 end


### PR DESCRIPTION
The debug output includes a mess of information in the beginning that I have never found useful and it's a chore to constantly scroll past it.

More importantly, the debug output doesn't provide enough relevant information about what's happening in livecheck internally. This makes it more difficult than it should be for anyone who isn't intimately familiar with livecheck's behavior to understand what's actually happening in a given check.

Even for people who spend a lot of time working with livecheck, not having better debug information means that we have to waste time figuring out what livecheck is doing instead of it being immediately apparent from the debug output.

The main things that this PR does related to improving debug output are:

* Removes the unhelpful glut of information printed at the start of debug output (so we don't have to scroll past it anymore). [If anyone actually finds this information useful, I could comment out these lines instead of removing them, so you can selectively uncomment them as needed.]
* Prints more information about the current check (in addition to the existing list of matched strings and the list of versions)
  * The name of the formula
  * If livecheck is using a livecheckable for this check
  * The URL that's being tried, before any processing
  * The processed URL, if it differs from the original URL
  * The strategy being used for the URL
  * The regex being used from the livecheckable, if provided

With these changes, the output looks something like this:

```
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/a52dec.rb
Loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-livecheck/Livecheckables/a52dec.rb
Formula:         a52dec
Livecheckable?:  Yes

URL:             http://liba52.sourceforge.net/downloads.html
Strategy:        page_match
Regex:           /href=.*?a52dec-(\d+(?:\.\d+)+)\.t/

Matched Text on Page:
0.7.4, 0.7.3, 0.7.2, 0.7.0

Matched Versions:
0.7.4 => #<Version:0x00007fa0fd874c68 @version="0.7.4", @tokens=[#<Version::NumericToken 0>, #<Version::NumericToken 7>, #<Version::NumericToken 4>]>
0.7.3 => #<Version:0x00007fa0fd874c18 @version="0.7.3", @tokens=[#<Version::NumericToken 0>, #<Version::NumericToken 7>, #<Version::NumericToken 3>]>
0.7.2 => #<Version:0x00007fa0fd874b00 @version="0.7.2", @tokens=[#<Version::NumericToken 0>, #<Version::NumericToken 7>, #<Version::NumericToken 2>]>
0.7.0 => #<Version:0x00007fa0fd874a60 @version="0.7.0", @tokens=[#<Version::NumericToken 0>, #<Version::NumericToken 7>, #<Version::NumericToken 0>]>
a52dec : 0.7.4 ==> 0.7.4
```

[I'll be creating a PR to refactor the strategy setup (leading up to the strategy feature PR) and in the process I'll also be expanding the debug output to display the URL and regex used in the strategy, if they differ from what's passed into the strategy. This is useful information but it's easier to implement this after the strategies are refactored into classes.]

---

Past that, this also improves the JSON output a bit. The big issue was that errors and skipped/versioned formulae appeared as normal output before the JSON was printed. This integrates these into the JSON output, which seems to be more in keeping with the intention of the `--json` flag.

* Errors now appear in the JSON output like `{"formula":"acme","errors":["Unable to get versions"]}`
* Versioned formulae now appear in the JSON output like `{"formula":"ansible@2.8","versioned":true}`
* Skipped formulae now appear in the JSON output like `{"formula":"anttweakbar","skipped":true,"skip_msg":"Not maintained"}` (`skip_msg` is omitted if it's not provided)

This is an improvement but there are still some different types of errors that appear before the JSON output that we'll need to address in a different manner. For example:

```
fatal: repository 'https://git.postgresql.org/gitweb/?p=pg_top.git/' not found
warning: redirecting to https://git.b-ehlers.de/ehlers/unyaffs.git/
```

I'll work on this sometime in the future in a follow-up PR, unless someone has a good idea of how to address this. Basically, we want to capture the error and make it available in the JSON output like the other errors (e.g., `"errors":["fatal: repository 'https://git.postgresql.org/gitweb/?p=pg_top.git/' not found"]`).

The end goal is to not have any non-JSON output when the `--json` flag is in use (outside of maybe having a temporary progress indicator in the future that gets wiped out when the JSON is printed at the end).

---

I think this is an improvement overall but please check my work here, test this out for yourself, and leave any feedback about the debug and JSON output here.