### PR TITLE
libsvg-cairo: add livecheckable

### DIFF
--- a/Livecheckables/libsvg-cairo.rb
+++ b/Livecheckables/libsvg-cairo.rb
@@ -1,0 +1,6 @@
+class LibsvgCairo
+  livecheck do
+    url "https://cairographics.org/snapshots/"
+    regex(/href=.*?libsvg-cairo-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `libsvg-cairo`.