### PR TITLE
vbindiff: add livecheckable

### DIFF
--- a/Livecheckables/vbindiff.rb
+++ b/Livecheckables/vbindiff.rb
@@ -1,0 +1,6 @@
+class Vbindiff
+  livecheck do
+    url :homepage
+    regex(/href=.*?vbindiff-v?(\d+(?:\.\d+)+(?:_beta\d+)?)\.t/i)
+  end
+end

--- a/Livecheckables/vbindiff.rb
+++ b/Livecheckables/vbindiff.rb
@@ -1,6 +1,6 @@
 class Vbindiff
   livecheck do
     url :homepage
-    regex(/href=.*?vbindiff-v?(\d+(?:\.\d+)+(?:_beta\d+)?)\.t/i)
+    regex(/href=.*?vbindiff-v?(\d+(?:\.\d+)+(?:.?beta\d+)?)\.t/i)
   end
 end


### PR DESCRIPTION
Adding Livecheckable for `vbindiff`. They have a GitHub repo without tags; Homebrew/homebrew-core uses the latest version available which is a beta. Development doesn't seemed to have happened since that release in 2017 (beta 5), before which the latest version seemed to have been released in 2008 (beta 4).