### PR TITLE
rpm2cpio: add livecheckable

### DIFF
--- a/Livecheckables/rpm2cpio.rb
+++ b/Livecheckables/rpm2cpio.rb
@@ -1,0 +1,6 @@
+class Rpm2cpio
+  livecheck do
+    url "https://svnweb.freebsd.org/ports/head/archivers/rpm2cpio/Makefile?view=markup"
+    regex(%r{PORTVERSION=\s*v?(\d+(?:\.\d+)+)</td>}i)
+  end
+end

--- a/Livecheckables/rpm2cpio.rb
+++ b/Livecheckables/rpm2cpio.rb
@@ -1,6 +1,6 @@
 class Rpm2cpio
   livecheck do
-    url "https://svnweb.freebsd.org/ports/head/archivers/rpm2cpio/Makefile?view=markup"
-    regex(%r{PORTVERSION=\s*v?(\d+(?:\.\d+)+)</td>}i)
+    url "https://svnweb.freebsd.org/ports/head/archivers/rpm2cpio/Makefile?view=co"
+    regex(/^PORTVERSION=\s*?v?(\d+(?:\.\d+)+)$/i)
   end
 end


### PR DESCRIPTION
Adding Livecheckable for `rpm2cpio`. In its current form the Livecheckable is probably less than ideal, however I was unable to find alternatives. Any better options?