### PR TITLE
Refactor strategies, add debug and JSON info

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -81,18 +81,16 @@ module Homebrew
     return unless formulae_to_check
 
     # Identify any non-homebrew/core taps in use for current formulae
-    other_taps_hash = {}
+    non_core_taps = {}
     formulae_to_check.each do |f|
-      other_taps_hash[f.tap.name] = true unless f.tap.name == "homebrew/core" || other_taps_hash.key?(f.tap.name)
+      non_core_taps[f.tap.name] = true unless f.tap.name == "homebrew/core" || non_core_taps.key?(f.tap.name)
     end
-    other_taps = other_taps_hash.keys.sort
+    non_core_taps = non_core_taps.keys.sort
 
     # Load additional LivecheckStrategy files from taps
-    unless other_taps.empty?
-      other_taps.each do |tap_name|
-        tap_strategy_path = File.join(Tap.fetch(tap_name).path, "livecheck_strategy")
-        Dir.glob(File.join(tap_strategy_path, "*.rb"), &method(:require)) if Dir.exist?(tap_strategy_path)
-      end
+    non_core_taps.each do |tap_name|
+      tap_strategy_path = File.join(Tap.fetch(tap_name).path, "livecheck_strategy")
+      Dir.glob(File.join(tap_strategy_path, "*.rb"), &method(:require)) if Dir.exist?(tap_strategy_path)
     end
 
     formulae_checked = formulae_to_check.sort.map.with_index do |formula, i|

--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -62,7 +62,7 @@ module Homebrew
       elsif Homebrew.args.installed?
         Formula.installed
       elsif Homebrew.args.all?
-        Formula.names.map { |name| Formula[name] }
+        Formula.full_names.map { |name| Formula[name] }
       elsif !Homebrew.args.formulae.empty?
         Homebrew.args.formulae
       elsif File.exist?(WATCHLIST_PATH)

--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -50,11 +50,9 @@ module Homebrew
     require_relative "../livecheck/livecheck_strategy"
 
     if Homebrew.args.debug? && Homebrew.args.verbose?
-      puts ARGV
+      puts ARGV.inspect
       puts Homebrew.args
-      puts ENV["HOMEBREW_LIVECHECK_WATCHLIST"]
-      puts Pathname.new(File.expand_path(__dir__)).basename
-      puts $LOAD_PATH
+      puts ENV["HOMEBREW_LIVECHECK_WATCHLIST"] if ENV["HOMEBREW_LIVECHECK_WATCHLIST"].present?
     end
 
     if (cmd = Homebrew.args.named.first)

--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -45,6 +45,10 @@ module Homebrew
   def livecheck
     livecheck_args.parse
 
+    # It's necessary to require livecheck_strategy.rb here, so that it has
+    # access to Homebrew.args.tap
+    require_relative "../livecheck/livecheck_strategy"
+
     if Homebrew.args.debug? && Homebrew.args.verbose?
       puts ARGV
       puts Homebrew.args

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -73,11 +73,13 @@ def latest_version(formula)
     next if original_url.include?("gist.github.com")
 
     url = preprocess_url(original_url)
-    strategy = LivecheckStrategy.from_url(url, livecheck_regex.present?)
+    strategies = LivecheckStrategy.from_url(url, livecheck_regex.present?)
+    strategy = strategies[0]
 
     if Homebrew.args.debug?
       puts "\nURL:              #{original_url}"
       puts "URL (processed):  #{url}" if url != original_url
+      puts "Strategies:       #{strategies.map { |s| s.name.demodulize }}" unless strategies.empty? || !Homebrew.args.verbose?
       puts "Strategy:         #{strategy.nil? ? "None" : strategy::NICE_NAME}"
       puts "Regex:            #{livecheck_regex.inspect}\n" unless livecheck_regex.nil?
     end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -132,10 +132,11 @@ def latest_version(formula)
         "url"      => {
           "original" => original_url,
         },
-        "strategy" => strategy.nil? ? nil : strategy::NAME,
+        "strategy" => strategy.nil? ? nil : strategy.name.demodulize,
       }
       version_info["meta"]["url"]["processed"] = url if url != original_url
       version_info["meta"]["url"]["strategy"] = strategy_data[:url] if strategy_data[:url] != url
+      version_info["meta"]["strategies"] = strategies.map { |s| s.name.demodulize } unless strategies.empty?
       version_info["meta"]["regex"] = regex.inspect unless regex.nil?
     end
 

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -1,4 +1,3 @@
-require_relative "livecheck_strategy"
 require "utils"
 
 GITHUB_SPECIAL_CASES = %w[

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -74,7 +74,7 @@ def latest_version(formula)
     next if original_url.include?("gist.github.com")
 
     url = preprocess_url(original_url)
-    strategy = LivecheckStrategy.from_url(url, !livecheck_regex.nil?)
+    strategy = LivecheckStrategy.from_url(url, livecheck_regex.present?)
 
     if Homebrew.args.debug?
       puts "\nURL:              #{original_url}"

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -83,7 +83,9 @@ def latest_version(formula)
 
     if Homebrew.args.debug?
       puts "URL (processed):  #{url}" if url != original_url
-      puts "Strategies:       #{strategies.map { |s| s.name.demodulize }}" unless strategies.empty? || !Homebrew.args.verbose?
+      unless strategies.empty? || !Homebrew.args.verbose?
+        puts "Strategies:       #{strategies.map { |s| s.name.demodulize }.join(", ")}"
+      end
       puts "Strategy:         #{strategy.nil? ? "None" : strategy.name.demodulize}"
       puts "Regex:            #{livecheck_regex.inspect}\n" unless livecheck_regex.nil?
     end

--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -84,7 +84,7 @@ def latest_version(formula)
     if Homebrew.args.debug?
       puts "URL (processed):  #{url}" if url != original_url
       unless strategies.empty? || !Homebrew.args.verbose?
-        puts "Strategies:       #{strategies.map { |s| s.name.demodulize }.join(", ")}"
+        puts "Strategies:       #{strategies.map { |s| s::NAME }.join(", ")}"
       end
       puts "Strategy:         #{strategy.nil? ? "None" : strategy.name.demodulize}"
       puts "Regex:            #{livecheck_regex.inspect}\n" unless livecheck_regex.nil?
@@ -134,11 +134,11 @@ def latest_version(formula)
         "url"      => {
           "original" => original_url,
         },
-        "strategy" => strategy.nil? ? nil : strategy.name.demodulize,
+        "strategy" => strategy.nil? ? nil : strategy::NAME,
       }
       version_info["meta"]["url"]["processed"] = url if url != original_url
       version_info["meta"]["url"]["strategy"] = strategy_data[:url] if strategy_data[:url] != url
-      version_info["meta"]["strategies"] = strategies.map { |s| s.name.demodulize } unless strategies.empty?
+      version_info["meta"]["strategies"] = strategies.map { |s| s::NAME } unless strategies.empty?
       version_info["meta"]["regex"] = regex.inspect unless regex.nil?
     end
 

--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -25,9 +25,11 @@ module LivecheckStrategy
 
     usable_strategies << strategies[:page_match] if strategies.key?(:page_match) && regex_provided
 
+    # Sort usable strategies in descending order by priority, using 5 as the
+    # default when a PRIORITY isn't provided in the LivecheckStrategy itself.
     usable_strategies.sort_by do |strategy|
-      (strategy.const_defined?(:PRIORITY) ? strategy::PRIORITY : 5)
-    end.reverse
+      (strategy.const_defined?(:PRIORITY) ? -strategy::PRIORITY : -5)
+    end
   end
 end
 

--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -10,7 +10,7 @@ module LivecheckStrategy
       strategy = LivecheckStrategy.const_get(strategy_symbol)
       @strategies[key] = strategy
     end
-    @strategies.freeze
+    @strategies
   end
   private_class_method :strategies
 

--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -32,9 +32,3 @@ module LivecheckStrategy
 end
 
 Dir.glob(File.join(__dir__, "livecheck_strategy", "*.rb"), &method(:require))
-
-if Homebrew.args.tap
-  current_tap = Tap.fetch(Homebrew.args.tap)
-  tap_strategy_path = File.join(current_tap.path, "livecheck_strategy")
-  Dir.glob(File.join(tap_strategy_path, "*.rb"), &method(:require)) if Dir.exist?(tap_strategy_path)
-end

