### PR TITLE
Skip deprecated formulae

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -103,6 +103,18 @@ module Homebrew
   end
 
   def print_latest_version(formula)
+    if formula.deprecated? && !formula.livecheckable?
+      if Homebrew.args.json?
+        return {
+          "formula" => formula_name(formula),
+          "status"  => "deprecated",
+        }
+      elsif !Homebrew.args.quiet?
+        puts "#{Tty.red}#{formula_name(formula)}#{Tty.reset} : deprecated"
+        return
+      end
+    end
+
     if formula.to_s.include?("@") && !formula.livecheckable?
       if Homebrew.args.json?
         return {


### PR DESCRIPTION
In a recent livecheck run, I once again encountered a formula where the GitHub repo was deleted entirely. We decided it was appropriate to deprecate the formula and this reminded me that livecheck doesn't currently skip deprecated formulae. This seems like a straightforward addition to the existing automatic skip for versioned formulae (unless a livecheckable is available).