### PR TITLE
Make --debug and --json flags mutually exclusive

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -37,6 +37,7 @@ module Homebrew
              description: "Check all available formulae."
       switch "--newer-only",
              description: "Show the latest version only if it's newer than the formula."
+      conflicts "--debug", "--json"
       conflicts "--tap=", "--all", "--installed"
     end
   end


### PR DESCRIPTION
The `--debug` and `--json` flags have different purposes (displaying debug output and outputting JSON, respectively) and shouldn't be executed together. This adds a `conflicts` line to the CLI information to enforce this.