### PR TITLE
vorbis-tools: add livecheckable

### DIFF
--- a/Livecheckables/vorbis-tools.rb
+++ b/Livecheckables/vorbis-tools.rb
@@ -1,0 +1,6 @@
+class VorbisTools
+  livecheck do
+    url "https://downloads.xiph.org/releases/vorbis/"
+    regex(/vorbis-tools-v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
The default check for `vorbis-tools` was unable to find any versions, so this adds a livecheckable with a URL and regex to establish a working check.