### PR TITLE
gst-plugins-base: update regex

### DIFF
--- a/Livecheckables/gst-plugins-base.rb
+++ b/Livecheckables/gst-plugins-base.rb
@@ -1,6 +1,6 @@
 class GstPluginsBase
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-base/"
-    regex(/href="gst-plugins-base-([\d.]+\.[\d.]+\.[\d.]+)\.t/)
+    regex(/href="gst-plugins-base-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
See #999, the `gst-` Livecheckables shouldn't match odd numbers in the minor version.