### PR TITLE
gst-plugins-bad: update regex

### DIFF
--- a/Livecheckables/gst-plugins-bad.rb
+++ b/Livecheckables/gst-plugins-bad.rb
@@ -1,6 +1,6 @@
 class GstPluginsBad
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-bad/"
-    regex(/href="gst-plugins-bad-([\d.]+\.[\d.]+\.[\d.]+)\.t/)
+    regex(/href=.*?gst-plugins-bad-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
See #999, the `gst-` Livecheckables shouldn't match odd numbers in the minor version, as pointed out in #942 as well.