### PR TITLE
Enable multiple strategies

### DIFF
--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -82,6 +82,39 @@ def preprocess_url(url)
   url
 end
 
+def strat_matcher(url, strat, livecheck_regex)
+  case strat
+  when :hackage_strategy
+    /hackage\.haskell\.org/.match?(url)
+  when :git_strategy
+    DownloadStrategyDetector.detect(url) <= GitDownloadStrategy
+  when :sourceforge_strategy
+    /(sourceforge|sf)\.net/.match?(url) && SOURCEFORGE_SPECIAL_CASES.none? { |sc| url.include? sc }
+  when :gnu_strategy
+    url =~ /gnu\.org/ && GNU_SPECIAL_CASES.none? { |sc| url.include? sc }
+  when :pypi_strategy
+    /files\.pythonhosted\.org/.match?(url)
+  when :npm_strategy
+    /registry\.npmjs\.org/.match?(url)
+  when :gnome_strategy
+    /download\.gnome\.org/.match?(url)
+  when :launchpad_strategy
+    /launchpad\.net/.match?(url)
+  when :apache_strategy
+    %r{www\.apache\.org/dyn}.match?(url)
+  when :bitbucket_strategy
+    %r{bitbucket\.org(/[^/]+){4}\.\w+}.match?(url)
+  when :page_match_strategy
+    livecheck_regex
+  end
+end
+
+def available_strategies
+  [:hackage_strategy, :git_strategy, :sourceforge_strategy, :gnu_strategy,
+   :pypi_strategy, :npm_strategy, :gnome_strategy, :launchpad_strategy,
+   :apache_strategy, :bitbucket_strategy, :page_match_strategy]
+end
+
 def latest_version(formula)
   has_livecheckable = formula.livecheckable?
   livecheck = formula.livecheck
@@ -103,56 +136,53 @@ def latest_version(formula)
 
     url = preprocess_url(original_url)
 
-    strategy = if /hackage\.haskell\.org/.match?(url)
-      :hackage_strategy
-    elsif DownloadStrategyDetector.detect(url) <= GitDownloadStrategy
-      :git_strategy
-    elsif /(sourceforge|sf)\.net/.match?(url) &&
-          SOURCEFORGE_SPECIAL_CASES.none? { |sc| url.include? sc }
-      :sourceforge_strategy
-    elsif url =~ /gnu\.org/ && GNU_SPECIAL_CASES.none? { |sc| url.include? sc }
-      :gnu_strategy
-    elsif /files\.pythonhosted\.org/.match?(url)
-      :pypi_strategy
-    elsif /registry\.npmjs\.org/.match?(url)
-      :npm_strategy
-    elsif /download\.gnome\.org/.match?(url)
-      :gnome_strategy
-    elsif /launchpad\.net/.match?(url)
-      :launchpad_strategy
-    elsif %r{www\.apache\.org/dyn}.match?(url)
-      :apache_strategy
-    elsif %r{bitbucket\.org(/[^/]+){4}\.\w+}.match?(url)
-      :bitbucket_strategy
-    elsif livecheck_regex
-      :page_match_strategy
+    strategies = available_strategies.select { |strat| strat_matcher(url, strat, livecheck_regex) }
+    strat_names = if strategies.empty?
+      "None found"
+    else
+      strategies.map(&:to_s).map { |s| s.delete_suffix("_strategy") }.join(", ")
     end
 
     if Homebrew.args.debug?
       puts "\nURL:             #{original_url}"
       puts "URL (processed): #{url}" if url != original_url
-      puts "Strategy:        #{strategy.nil? ? "None" : strategy.to_s.delete_suffix("_strategy")}"
+      puts "# of strategies: #{strategies.size}"
+      puts "Strategies:      #{strat_names}"
       puts "Regex:           #{livecheck_regex.inspect}\n" unless livecheck_regex.nil?
     end
 
-    next if strategy.nil?
+    opoo "No strategies identified for #{formula_name(formula)} using URL: #{url}" if strategies.empty?
 
-    match_version_map = Symbol.send(strategy, url, livecheck_regex)
+    next if strategies.empty?
 
     empty_version = Version.new("")
-    match_version_map.delete_if do |_match, version|
-      next true if version == empty_version
-      next false if has_livecheckable
+    match_version_map = {}
 
