### PR TITLE
nomad: update livecheckable

### DIFF
--- a/Livecheckables/nomad.rb
+++ b/Livecheckables/nomad.rb
@@ -1,6 +1,5 @@
 class Nomad
   livecheck do
-    url "https://www.nomadproject.io/downloads.html"
-    regex(%r{href="https://releases.hashicorp.com/nomad/([0-9.]+)})
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/nomad.rb
+++ b/Livecheckables/nomad.rb
@@ -1,5 +1,6 @@
 class Nomad
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end


### PR DESCRIPTION
I have updated the `livecheckable` for `nomad` to use `https://releases.hashicorp.com/nomad/` for the `url` and added `[<\/a>]` to the regex based on studying the page source of the `url` -- this is so that things like `-beta1`, `-rc1` and/or `-connect1` are not included in `livecheck`.

Output before:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck nomad
nomad : 0.11.3 ==> 0.12.0
```

Output after:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck nomad
nomad : 0.11.3 ==> 0.11.3
```

Closes https://github.com/Homebrew/homebrew-livecheck/issues/1036

Thanks.

**EDIT:** This is what I had originally:
```
class Nomad
  livecheck do
    url "https://releases.hashicorp.com/nomad/"
    regex(/href=.*?nomad_v?(\d+(?:\.\d+)+)[<\/a>]/i)
  end
end
```