### PR TITLE
vert.x: add livecheckable

### DIFF
--- a/Livecheckables/vert.x.rb
+++ b/Livecheckables/vert.x.rb
@@ -1,0 +1,6 @@
+class VertX
+  livecheck do
+    url "https://vertx.io/download/"
+    regex(/href=.*?vert\.x-v?(\d+(?:\.\d+)+)-full\.t/i)
+  end
+end


### PR DESCRIPTION
Livecheck was unable to find a version by default, so this adds a livecheckable that checks the first-party download page for the latest version.