### PR TITLE
mecab-ipadic: add livecheckable

### DIFF
--- a/Livecheckables/mecab-ipadic.rb
+++ b/Livecheckables/mecab-ipadic.rb
@@ -1,0 +1,9 @@
+class MecabIpadic
+  # We check the Debian index page because the first-party website uses a Google
+  # Drive download URL and doesn't list the version in any other way, so we
+  # can't identify the newest version there.
+  livecheck do
+    url "https://deb.debian.org/debian/pool/main/m/mecab-ipadic/"
+    regex(/href=.*?mecab-ipadic.v?(\d+(?:\.\d+)+(?:-\d+)?)(?:\+main)?\.orig\.t/i)
+  end
+end


### PR DESCRIPTION
The default check for `mecab-ipadic` wasn't able to find any versions, so this adds a livecheckable that checks the Debian index page where the stable archive in the formula is found. Unfortunately we can't check the first-party website for new versions because they use Google Drive download links and the filename isn't listed on the page for this particular software.