--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -24,30 +24,28 @@ module LivecheckStrategy
 
   def self.from_url(url, regex_provided = nil)
     if Hackage.match?(url)
-      return Hackage
+      Hackage
     elsif Git.match?(url)
-      return Git
+      Git
     elsif SourceForge.match?(url)
-      return SourceForge
+      SourceForge
     elsif Gnu.match?(url)
-      return Gnu
+      Gnu
     elsif PyPI.match?(url)
-      return PyPI
+      PyPI
     elsif Npm.match?(url)
-      return Npm
+      Npm
     elsif Gnome.match?(url)
-      return Gnome
+      Gnome
     elsif Launchpad.match?(url)
-      return Launchpad
+      Launchpad
     elsif Apache.match?(url)
-      return Apache
+      Apache
     elsif Bitbucket.match?(url)
-      return Bitbucket
+      Bitbucket
     elsif regex_provided
-      return PageMatch
+      PageMatch
     end
-
-    nil
   end
 end
 

--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -25,11 +25,9 @@ module LivecheckStrategy
 
     usable_strategies << strategies[:page_match] if strategies.key?(:page_match) && regex_provided
 
-    usable_strategies.sort_by! do |strategy|
+    usable_strategies.sort_by do |strategy|
       (strategy.const_defined?(:PRIORITY) ? strategy::PRIORITY : 5)
-    end.reverse!
-
-    usable_strategies[0]
+    end.reverse
   end
 end
 

--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -1,218 +1,64 @@
-# Formulae that do not use GNOME's "even-numbered minor is stable" scheme
-GNOME_DEVEL_ALLOWLIST = [
-  "gcab",
-  "gtk-doc",
-  "gtk-mac-integration",
-  "libart_lgpl", # The package name for libart is "libart_lgpl"
-  "libepoxy",
-].freeze
+# frozen_string_literal: true
 
-def apache_strategy(url, regex = nil)
-  match_version_map = {}
+module LivecheckStrategy
+  def self.strategies
+    @strategies ||= {
+      :apache      => Apache,
+      :bitbucket   => Bitbucket,
+      :git         => Git,
+      :gnome       => Gnome,
+      :gnu         => Gnu,
+      :hackage     => Hackage,
+      :launchpad   => Launchpad,
+      :npm         => Npm,
+      :page_match  => PageMatch,
+      :pypi        => PyPI,
+      :sourceforge => SourceForge,
+    }.freeze
+  end
+  private_class_method :strategies
 
-  path, prefix, suffix = url.match(%r{path=(.+?)/([^/]*?)\d+(?:\.\d+)+(/|[^/]*)})[1, 3]
-  page_url = "https://archive.apache.org/dist/#{path}/"
-
-  regex ||= /href="#{Regexp.escape(prefix)}(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/
-
-  page_matches(page_url, regex).each do |match|
-    version = Version.new(match)
-    match_version_map[match] = version
+  def self.from_symbol(symbol)
+    strategies[symbol]
   end
 
-  match_version_map
-end
-
-def bitbucket_strategy(url, regex = nil)
-  match_version_map = {}
-
-  path, kind, suffix =
-    url.match(%r{bitbucket\.org/(.+?)/(get|downloads)/(?:.*?[-_])?v?\d+(?:\.\d+)+([^/]+)})[1, 3]
-  page_url = "https://bitbucket.org/#{path}/downloads/"
-  page_url << "?tab=tags" if kind == "get"
-
-  regex ||= /(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}"/
-
-  page_matches(page_url, regex).each do |match|
-    version = Version.new(match)
-    match_version_map[match] = version
-  end
-
-  match_version_map
-end
-
-def git_strategy(url, regex = nil)
-  match_version_map = {}
-
-  tags = git_tags(url, regex)
-  tags_only_debian = tags.all? { |tag| tag.start_with?("debian/") }
-
-  tags.each do |tag|
-    # Move to the next one if tag actually is prefixed with 'debian/'
-    # and upstream does not do only 'debian/' prefixed tags
-    next if tag =~ %r{debian/} && !tags_only_debian
-
-    captures = tag.scan(regex) if regex
-    tag_cleaned = if captures &&
-                     !captures.empty? &&
-                     captures[0].is_a?(Array)
-      # Use the first capture group as the version
-      captures[0][0]
-    else
-      # Remove any character before the first number
-      tag[/\D*(.*)/, 1]
+  def self.from_url(url, regex_provided = nil)
+    if Hackage.match?(url)
+      return Hackage
+    elsif Git.match?(url)
+      return Git
+    elsif SourceForge.match?(url)
+      return SourceForge
+    elsif Gnu.match?(url)
+      return Gnu
+    elsif PyPI.match?(url)
+      return PyPI
+    elsif Npm.match?(url)
+      return Npm
+    elsif Gnome.match?(url)
+      return Gnome
+    elsif Launchpad.match?(url)
+      return Launchpad
+    elsif Apache.match?(url)
+      return Apache
+    elsif Bitbucket.match?(url)
+      return Bitbucket
+    elsif regex_provided
+      return PageMatch
     end
 
-    match_version_map[tag] = Version.new(tag_cleaned)
-  rescue TypeError
     nil
   end
-
-  match_version_map
 end
 
