### PR TITLE
less: add livecheckable

### DIFF
--- a/Livecheckables/less.rb
+++ b/Livecheckables/less.rb
@@ -1,0 +1,6 @@
+class Less
+  livecheck do
+    url "http://www.greenwoodsoftware.com/less/download.html"
+    regex(%r{<strong>RECOMMENDED</strong> version v?(\d+)}i)
+  end
+end

--- a/Livecheckables/less.rb
+++ b/Livecheckables/less.rb
@@ -1,6 +1,6 @@
 class Less
   livecheck do
-    url "http://www.greenwoodsoftware.com/less/download.html"
-    regex(%r{<strong>RECOMMENDED</strong> version v?(\d+)}i)
+    url :homepage
+    regex(/less-v?(\d+).+?released.+?general use/i)
   end
 end


### PR DESCRIPTION
Adding Livecheckable for `less`. The website also lists a BETA version along with the RECOMMENDED version, and unless we check for the presence of RECOMMENDED, I don't think we can match the latest non-BETA version. (The tarball URLs have no `-beta` or `-rc` for the BETA version and look exactly like a normal version's URLs).