### PR TITLE
foremost: add livecheckable

### DIFF
--- a/Livecheckables/foremost.rb
+++ b/Livecheckables/foremost.rb
@@ -1,0 +1,6 @@
+class Foremost
+  livecheck do
+    url "http://foremost.sourceforge.net/"
+    regex(/href=.*?foremost-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -40,6 +40,7 @@ SOURCEFORGE_SPECIAL_CASES = %w[
   /netpbm/
   opencore-amr
   liba52.sourceforge.net/
+  foremost.sourceforge.net/
 ].freeze
 
 UNSTABLE_VERSION_KEYWORDS = %w[


### PR DESCRIPTION
Using `:homepage` isn't feasible due to the `sourceforge.io` URL redirecting to the `sourceforge.net` URL. We could possibly open a PR in homebrew-core but the `.io` URL is `https` while the `.net` isn't, and I'm not sure that change would be preferred (despite the redirect in the browser too).