### PR TITLE
cairomm: update livecheckable

### DIFF
--- a/Livecheckables/cairomm.rb
+++ b/Livecheckables/cairomm.rb
@@ -1,6 +1,6 @@
 class Cairomm
   livecheck do
-    url "https://cairographics.org/releases/"
-    regex(/href=.*?cairomm-v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://cairographics.org/releases/?C=M&O=D"
+    regex(/href=.*?cairomm-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
I have updated the `livecheckable` for `cairomm` to conform to the recent style, combined with the assumption that only even minor versions are stable, as explained [here for `cairo`](https://www.cairographics.org/manual/cairo-Version-Information.html). This matches https://github.com/Homebrew/homebrew-livecheck/pull/1041  and https://github.com/Homebrew/homebrew-livecheck/pull/1042.

Output before:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck cairomm
cairomm : 1.12.2 ==> 1.15.5
```

Output after:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck cairomm
cairomm : 1.12.2 ==> 1.12.2
```

Closes https://github.com/Homebrew/homebrew-livecheck/issues/1040

Thanks.