### PR TITLE
interactive-rebase-tool: update livecheckable name, add url

### DIFF
--- a/Livecheckables/git-interactive-rebase-tool.rb
+++ b/Livecheckables/git-interactive-rebase-tool.rb
@@ -1,5 +1,6 @@
-class InteractiveRebaseTool
+class GitInteractiveRebaseTool
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end


### PR DESCRIPTION
The `interactive-rebase-tool` formula has been renamed to `git-interactive-rebase-tool`. This renames the livecheckable and also adds `url :stable` to make the desired URL explicit.