### PR TITLE
ecm: add livecheckable to skip

### DIFF
--- a/Livecheckables/ecm.rb
+++ b/Livecheckables/ecm.rb
@@ -1,0 +1,8 @@
+class Ecm
+  # The first-party website for the formula has been down
+  # since 2014, and it is not possible to reliably check
+  # for newer versions.
+  livecheck do
+    skip "Unable to check for versions"
+  end
+end

--- a/Livecheckables/ecm.rb
+++ b/Livecheckables/ecm.rb
@@ -1,8 +1,7 @@
 class Ecm
-  # The first-party website for the formula has been down
-  # since 2014, and it is not possible to reliably check
-  # for newer versions.
+  # The first-party web page was been missing since 2014, so we can't check for
+  # new versions and the developer doesn't seem to be actively working on this.
   livecheck do
-    skip "Unable to check for versions"
+    skip "No available sources to check for versions"
   end
 end


### PR DESCRIPTION
Adding a livecheckable to skip `ecm`.

The creator's website (http://neillcorlett.com) shows a message stating that the website has been "down" since 2014 (they're taking a break, according to a post of theirs [elsewhere](https://www.reddit.com/r/retrogaming/comments/6zbgly/does_anyone_know_what_happened_to_neill_corlett/dn2dca8/?context=3)).

The skip message and the comment could be improved, as always.