### PR TITLE
kim-api: add livecheckable

### DIFF
--- a/Livecheckables/kim-api.rb
+++ b/Livecheckables/kim-api.rb
@@ -1,0 +1,6 @@
+class KimApi
+  livecheck do
+    url "https://openkim.org/kim-api/previous-versions/"
+    regex(/href=.*?kim-api-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `kim-api`.

We have multiple resources to check for newer versions. The page for `kim-api` at https://openkim.org/kim-api/ has a link to a GitHub repository and also a releases page (which is what I use). It also lists the current latest version available from Homebrew (through Repology).