### PR TITLE
hfstospell: add livecheckable

### DIFF
--- a/Livecheckables/hfstospell.rb
+++ b/Livecheckables/hfstospell.rb
@@ -1,0 +1,6 @@
+class Hfstospell
+  livecheck do
+    url "https://github.com/hfst/hfst-ospell/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["']}i)
+  end
+end


### PR DESCRIPTION
### before the change

0.5.2 is not the latest release, thus there is no release artifact that we need.

```
curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "hfstospell"
Download failed: https://github.com/hfst/hfst-ospell/releases/download/v0.5.2/hfstospell-0.5.2.tar.gz
```

### after the change

```
$ brew livecheck -v hfstospell
hfstospell : 0.5.1 ==> 0.5.1
```