### PR TITLE
git_tags: disable terminal prompt

### DIFF
--- a/livecheck/utils.rb
+++ b/livecheck/utils.rb
@@ -17,7 +17,7 @@ def formula_name(formula)
 end
 
 def git_tags(repo_url, filter = nil)
-  raw_tags = `git ls-remote --tags #{repo_url}`
+  raw_tags = `GIT_TERMINAL_PROMPT=0 git ls-remote --tags #{repo_url}`
   raw_tags.gsub!(%r{^.*\trefs/tags/}, "")
   raw_tags.delete_suffix!("^{}")
 


### PR DESCRIPTION
We've had a longstanding issue with livecheck where we'll get a `Username for 'https://github.com':` type prompt when livecheck executes `git_tags` (i.e., `git ls-remote --tags ...`) on a repo that no longer exists. This is a problem, as it will halt a livecheck run until you press enter to get past the prompts (which often repeat due to multiple URLs being tried).

Prepending `GIT_TERMINAL_PROMPT=0` to the `git ls-remote --tags` call prevents this from happening and we instead get a `fatal: could not read Username for 'https://github.com': terminal prompts disabled` error, which is preferable.