### PR TITLE
gmp: add livecheckable

### DIFF
--- a/Livecheckables/gmp.rb
+++ b/Livecheckables/gmp.rb
@@ -1,0 +1,6 @@
+class Gmp
+  livecheck do
+    url "https://gmplib.org/download/gmp/"
+    regex(/href=.*?gmp-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
The default check for `gmp` ends up checking a mirror which supports the GNU strategy, whereas it would be preferable to be checking for a version in the same location as the stable archive. This adds a livecheckable that checks the index page where the stable archive is located.