### PR TITLE
Add completion for livecheck

### DIFF
--- a/completions/bash/brew-livecheck
+++ b/completions/bash/brew-livecheck
@@ -1,0 +1,20 @@
+_brew_livecheck() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
+    -*)
+      __brewcomp "--verbose --quiet --debug --full-name --tap --installed --json --all --newer-only --help"
+      return
+      ;;
+  esac
+  __brew_complete_formulae
+}
+
+_brew_with_livecheck() {
+  if [ $COMP_CWORD -gt 1 ] && [ "${COMP_WORDS[1]}" = "livecheck" ] ; then
+    _brew_livecheck
+    return
+  fi
+  _brew
+}
+
+complete -o bashdefault -o default -F _brew_with_livecheck brew

--- a/completions/zsh/_brew_livecheck
+++ b/completions/zsh/_brew_livecheck
@@ -1,0 +1,19 @@
+#compdef brew
+#autoload
+
+_brew_livecheck() {
+  _arguments \
+    '(--verbose,-v)'{--verbose,-v}'[Make some output more verbose]' \
+    '(--quiet,-q)'{--quiet,-q}'[Suppress any warnings]' \
+    '(--debug,-d)'{--debug,-d}'[Display any debugging information]' \
+    '--full-name[Print formulae with fully-qualified name]' \
+    '--tap[Check the formulae within the given tap, specified as user/repo]' \
+    '--installed[Check formulae that are currently installed]' \
+    '--json[Output information in JSON format]' \
+    '--all[Check all available formulae]' \
+    '--newer-only[Show the latest version only if it is newer than the formula]' \
+    '(--help,-h)'{--help,-h}'[Show the help message]' \
+    '*:: :__brew_formulae'
+}
+
+_brew_livecheck "$@"


### PR DESCRIPTION
Adding `bash` and `zsh` completions for `brew livecheck`. Should add `fish` shortly too. The changes here almost resemble those in Homebrew/brew#7748 entirely but with inputs taken from similar PRs in Homebrew/homebrew-services.

To test the `zsh` completion you'll have to use this symlink:
```zsh
ln -s /usr/local/Homebrew/Library/Taps/homebrew/homebrew-livecheck/completions/zsh/_brew_livecheck /usr/local/share/zsh/site-functions/_brew_functions
```

As for `bash`, I just used `source` for the `completions/bash/brew-livecheck` file and tested it.

If the Tap is (re)installed, the symlinks will be created automatically (this will happen only after the PR is merged, obviously).

As for the Homebrew/brew PR, do I let it be or close it and create a new one when it's time to migrate the command?

CC: @samford 