### PR TITLE
chibi-scheme: update url and regex

### DIFF
--- a/Livecheckables/chibi-scheme.rb
+++ b/Livecheckables/chibi-scheme.rb
@@ -1,6 +1,6 @@
 class ChibiScheme
   livecheck do
-    url "http://synthcode.com/wiki/chibi-scheme"
-    regex(%r{.*?/chibi-scheme-([0-9.]+)\.t})
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end


### PR DESCRIPTION
The site is down, reported in [here](https://github.com/ashinn/chibi-scheme/issues/663)

I also updated the formula to [use github resource](https://github.com/Homebrew/homebrew-core/pull/57097) 

## Current behavior

```
$ brew livecheck chibi-scheme
chibi-scheme : 0.8 ==> 0.8
```