### PR TITLE
tcptrace: add livecheckable

### DIFF
--- a/Livecheckables/tcptrace.rb
+++ b/Livecheckables/tcptrace.rb
@@ -1,0 +1,6 @@
+class Tcptrace
+  livecheck do
+    url "http://www.tcptrace.org/download.shtml"
+    regex(/href=.*?tcptrace-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/tcptrace.rb
+++ b/Livecheckables/tcptrace.rb
@@ -1,4 +1,7 @@
 class Tcptrace
+  # This site has a history of going down for periods of time, which is why the
+  # formula uses mirrors. This is something to be aware of if livecheck is
+  # unable to find versions.
   livecheck do
     url "http://www.tcptrace.org/download.shtml"
     regex(/href=.*?tcptrace-v?(\d+(?:\.\d+)+)\.t/i)


### PR DESCRIPTION
Adding Livecheckable for `tcptrace`. The homebrew-core Formula definition for `tcptrace` has a comment stating that the website "is currently offline", but that doesn't seem to be the case.