### PR TITLE
procmail: add livecheckable

### DIFF
--- a/Livecheckables/procmail.rb
+++ b/Livecheckables/procmail.rb
@@ -1,7 +1,8 @@
 class Procmail
-  # We use the patched version obtained from Apple for this
-  # formula, so it is appropriate to check for the version
-  # number supplied by Apple.
+  # Procmail is no longer developed/maintained and the formula uses tarballs
+  # from Apple, so we check this source for new releases. The "version" here is
+  # the numeric portion of the archive name (e.g. 14 for procmail-14.tar.gz)
+  # instead of the actual procmail version.
   livecheck do
     url "https://opensource.apple.com/tarballs/procmail/"
     regex(/href=.*?procmail-v?(\d+(?:\.\d+)*)\.t/i)

--- a/Livecheckables/procmail.rb
+++ b/Livecheckables/procmail.rb
@@ -1,0 +1,9 @@
+class Procmail
+  # We use the patched version obtained from Apple for this
+  # formula, so it is appropriate to check for the version
+  # number supplied by Apple.
+  livecheck do
+    url "https://opensource.apple.com/tarballs/procmail/"
+    regex(/href=.*?procmail-v?(\d+(?:\.\d+)*)\.t/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `procmail`.

We use a WayBack Machine URL as the website `procmail.org` has been down since 2015, probably. The Formula has a comment stating that the Apple-provided patched version is used, and `brew info` lists the version as `stable 14 (bottled)`.

Unless we decide to `skip`, this is probably a good way to check for new versions. Comment could be reworded though.