### PR TITLE
libagg: add livecheckable to skip

### DIFF
--- a/Livecheckables/libagg.rb
+++ b/Livecheckables/libagg.rb
@@ -1,0 +1,9 @@
+class Libagg
+  # The homepage for this formula is reachable, but it does not
+  # provide any version information, while other pages are not
+  # accessible. Furthermore, the formula is not being developed
+  # or maintained, so we skip checking for new versions.
+  livecheck do
+    skip "Not actively developed or maintained"
+  end
+end

--- a/Livecheckables/libagg.rb
+++ b/Livecheckables/libagg.rb
@@ -1,9 +1,10 @@
 class Libagg
-  # The homepage for this formula is reachable, but it does not
-  # provide any version information, while other pages are not
-  # accessible. Furthermore, the formula is not being developed
-  # or maintained, so we skip checking for new versions.
+  # The homepage for this formula is a copy of the original and was created
+  # after the original was discontinued. There will be no further releases of
+  # the copy of this software used in the formula, as the developer is deceased.
+  # New development of libagg occurs in a fork of v2.4 and can be found at:
+  # https://sourceforge.net/projects/agg/
   livecheck do
-    skip "Not actively developed or maintained"
+    skip "No longer developed/maintained"
   end
 end


### PR DESCRIPTION
Adding Livecheckable to skip `libagg`.

The [Wikipedia entry](https://en.wikipedia.org/wiki/Anti-Grain_Geometry) for this Formula offers some information – active development stalled in 2006, and the creator passed away in 2013. The homepage is up, but other pages (such as the Downloads page) are down.

So I think skipping this is okay, though of course the comment and message could be modified.