-def gnome_strategy(url, regex = nil)
-  match_version_map = {}
-
-  package = url.match(%r{/sources/(.*?)/})[1]
-  page_url = "https://download.gnome.org/sources/#{package}/cache.json"
-
-  # Restrict versions to even numbered minor versions (except x.90+)
-  regex ||= if GNOME_DEVEL_ALLOWLIST.include?(package)
-    /#{Regexp.escape(package)}-(\d+(?:\.\d+)+)\.t/
-  else
-    /#{Regexp.escape(package)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/
-  end
-
-  page_matches(page_url, regex).each do |match|
-    version = Version.new(match)
-    match_version_map[match] = version
-  end
-
-  match_version_map
-end
-
-def gnu_strategy(url, regex = nil)
-  match_version_map = {}
-
-  project_name_regexps = [
-    %r{/(?:software|gnu)/(.*?)/},
-    %r{//(.*?)\.gnu\.org(?:/)?$},
-  ]
-  match_list = project_name_regexps.map do |r|
-    url.match(r)
-  end.compact
-
-  puts "Multiple project names found: #{match_list}" if match_list.length > 1 && Homebrew.args.debug?
-
-  unless match_list.empty?
-    project_name = match_list[0][1]
-    page_url = "http://ftp.gnu.org/gnu/#{project_name}/?C=M&O=D"
-
-    regex ||= /#{project_name}-(\d+(?:\.\d+)*)/
-
-    page_matches(page_url, regex).each do |match|
-      version = Version.new(match)
-      match_version_map[match] = version
-    end
-  end
-
-  match_version_map
-end
-
-def hackage_strategy(url, _regex = nil)
-  match_version_map = {}
-
-  package = ((url.split("/")[4]).split("-")[0..-2]).join("-")
-  page_url = "https://hackage.haskell.org/package/#{package}/src"
-
-  regex ||= %r{<h3>#{package}-(.*?)/?</h3>}i
-
-  page_matches(page_url, regex).each do |match|
-    version = Version.new(match)
-    match_version_map[match] = version
-  end
-
-  match_version_map
-end
-
-def launchpad_strategy(url, regex = nil)
-  match_version_map = {}
-
-  package = url.match(%r{launchpad\.net/([^/]*)})[1]
-  page_url = "https://launchpad.net/#{package}"
-
-  regex ||= %r{<div class="version">\s*Latest version is (.+)\s*</div>}
-
-  page_matches(page_url, regex).each do |match|
-    version = Version.new(match)
-    match_version_map[match] = version
-  end
-
-  match_version_map
-end
-
-def npm_strategy(url, regex = nil)
-  match_version_map = {}
-
-  package = url.split("/")[3..-3].reject { |s| s == "-" }.join("/")
-  page_url = "https://www.npmjs.com/package/#{package}?activeTab=versions"
-
-  regex ||= %r{/package/#{package}/v/(\d+(?:\.\d+)+)"}
-
-  page_matches(page_url, regex).each do |match|
-    version = Version.new(match)
-    match_version_map[match] = version
-  end
-
-  match_version_map
-end
-
-def page_match_strategy(url, regex = nil)
-  match_version_map = {}
-
-  page_matches(url, regex).each do |match|
-    version = Version.new(match)
-    match_version_map[match] = version
-  end
-
-  match_version_map
-end
-
-def pypi_strategy(url, regex = nil)
-  match_version_map = {}
-
-  package = url[%r{https://files.pythonhosted.org/packages/.*/.*/(.*)-.*}, 1]
-  page_url = "https://pypi.org/project/#{package}"
-
-  regex ||= /#{package} ([0-9.]+)/
-
-  page_matches(page_url, regex).each do |match|
-    version = Version.new(match)
-    match_version_map[match] = version
-  end
-
-  match_version_map
-end
-
-def sourceforge_strategy(url, regex = nil)
-  match_version_map = {}
-
-  project_name = if url.include?("/project")
-    url.match(%r{/projects?/([^/]+)/})[1]
-  elsif url.include?(".net/p/")
-    url.match(%r{\.net/p/([^/]+)/})[1]
-  else
-    url.match(%r{\.net(?::/cvsroot)?/([^/]+)})[1]
-  end
-  page_url = "https://sourceforge.net/projects/#{project_name}/rss"
-
-  regex ||= %r{url=.+?/#{project_name}/files/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i
-
-  page_matches(page_url, regex).each do |match|
-    version = Version.new(match)
-    match_version_map[match] = version
-  end
-
-  match_version_map
-end
+require_relative "livecheck_strategy/apache.rb"
+require_relative "livecheck_strategy/bitbucket.rb"
+require_relative "livecheck_strategy/git.rb"
+require_relative "livecheck_strategy/gnome.rb"
+require_relative "livecheck_strategy/gnu.rb"
+require_relative "livecheck_strategy/hackage.rb"
+require_relative "livecheck_strategy/launchpad.rb"
+require_relative "livecheck_strategy/npm.rb"
+require_relative "livecheck_strategy/page_match.rb"
+require_relative "livecheck_strategy/pypi.rb"
+require_relative "livecheck_strategy/sourceforge.rb"

--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -2,19 +2,15 @@
 
 module LivecheckStrategy
   def self.strategies
-    @strategies ||= {
-      :apache      => Apache,
-      :bitbucket   => Bitbucket,
-      :git         => Git,
-      :gnome       => Gnome,
-      :gnu         => Gnu,
-      :hackage     => Hackage,
-      :launchpad   => Launchpad,
-      :npm         => Npm,
-      :page_match  => PageMatch,
-      :pypi        => PyPI,
-      :sourceforge => SourceForge,
-    }.freeze
+    return @strategies if defined? @strategies
+
+    @strategies = {}
+    LivecheckStrategy.constants.sort.each do |strategy_symbol|
+      key = strategy_symbol.to_s.underscore.to_sym
+      strategy = LivecheckStrategy.const_get(strategy_symbol)
+      @strategies[key] = strategy
+    end
+    @strategies.freeze
   end
   private_class_method :strategies
 
@@ -23,40 +19,24 @@ module LivecheckStrategy
   end
 
   def self.from_url(url, regex_provided = nil)
-    if Hackage.match?(url)
-      Hackage
-    elsif Git.match?(url)
-      Git
-    elsif SourceForge.match?(url)
-      SourceForge
-    elsif Gnu.match?(url)
-      Gnu
-    elsif PyPI.match?(url)
-      PyPI
-    elsif Npm.match?(url)
-      Npm
-    elsif Gnome.match?(url)
-      Gnome
-    elsif Launchpad.match?(url)
-      Launchpad
-    elsif Apache.match?(url)
-      Apache
-    elsif Bitbucket.match?(url)
-      Bitbucket
-    elsif regex_provided
-      PageMatch
+    usable_strategies = strategies.except(:page_match).values.select do |strategy|
+      strategy.respond_to?(:match?) && strategy.match?(url)
     end
+
+    usable_strategies << strategies[:page_match] if strategies.key?(:page_match) && regex_provided
+
+    usable_strategies.sort_by! do |strategy|
+      (strategy.const_defined?(:PRIORITY) ? strategy::PRIORITY : 5)
+    end.reverse!
+
+    usable_strategies[0]
   end
 end
 
-require_relative "livecheck_strategy/apache.rb"
-require_relative "livecheck_strategy/bitbucket.rb"
-require_relative "livecheck_strategy/git.rb"
-require_relative "livecheck_strategy/gnome.rb"
-require_relative "livecheck_strategy/gnu.rb"
-require_relative "livecheck_strategy/hackage.rb"
-require_relative "livecheck_strategy/launchpad.rb"
-require_relative "livecheck_strategy/npm.rb"
-require_relative "livecheck_strategy/page_match.rb"
-require_relative "livecheck_strategy/pypi.rb"
-require_relative "livecheck_strategy/sourceforge.rb"
+Dir.glob(File.join(__dir__, "livecheck_strategy", "*.rb"), &method(:require))
+
+if Homebrew.args.tap
+  current_tap = Tap.fetch(Homebrew.args.tap)
+  tap_strategy_path = File.join(current_tap.path, "livecheck_strategy")
+  Dir.glob(File.join(tap_strategy_path, "*.rb"), &method(:require)) if Dir.exist?(tap_strategy_path)
+end

--- a/livecheck/livecheck_strategy/apache.rb
+++ b/livecheck/livecheck_strategy/apache.rb
@@ -11,8 +11,8 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex)
       path, prefix, suffix = url.match(%r{path=(.+?)/([^/]*?)\d+(?:\.\d+)+(/|[^/]*)})[1, 3]
-      page_url = "https://archive.apache.org/dist/#{path}/"
 
+      page_url = "https://archive.apache.org/dist/#{path}/"
       regex ||= /href="#{Regexp.escape(prefix)}(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/
 
       PageMatch.find_versions(page_url, regex)

--- a/livecheck/livecheck_strategy/apache.rb
+++ b/livecheck/livecheck_strategy/apache.rb
@@ -15,13 +15,7 @@ module LivecheckStrategy
 
       regex ||= /href="#{Regexp.escape(prefix)}(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/
 
-      match_data = { :matches => {}, :regex => regex, :url => page_url }
-      page_matches(page_url, regex).each do |match|
-        version = Version.new(match)
-        match_data[:matches][match] = version
-      end
-
-      match_data
+      PageMatch.find_versions(page_url, regex)
     end
   end
 end

--- a/livecheck/livecheck_strategy/apache.rb
+++ b/livecheck/livecheck_strategy/apache.rb
@@ -2,8 +2,7 @@
 
 module LivecheckStrategy
   class Apache
-    NICE_NAME = "Apache"
-    NAME = NICE_NAME.downcase
+    NAME = name.demodulize
 
     def self.match?(url)
       %r{www\.apache\.org/dyn}.match?(url)

--- a/livecheck/livecheck_strategy/apache.rb
+++ b/livecheck/livecheck_strategy/apache.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module LivecheckStrategy
+  class Apache
+    NICE_NAME = "Apache"
+    NAME = NICE_NAME.downcase
+
+    def self.match?(url)
+      %r{www\.apache\.org/dyn}.match?(url)
+    end
+
+    def self.find_versions(url, regex)
+      path, prefix, suffix = url.match(%r{path=(.+?)/([^/]*?)\d+(?:\.\d+)+(/|[^/]*)})[1, 3]
+      page_url = "https://archive.apache.org/dist/#{path}/"
+
+      regex ||= /href="#{Regexp.escape(prefix)}(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/
+
+      match_data = { :matches => {}, :regex => regex, :url => page_url }
+      page_matches(page_url, regex).each do |match|
+        version = Version.new(match)
+        match_data[:matches][match] = version
+      end
+
+      match_data
+    end
+  end
+end

--- a/livecheck/livecheck_strategy/bitbucket.rb
+++ b/livecheck/livecheck_strategy/bitbucket.rb
@@ -17,13 +17,7 @@ module LivecheckStrategy
 
       regex ||= /(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}"/
 
-      match_data = { :matches => {}, :regex => regex, :url => page_url }
-      page_matches(page_url, regex).each do |match|
-        version = Version.new(match)
-        match_data[:matches][match] = version
-      end
-
-      match_data
+      PageMatch.find_versions(page_url, regex)
     end
   end
 end

--- a/livecheck/livecheck_strategy/bitbucket.rb
+++ b/livecheck/livecheck_strategy/bitbucket.rb
@@ -12,9 +12,9 @@ module LivecheckStrategy
     def self.find_versions(url, regex)
       path, kind, suffix =
         url.match(%r{bitbucket\.org/(.+?)/(get|downloads)/(?:.*?[-_])?v?\d+(?:\.\d+)+([^/]+)})[1, 3]
+
       page_url = "https://bitbucket.org/#{path}/downloads/"
       page_url << "?tab=tags" if kind == "get"
-
       regex ||= /(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}"/
 
       PageMatch.find_versions(page_url, regex)

--- a/livecheck/livecheck_strategy/bitbucket.rb
+++ b/livecheck/livecheck_strategy/bitbucket.rb
@@ -2,8 +2,7 @@
 
 module LivecheckStrategy
   class Bitbucket
-    NICE_NAME = "Bitbucket"
-    NAME = NICE_NAME.downcase
+    NAME = name.demodulize
 
     def self.match?(url)
       %r{bitbucket\.org(/[^/]+){4}\.\w+}.match?(url)

--- a/livecheck/livecheck_strategy/bitbucket.rb
+++ b/livecheck/livecheck_strategy/bitbucket.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module LivecheckStrategy
+  class Bitbucket
+    NICE_NAME = "Bitbucket"
+    NAME = NICE_NAME.downcase
+
+    def self.match?(url)
+      %r{bitbucket\.org(/[^/]+){4}\.\w+}.match?(url)
+    end
+
+    def self.find_versions(url, regex)
+      path, kind, suffix =
+        url.match(%r{bitbucket\.org/(.+?)/(get|downloads)/(?:.*?[-_])?v?\d+(?:\.\d+)+([^/]+)})[1, 3]
+      page_url = "https://bitbucket.org/#{path}/downloads/"
+      page_url << "?tab=tags" if kind == "get"
+
+      regex ||= /(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}"/
+
+      match_data = { :matches => {}, :regex => regex, :url => page_url }
+      page_matches(page_url, regex).each do |match|
+        version = Version.new(match)
+        match_data[:matches][match] = version
+      end
+
+      match_data
+    end
+  end
+end

--- a/livecheck/livecheck_strategy/bitbucket.rb
+++ b/livecheck/livecheck_strategy/bitbucket.rb
@@ -13,8 +13,11 @@ module LivecheckStrategy
       path, kind, suffix =
         url.match(%r{bitbucket\.org/(.+?)/(get|downloads)/(?:.*?[-_])?v?\d+(?:\.\d+)+([^/]+)})[1, 3]
 
-      page_url = "https://bitbucket.org/#{path}/downloads/"
-      page_url << "?tab=tags" if kind == "get"
+      page_url = if kind == "get"
+        "https://bitbucket.org/#{path}/downloads/?tab=tags"
+      else
+        "https://bitbucket.org/#{path}/downloads/"
+      end
       regex ||= /(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}"/
 
       PageMatch.find_versions(page_url, regex)

--- a/livecheck/livecheck_strategy/git.rb
+++ b/livecheck/livecheck_strategy/git.rb
@@ -4,6 +4,7 @@ module LivecheckStrategy
   class Git
     NICE_NAME = "Git"
     NAME = NICE_NAME.downcase
+    PRIORITY = 8
 
     def self.match?(url)
       DownloadStrategyDetector.detect(url) <= GitDownloadStrategy

--- a/livecheck/livecheck_strategy/git.rb
+++ b/livecheck/livecheck_strategy/git.rb
@@ -21,9 +21,9 @@ module LivecheckStrategy
 
         captures = regex.is_a?(Regexp) ? tag.scan(regex) : []
         tag_cleaned = if captures[0].is_a?(Array)
-          captures[0][0]  # Extract the first capture group
+          captures[0][0] # Extract the first capture group
         else
-          tag[/\D*(.*)/, 1]  # Remove non-digits from the beginning of the tag
+          tag[/\D*(.*)/, 1] # Remove non-digits from the beginning of the tag
         end
 
         match_data[:matches][tag] = Version.new(tag_cleaned)

--- a/livecheck/livecheck_strategy/git.rb
+++ b/livecheck/livecheck_strategy/git.rb
@@ -19,13 +19,11 @@ module LivecheckStrategy
         # 'debian/' prefixed tags
         next if tag =~ %r{debian/} && !tags_only_debian
 
-        captures = tag.scan(regex) if regex
-        tag_cleaned = if captures && !captures.empty? && captures[0].is_a?(Array)
-          # Use the first capture group as the version
-          captures[0][0]
+        captures = regex.is_a?(Regexp) ? tag.scan(regex) : []
+        tag_cleaned = if captures[0].is_a?(Array)
+          captures[0][0]  # Extract the first capture group
         else
-          # Remove any character before the first number
-          tag[/\D*(.*)/, 1]
+          tag[/\D*(.*)/, 1]  # Remove non-digits from the beginning of the tag
         end
 
         match_data[:matches][tag] = Version.new(tag_cleaned)

--- a/livecheck/livecheck_strategy/git.rb
+++ b/livecheck/livecheck_strategy/git.rb
@@ -2,8 +2,7 @@
 
 module LivecheckStrategy
   class Git
-    NICE_NAME = "Git"
-    NAME = NICE_NAME.downcase
+    NAME = name.demodulize
     PRIORITY = 8
 
     def self.match?(url)

--- a/livecheck/livecheck_strategy/gnome.rb
+++ b/livecheck/livecheck_strategy/gnome.rb
@@ -14,6 +14,7 @@ module LivecheckStrategy
       libart_lgpl
       libepoxy
     ].freeze
+    private_constant :DEV_VERSION_ALLOWLIST
 
     def self.match?(url)
       /download\.gnome\.org/.match?(url)

--- a/livecheck/livecheck_strategy/gnome.rb
+++ b/livecheck/livecheck_strategy/gnome.rb
@@ -21,14 +21,14 @@ module LivecheckStrategy
     end
 
     def self.find_versions(url, regex)
-      package = url.match(%r{/sources/(.*?)/})[1]
+      package_name = url.match(%r{/sources/(.*?)/})[1]
 
-      page_url = "https://download.gnome.org/sources/#{package}/cache.json"
-      regex ||= if DEV_VERSION_ALLOWLIST.include?(package)
-        /#{Regexp.escape(package)}-(\d+(?:\.\d+)+)\.t/
+      page_url = "https://download.gnome.org/sources/#{package_name}/cache.json"
+      regex ||= if DEV_VERSION_ALLOWLIST.include?(package_name)
+        /#{Regexp.escape(package_name)}-(\d+(?:\.\d+)+)\.t/
       else
         # Only match versions with an even-numbered minor (except x.90+)
-        /#{Regexp.escape(package)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/
+        /#{Regexp.escape(package_name)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/
       end
 
       PageMatch.find_versions(page_url, regex)

--- a/livecheck/livecheck_strategy/gnome.rb
+++ b/livecheck/livecheck_strategy/gnome.rb
@@ -6,12 +6,13 @@ module LivecheckStrategy
     NAME = NICE_NAME.downcase
 
     # Formulae that do not use GNOME's "even-numbered minor is stable" scheme
-    GNOME_DEVEL_ALLOWLIST = [
-      "gcab",
-      "gtk-doc",
-      "gtk-mac-integration",
-      "libart_lgpl", # The package name for libart is "libart_lgpl"
-      "libepoxy",
+    # "libart_lgpl" is the package name for libart
+    GNOME_DEVEL_ALLOWLIST = %w[
+      gcab
+      gtk-doc
+      gtk-mac-integration
+      libart_lgpl
+      libepoxy
     ].freeze
 
     def self.match?(url)

--- a/livecheck/livecheck_strategy/gnome.rb
+++ b/livecheck/livecheck_strategy/gnome.rb
@@ -7,7 +7,7 @@ module LivecheckStrategy
 
     # Formulae that do not use GNOME's "even-numbered minor is stable" scheme
     # "libart_lgpl" is the package name for libart
-    GNOME_DEVEL_ALLOWLIST = %w[
+    DEV_VERSION_ALLOWLIST = %w[
       gcab
       gtk-doc
       gtk-mac-integration
@@ -24,7 +24,7 @@ module LivecheckStrategy
       page_url = "https://download.gnome.org/sources/#{package}/cache.json"
 
       # Restrict versions to even numbered minor versions (except x.90+)
-      regex ||= if GNOME_DEVEL_ALLOWLIST.include?(package)
+      regex ||= if DEV_VERSION_ALLOWLIST.include?(package)
         /#{Regexp.escape(package)}-(\d+(?:\.\d+)+)\.t/
       else
         /#{Regexp.escape(package)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/

--- a/livecheck/livecheck_strategy/gnome.rb
+++ b/livecheck/livecheck_strategy/gnome.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module LivecheckStrategy
+  class Gnome
+    NICE_NAME = "GNOME"
+    NAME = NICE_NAME.downcase
+
+    # Formulae that do not use GNOME's "even-numbered minor is stable" scheme
+    GNOME_DEVEL_ALLOWLIST = [
+      "gcab",
+      "gtk-doc",
+      "gtk-mac-integration",
+      "libart_lgpl", # The package name for libart is "libart_lgpl"
+      "libepoxy",
+    ].freeze
+
+    def self.match?(url)
+      /download\.gnome\.org/.match?(url)
+    end
+
+    def self.find_versions(url, regex)
+      package = url.match(%r{/sources/(.*?)/})[1]
+      page_url = "https://download.gnome.org/sources/#{package}/cache.json"
+
+      # Restrict versions to even numbered minor versions (except x.90+)
+      regex ||= if GNOME_DEVEL_ALLOWLIST.include?(package)
+        /#{Regexp.escape(package)}-(\d+(?:\.\d+)+)\.t/
+      else
+        /#{Regexp.escape(package)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/
+      end
+
+      match_data = { :matches => {}, :regex => regex, :url => page_url }
+      page_matches(page_url, regex).each do |match|
+        version = Version.new(match)
+        match_data[:matches][match] = version
+      end
+
+      match_data
+    end
+  end
+end

--- a/livecheck/livecheck_strategy/gnome.rb
+++ b/livecheck/livecheck_strategy/gnome.rb
@@ -3,7 +3,7 @@
 module LivecheckStrategy
   class Gnome
     NICE_NAME = "GNOME"
-    NAME = NICE_NAME.downcase
+    NAME = name.demodulize
 
     # Formulae that do not use GNOME's "even-numbered minor is stable" scheme
     # "libart_lgpl" is the package name for libart

--- a/livecheck/livecheck_strategy/gnome.rb
+++ b/livecheck/livecheck_strategy/gnome.rb
@@ -31,13 +31,7 @@ module LivecheckStrategy
         /#{Regexp.escape(package)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/
       end
 
-      match_data = { :matches => {}, :regex => regex, :url => page_url }
-      page_matches(page_url, regex).each do |match|
-        version = Version.new(match)
-        match_data[:matches][match] = version
-      end
-
-      match_data
+      PageMatch.find_versions(page_url, regex)
     end
   end
 end

--- a/livecheck/livecheck_strategy/gnome.rb
+++ b/livecheck/livecheck_strategy/gnome.rb
@@ -22,12 +22,12 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex)
       package = url.match(%r{/sources/(.*?)/})[1]
-      page_url = "https://download.gnome.org/sources/#{package}/cache.json"
 
-      # Restrict versions to even numbered minor versions (except x.90+)
+      page_url = "https://download.gnome.org/sources/#{package}/cache.json"
       regex ||= if DEV_VERSION_ALLOWLIST.include?(package)
         /#{Regexp.escape(package)}-(\d+(?:\.\d+)+)\.t/
       else
+        # Only match versions with an even-numbered minor (except x.90+)
         /#{Regexp.escape(package)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/
       end
 

--- a/livecheck/livecheck_strategy/gnome.rb
+++ b/livecheck/livecheck_strategy/gnome.rb
@@ -2,8 +2,8 @@
 
 module LivecheckStrategy
   class Gnome
-    NICE_NAME = "GNOME"
     NAME = name.demodulize
+    NICE_NAME = "GNOME"
 
     # Formulae that do not use GNOME's "even-numbered minor is stable" scheme
     # "libart_lgpl" is the package name for libart

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -3,7 +3,7 @@
 module LivecheckStrategy
   class Gnu
     NICE_NAME = "GNU"
-    NAME = NICE_NAME.downcase
+    NAME = name.demodulize
 
     PROJECT_NAME_REGEXES = [
       %r{/(?:software|gnu)/(.*?)/},

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module LivecheckStrategy
+  class Gnu
+    NICE_NAME = "GNU"
+    NAME = NICE_NAME.downcase
+
+    GNU_PROJECT_NAME_REGEXES = [
+      %r{/(?:software|gnu)/(.*?)/},
+      %r{//(.*?)\.gnu\.org(?:/)?$},
+    ].freeze
+
+    GNU_SPECIAL_CASES = %w[
+      avrdude
+      clisp
+      cvs
+      dvdrtools
+      icoutils
+      kawa
+      lzip
+      mit-scheme
+      numdiff
+      oath-toolkit
+    ].freeze
+
+    def self.match?(url)
+      url =~ /gnu\.org/ && GNU_SPECIAL_CASES.none? { |sc| url.include? sc }
+    end
+
+    def self.find_versions(url, regex)
+      match_data = { :matches => {}, :regex => regex, :url => url }
+
+      match_list = GNU_PROJECT_NAME_REGEXES.map do |r|
+        url.match(r)
+      end.compact
+
+      puts "\nMultiple project names found: #{match_list}\n" if match_list.length > 1 && Homebrew.args.debug?
+
+      return match_data if match_list.empty?
+
+      project_name = match_list[0][1]
+      page_url = "http://ftp.gnu.org/gnu/#{project_name}/?C=M&O=D"
+      match_data[:url] = page_url
+
+      regex ||= /#{project_name}-(\d+(?:\.\d+)*)/
+
+      page_matches(page_url, regex).each do |match|
+        version = Version.new(match)
+        match_data[:matches][match] = version
+      end
+
+      match_data
+    end
+  end
+end

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -31,14 +31,13 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex)
       match_list = PROJECT_NAME_REGEXES.map { |r| url.match(r) }.compact
+      return { :matches => {}, :regex => regex, :url => url } if match_list.empty?
 
       puts "\nMultiple project names found: #{match_list}\n" if match_list.length > 1 && Homebrew.args.debug?
 
-      return { :matches => {}, :regex => regex, :url => url } if match_list.empty?
-
       project_name = match_list[0][1]
-      page_url = "http://ftp.gnu.org/gnu/#{project_name}/?C=M&O=D"
 
+      page_url = "http://ftp.gnu.org/gnu/#{project_name}/?C=M&O=D"
       regex ||= /#{project_name}-(\d+(?:\.\d+)*)/
 
       PageMatch.find_versions(page_url, regex)

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -32,9 +32,7 @@ module LivecheckStrategy
     def self.find_versions(url, regex)
       match_data = { :matches => {}, :regex => regex, :url => url }
 
-      match_list = PROJECT_NAME_REGEXES.map do |r|
-        url.match(r)
-      end.compact
+      match_list = PROJECT_NAME_REGEXES.map { |r| url.match(r) }.compact
 
       puts "\nMultiple project names found: #{match_list}\n" if match_list.length > 1 && Homebrew.args.debug?
 

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -2,8 +2,8 @@
 
 module LivecheckStrategy
   class Gnu
-    NICE_NAME = "GNU"
     NAME = name.demodulize
+    NICE_NAME = "GNU"
 
     PROJECT_NAME_REGEXES = [
       %r{/(?:software|gnu)/(.*?)/},

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -5,12 +5,12 @@ module LivecheckStrategy
     NICE_NAME = "GNU"
     NAME = NICE_NAME.downcase
 
-    GNU_PROJECT_NAME_REGEXES = [
+    PROJECT_NAME_REGEXES = [
       %r{/(?:software|gnu)/(.*?)/},
       %r{//(.*?)\.gnu\.org(?:/)?$},
     ].freeze
 
-    GNU_SPECIAL_CASES = %w[
+    SPECIAL_CASES = %w[
       avrdude
       clisp
       cvs
@@ -24,13 +24,13 @@ module LivecheckStrategy
     ].freeze
 
     def self.match?(url)
-      url =~ /gnu\.org/ && GNU_SPECIAL_CASES.none? { |sc| url.include? sc }
+      url =~ /gnu\.org/ && SPECIAL_CASES.none? { |sc| url.include? sc }
     end
 
     def self.find_versions(url, regex)
       match_data = { :matches => {}, :regex => regex, :url => url }
 
-      match_list = GNU_PROJECT_NAME_REGEXES.map do |r|
+      match_list = PROJECT_NAME_REGEXES.map do |r|
         url.match(r)
       end.compact
 

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -9,6 +9,7 @@ module LivecheckStrategy
       %r{/(?:software|gnu)/(.*?)/},
       %r{//(.*?)\.gnu\.org(?:/)?$},
     ].freeze
+    private_constant :PROJECT_NAME_REGEXES
 
     SPECIAL_CASES = %w[
       avrdude
@@ -22,6 +23,7 @@ module LivecheckStrategy
       numdiff
       oath-toolkit
     ].freeze
+    private_constant :SPECIAL_CASES
 
     def self.match?(url)
       url =~ /gnu\.org/ && SPECIAL_CASES.none? { |sc| url.include? sc }

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -30,26 +30,18 @@ module LivecheckStrategy
     end
 
     def self.find_versions(url, regex)
-      match_data = { :matches => {}, :regex => regex, :url => url }
-
       match_list = PROJECT_NAME_REGEXES.map { |r| url.match(r) }.compact
 
       puts "\nMultiple project names found: #{match_list}\n" if match_list.length > 1 && Homebrew.args.debug?
 
-      return match_data if match_list.empty?
+      return { :matches => {}, :regex => regex, :url => url } if match_list.empty?
 
       project_name = match_list[0][1]
       page_url = "http://ftp.gnu.org/gnu/#{project_name}/?C=M&O=D"
-      match_data[:url] = page_url
 
       regex ||= /#{project_name}-(\d+(?:\.\d+)*)/
 
-      page_matches(page_url, regex).each do |match|
-        version = Version.new(match)
-        match_data[:matches][match] = version
-      end
-
-      match_data
+      PageMatch.find_versions(page_url, regex)
     end
   end
 end

--- a/livecheck/livecheck_strategy/hackage.rb
+++ b/livecheck/livecheck_strategy/hackage.rb
@@ -2,8 +2,7 @@
 
 module LivecheckStrategy
   class Hackage
-    NICE_NAME = "Hackage"
-    NAME = NICE_NAME.downcase
+    NAME = name.demodulize
 
     def self.match?(url)
       /hackage\.haskell\.org/.match?(url)

--- a/livecheck/livecheck_strategy/hackage.rb
+++ b/livecheck/livecheck_strategy/hackage.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module LivecheckStrategy
+  class Hackage
+    NICE_NAME = "Hackage"
+    NAME = NICE_NAME.downcase
+
+    def self.match?(url)
+      /hackage\.haskell\.org/.match?(url)
+    end
+
+    def self.find_versions(url, regex)
+      package = ((url.split("/")[4]).split("-")[0..-2]).join("-")
+      page_url = "https://hackage.haskell.org/package/#{package}/src"
+
+      regex ||= %r{<h3>#{package}-(.*?)/?</h3>}i
+
+      match_data = { :matches => {}, :regex => regex, :url => page_url }
+      page_matches(page_url, regex).each do |match|
+        version = Version.new(match)
+        match_data[:matches][match] = version
+      end
+
+      match_data
+    end
+  end
+end

--- a/livecheck/livecheck_strategy/hackage.rb
+++ b/livecheck/livecheck_strategy/hackage.rb
@@ -11,8 +11,8 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex)
       package = ((url.split("/")[4]).split("-")[0..-2]).join("-")
-      page_url = "https://hackage.haskell.org/package/#{package}/src"
 
+      page_url = "https://hackage.haskell.org/package/#{package}/src"
       regex ||= %r{<h3>#{package}-(.*?)/?</h3>}i
 
       PageMatch.find_versions(page_url, regex)

--- a/livecheck/livecheck_strategy/hackage.rb
+++ b/livecheck/livecheck_strategy/hackage.rb
@@ -10,10 +10,10 @@ module LivecheckStrategy
     end
 
     def self.find_versions(url, regex)
-      package = ((url.split("/")[4]).split("-")[0..-2]).join("-")
+      package_name = ((url.split("/")[4]).split("-")[0..-2]).join("-")
 
-      page_url = "https://hackage.haskell.org/package/#{package}/src"
-      regex ||= %r{<h3>#{package}-(.*?)/?</h3>}i
+      page_url = "https://hackage.haskell.org/package/#{package_name}/src"
+      regex ||= %r{<h3>#{package_name}-(.*?)/?</h3>}i
 
       PageMatch.find_versions(page_url, regex)
     end

--- a/livecheck/livecheck_strategy/hackage.rb
+++ b/livecheck/livecheck_strategy/hackage.rb
@@ -15,13 +15,7 @@ module LivecheckStrategy
 
       regex ||= %r{<h3>#{package}-(.*?)/?</h3>}i
 
-      match_data = { :matches => {}, :regex => regex, :url => page_url }
-      page_matches(page_url, regex).each do |match|
-        version = Version.new(match)
-        match_data[:matches][match] = version
-      end
-
-      match_data
+      PageMatch.find_versions(page_url, regex)
     end
   end
 end

--- a/livecheck/livecheck_strategy/launchpad.rb
+++ b/livecheck/livecheck_strategy/launchpad.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module LivecheckStrategy
+  class Launchpad
+    NICE_NAME = "Launchpad"
+    NAME = NICE_NAME.downcase
+
+    def self.match?(url)
+      /launchpad\.net/.match?(url)
+    end
+
+    def self.find_versions(url, regex)
+      package = url.match(%r{launchpad\.net/([^/]*)})[1]
+      page_url = "https://launchpad.net/#{package}"
+
+      regex ||= %r{<div class="version">\s*Latest version is (.+)\s*</div>}
+
+      match_data = { :matches => {}, :regex => regex, :url => page_url }
+      page_matches(page_url, regex).each do |match|
+        version = Version.new(match)
+        match_data[:matches][match] = version
+      end
+
+      match_data
+    end
+  end
+end

--- a/livecheck/livecheck_strategy/launchpad.rb
+++ b/livecheck/livecheck_strategy/launchpad.rb
@@ -2,8 +2,7 @@
 
 module LivecheckStrategy
   class Launchpad
-    NICE_NAME = "Launchpad"
-    NAME = NICE_NAME.downcase
+    NAME = name.demodulize
 
     def self.match?(url)
       /launchpad\.net/.match?(url)

--- a/livecheck/livecheck_strategy/launchpad.rb
+++ b/livecheck/livecheck_strategy/launchpad.rb
@@ -15,13 +15,7 @@ module LivecheckStrategy
 
       regex ||= %r{<div class="version">\s*Latest version is (.+)\s*</div>}
 
-      match_data = { :matches => {}, :regex => regex, :url => page_url }
-      page_matches(page_url, regex).each do |match|
-        version = Version.new(match)
-        match_data[:matches][match] = version
-      end
-
-      match_data
+      PageMatch.find_versions(page_url, regex)
     end
   end
 end

--- a/livecheck/livecheck_strategy/launchpad.rb
+++ b/livecheck/livecheck_strategy/launchpad.rb
@@ -11,8 +11,8 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex)
       package = url.match(%r{launchpad\.net/([^/]*)})[1]
-      page_url = "https://launchpad.net/#{package}"
 
+      page_url = "https://launchpad.net/#{package}"
       regex ||= %r{<div class="version">\s*Latest version is (.+)\s*</div>}
 
       PageMatch.find_versions(page_url, regex)

--- a/livecheck/livecheck_strategy/launchpad.rb
+++ b/livecheck/livecheck_strategy/launchpad.rb
@@ -10,9 +10,9 @@ module LivecheckStrategy
     end
 
     def self.find_versions(url, regex)
-      package = url.match(%r{launchpad\.net/([^/]*)})[1]
+      package_name = url.match(%r{launchpad\.net/([^/]*)})[1]
 
-      page_url = "https://launchpad.net/#{package}"
+      page_url = "https://launchpad.net/#{package_name}"
       regex ||= %r{<div class="version">\s*Latest version is (.+)\s*</div>}
 
       PageMatch.find_versions(page_url, regex)

--- a/livecheck/livecheck_strategy/npm.rb
+++ b/livecheck/livecheck_strategy/npm.rb
@@ -11,8 +11,8 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex)
       package = url.split("/")[3..-3].reject { |s| s == "-" }.join("/")
-      page_url = "https://www.npmjs.com/package/#{package}?activeTab=versions"
 
+      page_url = "https://www.npmjs.com/package/#{package}?activeTab=versions"
       regex ||= %r{/package/#{package}/v/(\d+(?:\.\d+)+)"}
 
       PageMatch.find_versions(page_url, regex)

--- a/livecheck/livecheck_strategy/npm.rb
+++ b/livecheck/livecheck_strategy/npm.rb
@@ -15,13 +15,7 @@ module LivecheckStrategy
 
       regex ||= %r{/package/#{package}/v/(\d+(?:\.\d+)+)"}
 
-      match_data = { :matches => {}, :regex => regex, :url => page_url }
-      page_matches(page_url, regex).each do |match|
-        version = Version.new(match)
-        match_data[:matches][match] = version
-      end
-
-      match_data
+      PageMatch.find_versions(page_url, regex)
     end
   end
 end

--- a/livecheck/livecheck_strategy/npm.rb
+++ b/livecheck/livecheck_strategy/npm.rb
@@ -2,8 +2,8 @@
 
 module LivecheckStrategy
   class Npm
-    NICE_NAME = "npm"
     NAME = name.demodulize
+    NICE_NAME = "npm"
 
     def self.match?(url)
       /registry\.npmjs\.org/.match?(url)

--- a/livecheck/livecheck_strategy/npm.rb
+++ b/livecheck/livecheck_strategy/npm.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module LivecheckStrategy
+  class Npm
+    NICE_NAME = "NPM"
+    NAME = NICE_NAME.downcase
+
+    def self.match?(url)
+      /registry\.npmjs\.org/.match?(url)
+    end
+
+    def self.find_versions(url, regex)
+      package = url.split("/")[3..-3].reject { |s| s == "-" }.join("/")
+      page_url = "https://www.npmjs.com/package/#{package}?activeTab=versions"
+
+      regex ||= %r{/package/#{package}/v/(\d+(?:\.\d+)+)"}
+
+      match_data = { :matches => {}, :regex => regex, :url => page_url }
+      page_matches(page_url, regex).each do |match|
+        version = Version.new(match)
+        match_data[:matches][match] = version
+      end
+
+      match_data
+    end
+  end
+end

--- a/livecheck/livecheck_strategy/npm.rb
+++ b/livecheck/livecheck_strategy/npm.rb
@@ -10,10 +10,10 @@ module LivecheckStrategy
     end
 
     def self.find_versions(url, regex)
-      package = url.split("/")[3..-3].reject { |s| s == "-" }.join("/")
+      package_name = url.split("/")[3..-3].reject { |s| s == "-" }.join("/")
 
-      page_url = "https://www.npmjs.com/package/#{package}?activeTab=versions"
-      regex ||= %r{/package/#{package}/v/(\d+(?:\.\d+)+)"}
+      page_url = "https://www.npmjs.com/package/#{package_name}?activeTab=versions"
+      regex ||= %r{/package/#{package_name}/v/(\d+(?:\.\d+)+)"}
 
       PageMatch.find_versions(page_url, regex)
     end

--- a/livecheck/livecheck_strategy/npm.rb
+++ b/livecheck/livecheck_strategy/npm.rb
@@ -2,8 +2,8 @@
 
 module LivecheckStrategy
   class Npm
-    NICE_NAME = "NPM"
-    NAME = NICE_NAME.downcase
+    NICE_NAME = "npm"
+    NAME = name.demodulize
 
     def self.match?(url)
       /registry\.npmjs\.org/.match?(url)

--- a/livecheck/livecheck_strategy/page_match.rb
+++ b/livecheck/livecheck_strategy/page_match.rb
@@ -2,8 +2,8 @@
 
 module LivecheckStrategy
   class PageMatch
-    NICE_NAME = "Page match"
     NAME = name.demodulize
+    NICE_NAME = "Page match"
     PRIORITY = 0
 
     def self.find_versions(url, regex)

--- a/livecheck/livecheck_strategy/page_match.rb
+++ b/livecheck/livecheck_strategy/page_match.rb
@@ -7,6 +7,7 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex)
       match_data = { :matches => {}, :regex => regex, :url => url }
+
       page_matches(url, regex).each do |match|
         match_data[:matches][match] = Version.new(match)
       end

--- a/livecheck/livecheck_strategy/page_match.rb
+++ b/livecheck/livecheck_strategy/page_match.rb
@@ -4,6 +4,7 @@ module LivecheckStrategy
   class PageMatch
     NICE_NAME = "Page match"
     NAME = "page_match"
+    PRIORITY = 0
 
     def self.find_versions(url, regex)
       match_data = { :matches => {}, :regex => regex, :url => url }

--- a/livecheck/livecheck_strategy/page_match.rb
+++ b/livecheck/livecheck_strategy/page_match.rb
@@ -3,7 +3,7 @@
 module LivecheckStrategy
   class PageMatch
     NICE_NAME = "Page match"
-    NAME = "page_match"
+    NAME = name.demodulize
     PRIORITY = 0
 
     def self.find_versions(url, regex)

--- a/livecheck/livecheck_strategy/page_match.rb
+++ b/livecheck/livecheck_strategy/page_match.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module LivecheckStrategy
+  class PageMatch
+    NICE_NAME = "Page match"
+    NAME = "page_match"
+
+    def self.find_versions(url, regex)
+      match_data = { :matches => {}, :regex => regex, :url => url }
+      page_matches(url, regex).each do |match|
+        match_data[:matches][match] = Version.new(match)
+      end
+
+      match_data
+    end
+  end
+end

--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module LivecheckStrategy
+  class PyPI
+    NICE_NAME = "PyPI"
+    NAME = NICE_NAME.downcase
+
+    def self.match?(url)
+      /files\.pythonhosted\.org/.match?(url)
+    end
+
+    def self.find_versions(url, regex)
+      package = url[%r{https://files.pythonhosted.org/packages/.*/.*/(.*)-.*}, 1]
+      page_url = "https://pypi.org/project/#{package}"
+
+      regex ||= /#{package} ([0-9.]+)/
+
+      match_data = { :matches => {}, :regex => regex, :url => page_url }
+      page_matches(page_url, regex).each do |match|
+        version = Version.new(match)
+        match_data[:matches][match] = version
+      end
+
+      match_data
+    end
+  end
+end

--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -2,8 +2,8 @@
 
 module LivecheckStrategy
   class Pypi
-    NICE_NAME = "PyPI"
     NAME = name.demodulize
+    NICE_NAME = "PyPI"
 
     def self.match?(url)
       /files\.pythonhosted\.org/.match?(url)

--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -15,13 +15,7 @@ module LivecheckStrategy
 
       regex ||= /#{package} ([0-9.]+)/
 
-      match_data = { :matches => {}, :regex => regex, :url => page_url }
-      page_matches(page_url, regex).each do |match|
-        version = Version.new(match)
-        match_data[:matches][match] = version
-      end
-
-      match_data
+      PageMatch.find_versions(page_url, regex)
     end
   end
 end

--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -11,8 +11,8 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex)
       package = url[%r{https://files.pythonhosted.org/packages/.*/.*/(.*)-.*}, 1]
-      page_url = "https://pypi.org/project/#{package}"
 
+      page_url = "https://pypi.org/project/#{package}"
       regex ||= /#{package} ([0-9.]+)/
 
       PageMatch.find_versions(page_url, regex)

--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module LivecheckStrategy
-  class PyPI
+  class Pypi
     NICE_NAME = "PyPI"
     NAME = NICE_NAME.downcase
 

--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -10,10 +10,10 @@ module LivecheckStrategy
     end
 
     def self.find_versions(url, regex)
-      package = url[%r{https://files.pythonhosted.org/packages/.*/.*/(.*)-.*}, 1]
+      package_name = url[%r{https://files.pythonhosted.org/packages/.*/.*/(.*)-.*}, 1]
 
-      page_url = "https://pypi.org/project/#{package}"
-      regex ||= /#{package} ([0-9.]+)/
+      page_url = "https://pypi.org/project/#{package_name}"
+      regex ||= /#{package_name} ([0-9.]+)/
 
       PageMatch.find_versions(page_url, regex)
     end

--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -3,7 +3,7 @@
 module LivecheckStrategy
   class Pypi
     NICE_NAME = "PyPI"
-    NAME = NICE_NAME.downcase
+    NAME = name.demodulize
 
     def self.match?(url)
       /files\.pythonhosted\.org/.match?(url)

--- a/livecheck/livecheck_strategy/sourceforge.rb
+++ b/livecheck/livecheck_strategy/sourceforge.rb
@@ -20,6 +20,7 @@ module LivecheckStrategy
       potrace
       remake
     ].freeze
+    private_constant :SPECIAL_CASES
 
     def self.match?(url)
       /(sourceforge|sf)\.net/.match?(url) &&

--- a/livecheck/livecheck_strategy/sourceforge.rb
+++ b/livecheck/livecheck_strategy/sourceforge.rb
@@ -5,7 +5,7 @@ module LivecheckStrategy
     NICE_NAME = "SourceForge"
     NAME = NICE_NAME.downcase
 
-    SOURCEFORGE_SPECIAL_CASES = %w[
+    SPECIAL_CASES = %w[
       /avf/
       /bashdb/
       /netpbm/
@@ -23,7 +23,7 @@ module LivecheckStrategy
 
     def self.match?(url)
       /(sourceforge|sf)\.net/.match?(url) &&
-        SOURCEFORGE_SPECIAL_CASES.none? { |sc| url.include? sc }
+        SPECIAL_CASES.none? { |sc| url.include? sc }
     end
 
     def self.find_versions(url, regex)

--- a/livecheck/livecheck_strategy/sourceforge.rb
+++ b/livecheck/livecheck_strategy/sourceforge.rb
@@ -2,8 +2,8 @@
 
 module LivecheckStrategy
   class Sourceforge
-    NICE_NAME = "SourceForge"
     NAME = name.demodulize
+    NICE_NAME = "SourceForge"
 
     SPECIAL_CASES = %w[
       /avf/
@@ -37,7 +37,7 @@ module LivecheckStrategy
       end
 
       page_url = "https://sourceforge.net/projects/#{project_name}/rss"
-      regex ||= %r{url=.+?/#{project_name}/files/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i
+      regex ||= %r{url=.*?/#{project_name}/files/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i
 
       PageMatch.find_versions(page_url, regex)
     end

--- a/livecheck/livecheck_strategy/sourceforge.rb
+++ b/livecheck/livecheck_strategy/sourceforge.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module LivecheckStrategy
+  class SourceForge
+    NICE_NAME = "SourceForge"
+    NAME = NICE_NAME.downcase
+
+    SOURCEFORGE_SPECIAL_CASES = %w[
+      /avf/
+      /bashdb/
+      /netpbm/
+      bcrypt.sourceforge.net
+      e2fsprogs
+      foremost.sourceforge.net
+      liba52.sourceforge.net
+      libwps
+      log4cpp
+      mikmod
+      opencore-amr
+      potrace
+      remake
+    ].freeze
+
+    def self.match?(url)
+      /(sourceforge|sf)\.net/.match?(url) &&
+        SOURCEFORGE_SPECIAL_CASES.none? { |sc| url.include? sc }
+    end
+
+    def self.find_versions(url, regex)
+      project_name = if url.include?("/project")
+        url.match(%r{/projects?/([^/]+)/})[1]
+      elsif url.include?(".net/p/")
+        url.match(%r{\.net/p/([^/]+)/})[1]
+      else
+        url.match(%r{\.net(?::/cvsroot)?/([^/]+)})[1]
+      end
+      page_url = "https://sourceforge.net/projects/#{project_name}/rss"
+
+      regex ||= %r{url=.+?/#{project_name}/files/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i
+
+      match_data = { :matches => {}, :regex => regex, :url => page_url }
+      page_matches(page_url, regex).each do |match|
+        version = Version.new(match)
+        match_data[:matches][match] = version
+      end
+
+      match_data
+    end
+  end
+end

--- a/livecheck/livecheck_strategy/sourceforge.rb
+++ b/livecheck/livecheck_strategy/sourceforge.rb
@@ -35,8 +35,8 @@ module LivecheckStrategy
       else
         url.match(%r{\.net(?::/cvsroot)?/([^/]+)})[1]
       end
-      page_url = "https://sourceforge.net/projects/#{project_name}/rss"
 
+      page_url = "https://sourceforge.net/projects/#{project_name}/rss"
       regex ||= %r{url=.+?/#{project_name}/files/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i
 
       PageMatch.find_versions(page_url, regex)

--- a/livecheck/livecheck_strategy/sourceforge.rb
+++ b/livecheck/livecheck_strategy/sourceforge.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module LivecheckStrategy
-  class SourceForge
+  class Sourceforge
     NICE_NAME = "SourceForge"
     NAME = NICE_NAME.downcase
 

--- a/livecheck/livecheck_strategy/sourceforge.rb
+++ b/livecheck/livecheck_strategy/sourceforge.rb
@@ -3,7 +3,7 @@
 module LivecheckStrategy
   class Sourceforge
     NICE_NAME = "SourceForge"
-    NAME = NICE_NAME.downcase
+    NAME = name.demodulize
 
     SPECIAL_CASES = %w[
       /avf/

--- a/livecheck/livecheck_strategy/sourceforge.rb
+++ b/livecheck/livecheck_strategy/sourceforge.rb
@@ -39,13 +39,7 @@ module LivecheckStrategy
 
       regex ||= %r{url=.+?/#{project_name}/files/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i
 
-      match_data = { :matches => {}, :regex => regex, :url => page_url }
-      page_matches(page_url, regex).each do |match|
-        version = Version.new(match)
-        match_data[:matches][match] = version
-      end
-
-      match_data
+      PageMatch.find_versions(page_url, regex)
     end
   end
 end

--- a/livecheck/utils.rb
+++ b/livecheck/utils.rb
@@ -29,6 +29,5 @@ end
 def page_matches(url, regex)
   page = URI.open(url).read
   matches = page.scan(regex)
-  puts "\nMatched Text on Page:\n", matches.join(", ") if Homebrew.args.debug? && !matches.empty?
   matches.map(&:first).uniq
 end


### PR DESCRIPTION
Work on this started months ago when the strategies were all one big if/elsif statement in `heuristic.rb` and the general idea was to refactor the strategies into individual units of some sort (see the tail end of #301).

@maxim-belkin opened a PR (#601) before I had gotten around to creating one for my changes, so I ended up using that PR to close the gap some between the state of livecheck at the time and my refactoring work by moving the strategies into functions in `livecheck_strategy.rb`.

He had suggested that we create individual files for each strategy but I hadn't determined if that was going to be the best approach with the future migration to Homebrew/brew in mind. This ended up being appropriate In the end, after I took some inspiration from `unpack_strategy.rb`.

This creates a `LivecheckStrategy` module and convert the strategies to classes as part of that module, with all of the information relating to a strategy encompassed in its class. This helps to keep things organized while also moving code out of `heuristic.rb`, as everything in that file eventually needs to find a different home (so we can delete it to ease the future migration).

What was once the "heuristic" is now `LivecheckStrategy.from_url()`. The conditions for which a URL matches a strategy is now kept in each strategy's `match?` method. There's also a `LivecheckStrategy.from_symbol()` method, which uses an internal hash that maps symbols to strategies and is necessary for the forthcoming `strategy` addition to the livecheck DSL.

One other thing to note is that strategies now return a hash like `{ :matches => {}, :regex => regex, :url => page_url }` (or `:url => url`). This allows us to print debug output for the URL and regex that may be generated within a strategy, as well as passing it through to the verbose JSON output. Using a hash for this also allows us to extend it in the future, which is necessary for another upcoming feature.

Lastly, this removes the "Matched Text on Page" content from debug output. It was necessary to remove this to keep the debug output coherent, as we can't print the strategy URL and/or regex until after the "Matched Text on Page" output is printed. However, the "Matched Text on Page" output was almost always (if not always) redundant in practice anyway, as the "Matched Versions" were identical, so it was a good idea in its own right.

Overall, this should be easier to maintain and extend. Please let me know if you have any feedback, questions, requests, etc.