### PR TITLE
perl: update livecheckable

### DIFF
--- a/Livecheckables/perl.rb
+++ b/Livecheckables/perl.rb
@@ -1,6 +1,6 @@
 class Perl
   livecheck do
-    url "https://www.perl.org/get.html"
-    regex(%r{href=".*?/perl-([0-9.]+)\.t})
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/perl.rb
+++ b/Livecheckables/perl.rb
@@ -1,6 +1,6 @@
 class Perl
   livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://www.cpan.org/src/"
+    regex(/href=.*?perl-v?(\d+(?:\.\d+)+)\.t/)
   end
 end


### PR DESCRIPTION
Output before:
```
-bash-5.0.17- /Users/miccal (30) [> brew livecheck perl
perl : 5.30.3 ==> 5.30.3
```
Output after:
```
-bash-5.0.17- /Users/miccal (30) [> brew livecheck perl
perl : 5.30.3 ==> 5.32.0
```
I noticed that `livecheck` was not reporting the [latest version](https://github.com/Homebrew/homebrew-core/pull/56701), and I have tried to follow the strategy used in recent PR's.

Thank you (as always).