### PR TITLE
hmmer: add livecheckable

### DIFF
--- a/Livecheckables/hmmer.rb
+++ b/Livecheckables/hmmer.rb
@@ -1,0 +1,6 @@
+class Hmmer
+  livecheck do
+    url "http://eddylab.org/software/hmmer/"
+    regex(/href=.*?hmmer-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `hmmer`.

Alternative page to check: http://hmmer.org/download.html

Also, I'm unsure if this regex has to be modified – they seem to have had version numbers with letters affixed at the end, in the past.