### PR TITLE
mariadb-connector-c: add livecheckable

### DIFF
--- a/Livecheckables/mariadb-connector-c.rb
+++ b/Livecheckables/mariadb-connector-c.rb
@@ -1,6 +1,6 @@
 class MariadbConnectorC
   livecheck do
-    url "https://github.com/mariadb-corporation/mariadb-connector-c.git"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://downloads.mariadb.org/connector-c/+releases/"
+    regex(%r{href=.*?connector-c/v?(\d+(?:\.\d+)+)/?[ '">]}i)
   end
 end

--- a/Livecheckables/mariadb-connector-c.rb
+++ b/Livecheckables/mariadb-connector-c.rb
@@ -1,0 +1,6 @@
+class MariadbConnectorC
+  livecheck do
+    url "https://github.com/mariadb-corporation/mariadb-connector-c.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `mariadb-connector-c`.