### PR TITLE
crowdin: add livecheckable

### DIFF
--- a/Livecheckables/crowdin.rb
+++ b/Livecheckables/crowdin.rb
@@ -1,0 +1,6 @@
+class Crowdin
+  livecheck do
+    url "https://github.com/crowdin/crowdin-cli.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `crowdin`. The source is available on GitHub (and I'm using the repo in the Livecheckable). It seems the Formula in homebrew-core is for an older major version. They have their own Tap though, where the newer version is available. Should we consider updating the Formula?