### PR TITLE
javacc: add livecheckable

### DIFF
--- a/Livecheckables/javacc.rb
+++ b/Livecheckables/javacc.rb
@@ -1,0 +1,6 @@
+class Javacc
+  livecheck do
+    url "https://github.com/javacc/javacc/releases/latest"
+    regex(%r{href=.+?/tag/javacc-v?(\d+(?:\.\d+)+)}i)
+  end
+end


### PR DESCRIPTION
### before the change

```
$ brew livecheck -v javacc
javacc (guessed) : 7.0.5 ==> 60_61_merge
```

### after the change

```
$ brew livecheck -v javacc
javacc : 7.0.5 ==> 7.0.6
```

relates to Homebrew/homebrew-core#56648