### PR TITLE
chafa: add livecheckable

### DIFF
--- a/Livecheckables/chafa.rb
+++ b/Livecheckables/chafa.rb
@@ -1,0 +1,6 @@
+class Chafa
+  livecheck do
+    url "https://hpjansson.org/chafa/releases/?C=M&O=D"
+    regex(/href=.*?chafa-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
Output before:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck chafa
Error: chafa: Unable to get versions
```
Output after:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck chafa
chafa : 1.4.1 ==> 1.4.1
```
Thanks.