### PR TITLE
pango: add livecheckable

### DIFF
--- a/Livecheckables/pango.rb
+++ b/Livecheckables/pango.rb
@@ -1,0 +1,5 @@
+class Pango
+  livecheck do
+    url :stable
+  end
+end


### PR DESCRIPTION
I have created a `livecheckable` for `pango` using `:stable` for the `url` so that it uses GNOME's "even-numbered minor is stable" scheme. Previously, `livecheck` was using `https://gitlab.gnome.org/GNOME/pango.git`.

Output before:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck pango
pango : 1.44.7 ==> 1.45.3
```

Output after:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck pango
pango : 1.44.7 ==> 1.44.7
```

Closes https://github.com/Homebrew/homebrew-livecheck/issues/1035

Thanks.