### PR TITLE
tnftp: add livecheckable

### DIFF
--- a/Livecheckables/tnftp.rb
+++ b/Livecheckables/tnftp.rb
@@ -1,9 +1,6 @@
 class Tnftp
-  # Apple removed `tnftp` from macOS, after High Sierra (10.13).
-  # The `tnftp` Formula is built using Apple's official tarball
-  # for macOS 10.13. It's safe to assume there won't be any further
-  # updates and so we skip livecheck for this Formula.
   livecheck do
-    skip "No longer included with macOS (since 10.13)"
+    url "https://ftp.netbsd.org/pub/NetBSD/misc/tnftp/"
+    regex(/href=.*?tnftp-v?(\d+)\.t/i)
   end
 end

--- a/Livecheckables/tnftp.rb
+++ b/Livecheckables/tnftp.rb
@@ -1,0 +1,9 @@
+class Tnftp
+  # Apple removed `tnftp` from macOS, after High Sierra (10.13).
+  # The `tnftp` Formula is built using Apple's official tarball
+  # for macOS 10.13. It's safe to assume there won't be any further
+  # updates and so we skip livecheck for this Formula.
+  livecheck do
+    skip "No longer included with macOS (since 10.13)"
+  end
+end


### PR DESCRIPTION
Adding Livecheckable to skip livecheck for `tnftp`. Context: Apple removed `tnftp` from all macOS versions after High Sierra.

If this shouldn't be skipped or there are edits to be made, let me know.