### PR TITLE
geckodriver: add livecheckable

### DIFF
--- a/Livecheckables/geckodriver.rb
+++ b/Livecheckables/geckodriver.rb
@@ -1,0 +1,6 @@
+class Geckodriver
+  livecheck do
+    url "https://github.com/mozilla/geckodriver.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
The default check for `geckodriver` uses the Git strategy with the GitHub repo (derived from the homepage URL) but it has to go through the other URLs before it reaches this point. This adds a livecheckable to remove the guesswork and to also use the standard regex for Git tags.