### PR TITLE
vcs: add livecheckable

### DIFF
--- a/Livecheckables/vcs.rb
+++ b/Livecheckables/vcs.rb
@@ -1,0 +1,6 @@
+class Vcs
+  livecheck do
+    url "https://p.outlyer.net/files/vcs/?C=M&O=D"
+    regex(/href=.*?vcs-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
Output before:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck vcs
Error: vcs: Unable to get versions
```
Output after:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck vcs
vcs : 1.13.2 ==> 1.13.4
```
Note that I have sent a PR to update `vcs` [here](https://github.com/Homebrew/homebrew-core/pull/56927).

Thank you.