### PR TITLE
gst-plugins-good: update regex

### DIFF
--- a/Livecheckables/gst-plugins-good.rb
+++ b/Livecheckables/gst-plugins-good.rb
@@ -1,6 +1,6 @@
 class GstPluginsGood
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-good/"
-    regex(/href="gst-plugins-good-([\d.]+\.[\d.]+\.[\d.]+)\.t/)
+    regex(/href="gst-plugins-good-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
See #999, the `gst-` Livecheckables shouldn't match odd numbers in the minor version.