### PR TITLE
httperf: add livecheckable

### DIFF
--- a/Livecheckables/httperf.rb
+++ b/Livecheckables/httperf.rb
@@ -1,6 +1,7 @@
 class Httperf
+  # Until the upstream GitHub repository creates a new release (something after
+  # 0.9.0), we're unable to create a check that can identify new versions.
   livecheck do
-    url "https://www.googleapis.com/download/storage/v1/b/google-code-archive/o/v2%2Fcode.google.com%2Fhttperf%2Fdownloads-page-1.json\?\&alt\=media"
-    regex(/httperf-v?(\d+(?:\.\d+)+)\.t/i)
+    skip "No version information available to check"
   end
 end

--- a/Livecheckables/httperf.rb
+++ b/Livecheckables/httperf.rb
@@ -1,0 +1,6 @@
+class Httperf
+  livecheck do
+    url "https://www.googleapis.com/download/storage/v1/b/google-code-archive/o/v2%2Fcode.google.com%2Fhttperf%2Fdownloads-page-1.json\?\&alt\=media"
+    regex(/httperf-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `httperf`.

Development has moved from Google Code to https://github.com/httperf/httperf but the problem is that they don't have releases or tags, or any changes.txt we can check for the latest version – that happens to be `0.9.1` which isn't available from Google Code. Have I missed something?