### PR TITLE
libsvg: add livecheckable

### DIFF
--- a/Livecheckables/libsvg.rb
+++ b/Livecheckables/libsvg.rb
@@ -1,0 +1,6 @@
+class Libsvg
+  livecheck do
+    url "https://cairographics.org/snapshots/"
+    regex(/href=.*?libsvg-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `libsvg`. There is a version marked as `LATEST` but I've not checked that as it could be unreliable (despite the fact that this particular library's version hasn't changed since 2005~).