### PR TITLE
libsvm: add livecheckable

### DIFF
--- a/Livecheckables/libsvm.rb
+++ b/Livecheckables/libsvm.rb
@@ -1,6 +1,6 @@
 class Libsvm
   livecheck do
     url :homepage
-    regex(/The current release \(Version v?(\d+(?:\.\d+)+),/i)
+    regex(/The current release \(Version v?(\d+(?:\.\d+)+)[, )]/i)
   end
 end

--- a/Livecheckables/libsvm.rb
+++ b/Livecheckables/libsvm.rb
@@ -1,0 +1,6 @@
+class Libsvm
+  livecheck do
+    url :homepage
+    regex(/The current release \(Version v?(\d+(?:\.\d+)+),/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `libsvm`. Their website has a download link but that does not have the version number in it, and I could only create a Livecheckable by matching text. They have a GitHub repo but the versioning there is done without the `.`s, i.e., `v324` instead of `v3.2.4`.