### PR TITLE
bcrypt: add livecheckable

### DIFF
--- a/Livecheckables/bcrypt.rb
+++ b/Livecheckables/bcrypt.rb
@@ -1,0 +1,6 @@
+class Bcrypt
+  livecheck do
+    url "http://bcrypt.sourceforge.net"
+    regex(/href=.*?bcrypt-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -41,6 +41,7 @@ SOURCEFORGE_SPECIAL_CASES = %w[
   opencore-amr
   liba52.sourceforge.net/
   foremost.sourceforge.net/
+  bcrypt.sourceforge.net
 ].freeze
 
 UNSTABLE_VERSION_KEYWORDS = %w[


### PR DESCRIPTION
Adding a livecheckable for `bcrypt`.

Edit: The script I wrote to automate the `commit`, `push` and PR creation gave this PR a wrong title, which has been fixed.