### PR TITLE
pdflib-lite: add livecheckable to skip

### DIFF
--- a/Livecheckables/pdflib-lite.rb
+++ b/Livecheckables/pdflib-lite.rb
@@ -1,0 +1,7 @@
+class PdflibLite
+  # PDFlib Lite reached its end of life in 2011, and
+  # is no longer supported.
+  livecheck do
+    skip "No longer supported"
+  end
+end

--- a/Livecheckables/pdflib-lite.rb
+++ b/Livecheckables/pdflib-lite.rb
@@ -1,6 +1,5 @@
 class PdflibLite
-  # PDFlib Lite reached its end of life in 2011, and
-  # is no longer supported.
+  # PDFlib Lite reached its end of life in 2011 and is no longer supported.
   livecheck do
     skip "No longer supported"
   end


### PR DESCRIPTION
Adding a livecheckable to skip `pdflib-lite`.

See here: https://www.pdflib.com/products/pdflib-family/overview/?pdfliblite (at the bottom of the page there's a note about the situation)