### PR TITLE
Inline git_tags_only_debian? into git strategy

### DIFF
--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -47,7 +47,7 @@ def git_strategy(url, regex = nil)
   match_version_map = {}
 
   tags = git_tags(url, regex)
-  tags_only_debian = git_tags_only_debian?(tags)
+  tags_only_debian = tags.all? { |tag| tag.start_with?("debian/") }
 
   tags.each do |tag|
     # Move to the next one if tag actually is prefixed with 'debian/'

--- a/livecheck/utils.rb
+++ b/livecheck/utils.rb
@@ -22,14 +22,6 @@ def git_tags(repo_url, filter = nil)
   tags
 end
 
-# Check if upstream only does 'debian/' prefixed tags
-def git_tags_only_debian?(tags)
-  tags.each do |tag|
-    return false unless tag.start_with?("debian/")
-  end
-  true
-end
-
 def page_matches(url, regex)
   puts %Q[Using page_match("#{url}", "#{regex}")] if Homebrew.args.debug?
   page = URI.open(url).read


### PR DESCRIPTION
This is work done by Maxim in #601 but I wanted to avoid modifying the strategies in that PR (to keep it simple), so I removed the change and suggested that we could handle this in a separate PR.

There hasn't been a follow-up PR yet and I will be modifying this part of the Git strategy in another PR shortly, so I wanted to go ahead and incorporate these changes.