### PR TITLE
sloccount: add livecheckable

### DIFF
--- a/Livecheckables/sloccount.rb
+++ b/Livecheckables/sloccount.rb
@@ -1,0 +1,6 @@
+class Sloccount
+  livecheck do
+    url :homepage
+    regex(/href=.*?sloccount-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `sloccount`. The website states that they've moved development to SourceForge, but it's at the same version (2.26).