### PR TITLE
gst-libav: update regex

### DIFF
--- a/Livecheckables/gst-libav.rb
+++ b/Livecheckables/gst-libav.rb
@@ -1,6 +1,6 @@
 class GstLibav
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gst-libav/"
-    regex(/href="gst-libav-([\d.]+\.[\d.]+\.[\d.]+)\.t/)
+    regex(/href="gst-libav-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
See #999, we shouldn't match odd-number minor versions for `gstreamer` Formulae.