### PR TITLE
oath-toolkit: add livecheckable

### DIFF
--- a/Livecheckables/oath-toolkit.rb
+++ b/Livecheckables/oath-toolkit.rb
@@ -1,0 +1,6 @@
+class OathToolkit
+  livecheck do
+    url "http://download.savannah.nongnu.org/releases/oath-toolkit/"
+    regex(/href=.*?oath-toolkit-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -22,6 +22,7 @@ GNU_SPECIAL_CASES = %w[
   icoutils
   dvdrtools
   avrdude
+  oath-toolkit
 ].freeze
 
 SOURCEFORGE_SPECIAL_CASES = %w[


### PR DESCRIPTION
Adding Livecheckable for `oath-toolkit`, and also adding it to `GNU_SPECIAL_CASES`.

With the addition of this, all Formulae with >10000 downloads in the last 365 days (except versioned ones) should _probably_ have working `livecheck`s.