### PR TITLE
Delete livecheckables for removed formulae

### DIFF
--- a/Livecheckables/marathon-swift.rb
+++ b/Livecheckables/marathon-swift.rb
@@ -1,8 +1,0 @@
-class MarathonSwift
-  # This software was deprecated in favor of the official Swift package manager
-  # and the upstream repository has been archived as of 2019-09-09
-  # (see https://github.com/JohnSundell/Marathon/issues/208).
-  livecheck do
-    skip "No longer developed/maintained"
-  end
-end

--- a/Livecheckables/residualvm.rb
+++ b/Livecheckables/residualvm.rb
@@ -1,6 +1,0 @@
-class Residualvm
-  livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+)+)$/)
-  end
-end


### PR DESCRIPTION
The `marathon-swift` and `residualvm` formulae were recently deleted, so this removes the related livecheckables.