### PR TITLE
Refactor Hackage strategy to resemble others

### DIFF
--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -121,10 +121,19 @@ def gnu_strategy(url, regex = nil)
 end
 
 def hackage_strategy(url, _regex = nil)
+  match_version_map = {}
+
   package = ((url.split("/")[4]).split("-")[0..-2]).join("-")
-  haskell_pkg_url = "https://hackage.haskell.org/package/#{package}/src"
-  ver = URI.open(haskell_pkg_url).read.sub(/.*Directory listing for #{package}-(.*) source tarball.*/, "\\1")
-  { ver => Version.new(ver) }
+  page_url = "https://hackage.haskell.org/package/#{package}/src"
+
+  regex ||= %r{<h3>#{package}-(.*?)/?</h3>}i
+
+  page_matches(page_url, regex).each do |match|
+    version = Version.new(match)
+    match_version_map[match] = version
+  end
+
+  match_version_map
 end
 
 def launchpad_strategy(url, regex = nil)


### PR DESCRIPTION
This refactors the Hackage strategy to resemble similar strategies that use the `page_match` function. Refactoring the strategy in this manner is necessary to enable some future changes.

Specifically, we want to be able to return the generated URL and regex used in the strategy back to `latest_version()`, where we can print it in the debug output, and back to `print_latest_version`, where they can be included in JSON output. This will be enabled in a later PR but this is a necessary change leading up to that PR.