### PR TITLE
sentencepiece: add livecheckable

### DIFF
--- a/Livecheckables/sentencepiece.rb
+++ b/Livecheckables/sentencepiece.rb
@@ -1,6 +1,6 @@
 class Sentencepiece
   livecheck do
-    url "https://github.com/google/sentencepiece.git"
-    regex(/^v(\d+(?:\.\d+)+)$/)
+    url "https://github.com/google/sentencepiece/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["']}i)
   end
 end

--- a/Livecheckables/sentencepiece.rb
+++ b/Livecheckables/sentencepiece.rb
@@ -1,0 +1,6 @@
+class Sentencepiece
+  livecheck do
+    url "https://github.com/google/sentencepiece.git"
+    regex(/^v(\d+(?:\.\d+)+)$/)
+  end
+end


### PR DESCRIPTION
relates to Homebrew/homebrew-core#56614

Update livecheck to exclude `1.0.0` tag

### before the change

```
$ brew livecheck -v sentencepiece
sentencepiece (guessed) : 0.1.91 ==> 1.0.0
```

### after the change

```
$ brew livecheck -v sentencepiece
sentencepiece : 0.1.91 ==> 0.1.92
```