### PR TITLE
mavsdk: add livecheckable

### DIFF
--- a/Livecheckables/mavsdk.rb
+++ b/Livecheckables/mavsdk.rb
@@ -1,6 +1,6 @@
 class Mavsdk
   livecheck do
-    url :satble
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/mavsdk.rb
+++ b/Livecheckables/mavsdk.rb
@@ -1,0 +1,6 @@
+class Mavsdk
+  livecheck do
+    url :satble
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
### before

```
$ brew livecheck -v mavsdk
mavsdk (guessed) : 0.27.0 ==> 9
```

### after

```
$ brew livecheck -v mavsdk
mavsdk : 0.27.0 ==> 0.28.0
```

relates to Homebrew/homebrew-core#56620