-      UNSTABLE_VERSION_KEYWORDS.any? do |rejection|
-        version.to_s.include?(rejection)
+    strategies.each do |strategy|
+      strat_name = strategy.to_s.delete_suffix("_strategy")
+      puts "Using strategy: #{strat_name}" if Homebrew.args.debug?
+      version_map = Symbol.send(strategy, url, livecheck_regex)
+
+      version_map.delete_if do |_match, version|
+        next true if version == empty_version
+        next false if has_livecheckable
+
+        UNSTABLE_VERSION_KEYWORDS.any? do |rejection|
+          version.to_s.include?(rejection)
+        end
+      end
+      if version_map.empty?
+        puts "No new versions found using #{strat_name}" if Homebrew.args.debug?
+      else
+        puts "Found new versions: #{version_map.keys.map(&:to_s).join(", ")}" if Homebrew.args.debug?
+        match_version_map.merge!(version_map)
       end
     end
 
-    if Homebrew.args.debug? && !match_version_map.empty?
+    if Homebrew.args.debug? && Homebrew.args.verbose? && !match_version_map.empty?
       puts "\nMatched Versions:\n"
-      match_version_map.each do |match, version|
-        puts "#{match} => #{version.inspect}"
+      match_version_map.each_with_index do |(match, version), i|
+        puts "Match #{i}: #{match} => #{version}"
       end
     end
 

--- a/livecheck/utils.rb
+++ b/livecheck/utils.rb
@@ -29,6 +29,8 @@ end
 def page_matches(url, regex)
   page = URI.open(url).read
   matches = page.scan(regex)
-  puts "\nMatched Text on Page:\n", matches.join(", ") if Homebrew.args.debug? && !matches.empty?
+  if Homebrew.args.debug? && Homebrew.args.verbose? && !matches.empty?
+    puts "Matched Text on Page:\n", matches.join(", ")
+  end
   matches.map(&:first).uniq
 end


### PR DESCRIPTION
- Allow multiple strategies to match URL
- factor out available strategies into a method
- `strat_matcher` method returns whether specified strategy is applicable to specified url
- warn when no strategies have been matched
- guard `Matched Text on Page` and `Matched Versions` outputs by `Homebrew.args.verbose?`

Formulae that can be used to see the effect of this PR: xmp, wtf, aespipe
 
<details>
<summary><code>brew livecheck -d xmp</code></summary>
<pre><code>
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::TapLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/xmp.rb
Formula:         xmp
Livecheckable?:  No

URL:             https://git.code.sf.net/p/xmp/xmp-cli.git
\# of strategies: 2
Strategies:      git, sourceforge
Using strategy: git
Found new versions: 2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.4.0, 2.4.1, 2.5.0, 2.5.1, 2.7.0, 2.7.0-win32-amigaconf.patch, 2.7.1, 3.0.0, 3.0.0-pre1, 3.0.1, 3.1.0, 3.2.0, 3.3.0, 3.4.0, 3.4.1, 3.5.0, android-1.0.1, android-1.1, android-1.2, android-1.9, android-1.9.1, android-1.9.2, android-1.9.3, android-1.9.4, android-1.9.5, android-2.0.0, android-2.0.1, android-2.0.2, android-2.0.3, android-2.1.0, android-2.1.1, android-2.2.0, android-2.3.0, android-2.4.0, android-2.9.0, android-2.9.1, android-2.9.2, android-3.0.0, android-3.0.1, android-3.0.2, android-3.1.0, android-3.1.1, android-3.1.2, android-3.2.0, android-3.2.1, android-3.3.0, android-3.4.0, android-3.4.1, android-3.4.2, android-3.4.3, android-3.4.4, api-4.0, libxmp-3.9.0, libxmp-3.9.1, libxmp-3.9.2, libxmp-3.9.3, libxmp-3.9.4, libxmp-4.0.0, libxmp-4.0.1, libxmp-4.0.2, libxmp-4.0.3, libxmp-4.0.4, libxmp-4.1.0, libxmp-4.1.1, libxmp-4.1.2, libxmp-4.1.3, libxmp-4.1.4, r2_2_0, r2_2_0_pre1, r2_2_0_pre2, r2_2_0_pre3, r2_2_0_pre4, r2_2_0_pre5, r2_2_0_pre6, r2_3_0, r2_3_0_pre1, r2_3_0_pre2, r2_3_0_pre3, r2_3_1, r2_3_2, r2_4_0, r2_4_0_pre1, r2_4_0_pre2, r2_4_0_pre3, r2_4_0_pre4, r2_4_0_pre5, r2_4_0_pre6, r2_4_1, r2_5_0, r2_5_0_pre1, r2_5_0_pre3, r2_5_0_pre4, r2_5_0_pre5, r2_5_0_pre6, r2_5_1, v2.6.0, v2.6.1, v2.6.2, xmp-3.9.0, xmp-3.9.1, xmp-4.0.0, xmp-4.0.1, xmp-4.0.10, xmp-4.0.11, xmp-4.0.2, xmp-4.0.3, xmp-4.0.4, xmp-4.0.5, xmp-4.0.6, xmp-4.0.7, xmp-4.0.8, xmp-4.0.9, xmp-4.1.0
Using strategy: sourceforge
Found new versions: 4.4.1, 4.1.0, 4.4.0, 4.3.13, 4.0.11, 4.3.12, 4.3.11, 4.3.10, 4.3.9, 4.3.8, 4.3.7, 4.3.6, 4.3.5, 4.3.4, 4.3.3, 4.0.10, 4.3.2, 4.3.1, 4.3.0, 4.0.9, 4.0.8, 4.2.8, 4.2.7, 4.2.6, 4.2.5, 4.0.7, 4.2.4, 4.2.3, 4.2.2, 4.2.1, 4.2.0, 4.1.5, 4.0.6, 4.1.4, 4.0.5, 4.1.3, 4.1.2, 4.1.1, 4.0.4, 4.0.3
xmp : 4.1.0 ==> 4.4.1</code></pre>
</details>


