### PR TITLE
grace: add livecheckable

### DIFF
--- a/Livecheckables/grace.rb
+++ b/Livecheckables/grace.rb
@@ -1,6 +1,6 @@
 class Grace
   livecheck do
     url "https://deb.debian.org/debian/pool/main/g/grace/"
-    regex(/href=.*?grace_v?(\d+(?:\.\d+)+)\.orig\.t/i)
+    regex(/href=.*?grace.v?(\d+(?:\.\d+)+)\.orig\.t/i)
   end
 end

--- a/Livecheckables/grace.rb
+++ b/Livecheckables/grace.rb
@@ -1,0 +1,6 @@
+class Grace
+  livecheck do
+    url "https://deb.debian.org/debian/pool/main/g/grace/"
+    regex(/href=.*?grace_v?(\d+(?:\.\d+)+)\.orig\.t/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `grace`. The `Download` page inked to in the `homepage` is actually an FTP directory, so unless we have the strategy for that, we should check the Debian archives (which we use).