### PR TITLE
bash & readline: update url

### DIFF
--- a/Livecheckables/bash.rb
+++ b/Livecheckables/bash.rb
@@ -1,6 +1,6 @@
 class Bash
   livecheck do
-    url "http://ravenports.ironwolf.systems/catalog/bucket_C8/bash/standard/"
+    url "http://www.ravenports.com/catalog/bucket_C8/bash/standard/"
     regex(%r{<td id="pkgversion">v?(\d+(?:\.\d+)+)(?:_\d+)?</td>})
   end
 end

--- a/Livecheckables/readline.rb
+++ b/Livecheckables/readline.rb
@@ -1,6 +1,6 @@
 class Readline
   livecheck do
-    url "http://ravenports.ironwolf.systems/catalog/bucket_2D/readline/standard/"
+    url "http://www.ravenports.com/catalog/bucket_2D/readline/standard/"
     regex(%r{<td id="pkgversion">v?(\d+(?:\.\d+)+)(?:_\d+)?</td>})
   end
 end


### PR DESCRIPTION
I have updated the `url`'s for `bash` and `readline`, as the old ones are `404 Not Found`.

Before:
```
-bash-5.0.17- /Users/miccal (37) [> brew livecheck bash readline
Error: bash: 404 Not Found
Error: readline: 404 Not Found
```
After:
```
-bash-5.0.17- /Users/miccal (37) [> brew livecheck bash readline
bash : 5.0.17 ==> 5.0.17
readline : 8.0.4 ==> 8.0.4
```

Thanks.