### PR TITLE
ifstat: add livecheckable

### DIFF
--- a/Livecheckables/ifstat.rb
+++ b/Livecheckables/ifstat.rb
@@ -1,0 +1,6 @@
+class Ifstat
+  livecheck do
+    url :homepage
+    regex(/href=['"]?ifstat-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `ifstat`. I've used a stricter regex w.r.t `href` (`href=['"]?` rather than `href=.*?`) because there's another package's link on the same page, which matches our looser regex. Any suggestions on improving the regex?