### PR TITLE
cloog: add livecheckable

### DIFF
--- a/Livecheckables/cloog.rb
+++ b/Livecheckables/cloog.rb
@@ -1,0 +1,6 @@
+class Cloog
+  livecheck do
+    url "http://www.bastoul.net/cloog/download.php"
+    regex(/href=.*?cloog-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `cloog`. SSL error on using `https` so using `http` (for now).