<details>
<summary><code>brew livecheck -d wtf</code></summary>
<pre><code>
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/wtf.rb
Loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-livecheck/Livecheckables/wtf.rb
Formula:         wtf
Livecheckable?:  Yes

URL:             https://sourceforge.net/projects/bsdwtf/
\# of strategies: 2
Strategies:      sourceforge, page_match
Regex:           /.*?\/wtf-([0-9.]+)\.t/
Using strategy: sourceforge
Found new versions: 20200613, 20200611, 20200610, 20200609, 20200606, 20200605, 20200604, 20200603, 20200518, 20200505, 20200429, 20200427, 20200422, 20200326, 20200226, 20200217, 20200208, 20200130, 20200127, 20200110, 20191223, 20191214, 20191201, 20191111, 20191020, 20191006, 20191002, 20190925, 20190909, 20190903, 20190902, 20190901, 20190830, 20190822, 20190817, 20190728, 20190726, 20190723, 20190720, 20190711, 20190705, 20190704, 20190703, 20190702, 20190630, 20190629, 20190628, 20190623, 20190622, 20190621, 20190617, 20190612, 20190611, 20190608, 20190607, 20190604, 20190602, 20190527, 20190524, 20190516, 20190507, 20190424, 20190422, 20190417, 20190410, 20190405, 20190402, 20190401, 20190330, 20190323, 20190308, 20190304, 20190224, 20190221, 20190219, 20190201, 20190128, 20190123, 20190122, 20190114, 20190107, 20181230, 20181212, 20181207, 20181205, 20181119, 20180925, 20180919, 20180816, 20180813, 20180704, 20180627, 20180624, 20180623, 20180621, 20180620, 20180615, 20180529, 20180525, 20180522
Using strategy: page_match
No new versions found using page_match
wtf : 20200613 ==> 20200613</code></pre>
</details>


<details>
<summary><code>brew livecheck -d aespipe</code></summary>
<pre><code>
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/aespipe.rb
Formula:         aespipe
Livecheckable?:  No

URL:             https://loop-aes.sourceforge.io/aespipe/aespipe-v2.4f.tar.bz2
\# of strategies: 0
Strategies:      None found
Warning: No strategies identified for aespipe using URL: https://loop-aes.sourceforge.io/aespipe/aespipe-v2.4f.tar.bz2

URL:             https://loop-aes.sourceforge.io/
\# of strategies: 0
Strategies:      None found
Warning: No strategies identified for aespipe using URL: https://loop-aes.sourceforge.io/
Error: aespipe: Unable to get versions</code></pre>
</details>