### PR TITLE
cairo: update livecheckable

### DIFF
--- a/Livecheckables/cairo.rb
+++ b/Livecheckables/cairo.rb
@@ -1,6 +1,6 @@
 class Cairo
   livecheck do
-    url "https://www.cairographics.org/news/"
-    regex(/cairo-([0-9]+\.[0-9]*[02468]\.[0-9]+)/)
+    url "https://cairographics.org/releases/?C=M&O=D"
+    regex(/href=.*?[^r]cairo-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/cairo.rb
+++ b/Livecheckables/cairo.rb
@@ -1,6 +1,6 @@
 class Cairo
   livecheck do
     url "https://cairographics.org/releases/?C=M&O=D"
-    regex(/href=.*?[^r]cairo-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)cairo-v?(\d+\.\d*[02468](?:\.\d+)*)\.t}i)
   end
 end


### PR DESCRIPTION
I have slightly updated the `livecheckable` for `cairo` to conform to the recent style, combined with the fact that only even minor versions are stable, as explained [here](https://www.cairographics.org/manual/cairo-Version-Information.html) -- I had to add `[^r]` to ensure that the releases for `rcairo` were not included. This matches https://github.com/Homebrew/homebrew-livecheck/pull/1041, and it outputs the same as before:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck cairo
cairo : 1.16.0 ==> 1.16.0
```

Thanks.