### PR TITLE
pixman: update livecheckable

### DIFF
--- a/Livecheckables/pixman.rb
+++ b/Livecheckables/pixman.rb
@@ -1,6 +1,6 @@
 class Pixman
   livecheck do
-    url "https://cairographics.org/releases/"
-    regex(/href="LATEST-pixman-([\d.]+\.[\d.]+\.[\d.]+)"/)
+    url "https://cairographics.org/releases/?C=M&O=D"
+    regex(/href=.*?pixman-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
I have slightly updated the `livecheckable` for `pixman` to conform to the recent style, combined with the assumption that only even minor versions are stable, as explained [here for `cairo`](https://www.cairographics.org/manual/cairo-Version-Information.html):
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck pixman
pixman : 0.40.0 ==> 0.40.0
```

Thanks.