### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# Explicitly ignore OS X Finder thumbnail files.
+.DS_Store


### PR DESCRIPTION
I've been quietly dealing with removing `.DS_Store` files from changes and had been putting off adding it to `.gitignore` since this repo will eventually be migrated elsewhere and archived. There's still some time to go before the migration, so it won't hurt to add it for the interim time.