### PR TITLE
confluent-platform: add livecheckable

### DIFF
--- a/Livecheckables/confluent-platform.rb
+++ b/Livecheckables/confluent-platform.rb
@@ -1,0 +1,6 @@
+class ConfluentPlatform
+  livecheck do
+    url "https://docs.confluent.io/current/release-notes/index.html"
+    regex(/Confluent Platform v?(\d+(?:\.\d+)+) Release Notes/i)
+  end
+end

--- a/Livecheckables/confluent-platform.rb
+++ b/Livecheckables/confluent-platform.rb
@@ -1,6 +1,6 @@
 class ConfluentPlatform
   livecheck do
-    url "https://docs.confluent.io/current/release-notes/index.html"
-    regex(/Confluent Platform v?(\d+(?:\.\d+)+) Release Notes/i)
+    url "https://docs.confluent.io/current/release-notes/changelog.html"
+    regex(/>Version (\d+(?:\.\d+)+)</i)
   end
 end


### PR DESCRIPTION
Adding Livecheckable for `confluent-platform`.

I struggled with finding a good solution for this one. They don't have an idea page for all sources and the process to download the source tarball involves filling out an e-mail address, agreeing to T&C and then a submit action – the Downloads page has no url for the tarball in the page source.

The other option was to check the docs, which have buttons at the bottom right for the versions. I tried working with that but couldn't seem to get it right.

Finally I ended up matching text in the current release's Release Notes heading. Not ideal, but I'd like to know your suggestions on this one.