### PR TITLE
tnftpd: add livecheckable

### DIFF
--- a/Livecheckables/tnftpd.rb
+++ b/Livecheckables/tnftpd.rb
@@ -1,0 +1,6 @@
+class Tnftpd
+  livecheck do
+    url "https://ftp.netbsd.org/pub/NetBSD/misc/tnftp/"
+    regex(/href=.*?tnftpd-v?(\d+)\.t/i)
+  end
+end


### PR DESCRIPTION
This adds a very similar livecheckable to the recently-added `tnftp`, as these formulae are both found on the same index page. The only difference is the use of the `tnftpd` name in the regex.