### PR TITLE
funcoeszz: add livecheckable

### DIFF
--- a/Livecheckables/funcoeszz.rb
+++ b/Livecheckables/funcoeszz.rb
@@ -1,0 +1,6 @@
+class Funcoeszz
+  livecheck do
+    url "https://funcoeszz.net/download/"
+    regex(/href=.*?funcoeszz.v?(\d+(?:\.\d+)+)\.s/i)
+  end
+end

--- a/Livecheckables/funcoeszz.rb
+++ b/Livecheckables/funcoeszz.rb
@@ -1,6 +1,6 @@
 class Funcoeszz
   livecheck do
     url "https://funcoeszz.net/download/"
-    regex(/href=.*?funcoeszz.v?(\d+(?:\.\d+)+)\.s/i)
+    regex(/href=.*?funcoeszz.v?(\d+(?:\.\d+)+)\.sh/i)
   end
 end


### PR DESCRIPTION
Output before:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck funcoeszz
Error: funcoeszz: Unable to get versions
```
Output after:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck funcoeszz
funcoeszz : 18.3 ==> 18.3
```

The `\.s` part is to ensure only the `.sh` ones are matched, and not any of the other numbers that appear in the `url` via the examples shown.

I checked that `--debug` only matches the one `version` up the top of the `url` and the 47 `version`'s at the bottom of the `url`.

Thank you.