### PR TITLE
Remove deprecated livecheckables

### DIFF
--- a/Livecheckables/elasticsearch@5.6.rb
+++ b/Livecheckables/elasticsearch@5.6.rb
@@ -1,6 +1,0 @@
-class ElasticsearchAT56
-  livecheck do
-    url "https://github.com/elastic/elasticsearch.git"
-    regex(/v?(5\.6[0-9.]+)/)
-  end
-end

--- a/Livecheckables/go@1.10.rb
+++ b/Livecheckables/go@1.10.rb
@@ -1,6 +1,0 @@
-class GoAT110
-  livecheck do
-    url "https://golang.org/dl/"
-    regex(/go(1\.10\.[0-9.]+)\.src/)
-  end
-end

--- a/Livecheckables/go@1.9.rb
+++ b/Livecheckables/go@1.9.rb
@@ -1,6 +1,0 @@
-class GoAT19
-  livecheck do
-    url "https://golang.org/dl/"
-    regex(/go(1\.9\.[0-9.]+)\.src/)
-  end
-end

--- a/Livecheckables/kibana@5.6.rb
+++ b/Livecheckables/kibana@5.6.rb
@@ -1,6 +1,0 @@
-class KibanaAT56
-  livecheck do
-    url :stable
-    regex(/v?(5\.6[0-9.]+)/)
-  end
-end

--- a/Livecheckables/postgresql@9.4.rb
+++ b/Livecheckables/postgresql@9.4.rb
@@ -1,6 +1,0 @@
-class PostgresqlAT94
-  livecheck do
-    url "https://www.postgresql.org/docs/9.4/static/release.html"
-    regex(/Release ([0-9,.]+)/)
-  end
-end

--- a/Livecheckables/premake.rb
+++ b/Livecheckables/premake.rb
@@ -1,6 +1,0 @@
-class Premake
-  livecheck do
-    url "https://sourceforge.net/projects/premake/rss"
-    regex(%r{url=.+?/premake-v?(\d+(?:\.\d+)+(?:-[a-z]+\d+)?)-src\.(?:t|z)})
-  end
-end

--- a/Livecheckables/redis@3.2.rb
+++ b/Livecheckables/redis@3.2.rb
@@ -1,6 +1,0 @@
-class RedisAT32
-  livecheck do
-    url "http://download.redis.io/releases/"
-    regex(/href="redis-(3\.2\.[0-9,.]+)\.t/)
-  end
-end


### PR DESCRIPTION
The following formulae are currently deprecated and have livecheckables:

* elasticsearch@5.6
* go@1.10
* go@1.9
* kibana@5.6
* postgresql@9.4
* premake
* redis@3.2

All of these have been deprecated for over a year, so I think it's safe to remove the livecheckables and allow these to be skipped.