### PR TITLE
lv: add livecheckable to skip

### DIFF
--- a/Livecheckables/lv.rb
+++ b/Livecheckables/lv.rb
@@ -1,8 +1,8 @@
 class Lv
-  # The formula uses an archived version of the original project homepage
-  # as the original website is down. The formula is not actively maintained
-  # or developed either, so we skip checking for newer versions.
+  # The first-party website is no longer available (as of 2016) and there are no
+  # alternatives. The current release of this software is from 2004-01-16, so
+  # it's safe to say this is no longer actively developed or maintained.
   livecheck do
-    skip "Unable to check for versions"
+    skip "No available sources to check for versions"
   end
 end

--- a/Livecheckables/lv.rb
+++ b/Livecheckables/lv.rb
@@ -1,0 +1,8 @@
+class Lv
+  # The formula uses an archived version of the original project homepage
+  # as the original website is down. The formula is not actively maintained
+  # or developed either, so we skip checking for newer versions.
+  livecheck do
+    skip "Unable to check for versions"
+  end
+end


### PR DESCRIPTION
Adding a livecheckable to skip `lv`. The comment and message may need to be modified.