### PR TITLE
gst-plugins-ugly: update regex

### DIFF
--- a/Livecheckables/gst-plugins-ugly.rb
+++ b/Livecheckables/gst-plugins-ugly.rb
@@ -1,6 +1,6 @@
 class GstPluginsUgly
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/"
-    regex(/href="gst-plugins-ugly-([\d.]+\.[\d.]+\.[\d.]+)\.t/)
+    regex(/href="gst-plugins-ugly-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
See #999, the `gst-` Livecheckables shouldn't match odd numbers in the minor version.