### PR TITLE
gstreamer: update regex

### DIFF
--- a/Livecheckables/gstreamer.rb
+++ b/Livecheckables/gstreamer.rb
@@ -1,6 +1,6 @@
 class Gstreamer
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gstreamer/"
-    regex(/href="gstreamer-([\d.]+\.[\d.]+\.[\d.]+)\.t/)
+    regex(/href="gstreamer-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
See #999, the gst- Livecheckables shouldn't match odd numbers in the minor version.