### PR TITLE
Add url to Livecheckables

### DIFF
--- a/Livecheckables/aamath.rb
+++ b/Livecheckables/aamath.rb
@@ -1,5 +1,6 @@
 class Aamath
   livecheck do
+    url :homepage
     regex(/aamath-(\d+(?:\.\d+)+)\.tar/)
   end
 end

--- a/Livecheckables/afl-fuzz.rb
+++ b/Livecheckables/afl-fuzz.rb
@@ -1,5 +1,6 @@
 class AflFuzz
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)b?$/)
   end
 end

--- a/Livecheckables/ant-contrib.rb
+++ b/Livecheckables/ant-contrib.rb
@@ -1,5 +1,6 @@
 class AntContrib
   livecheck do
+    url :stable
     regex(%r{url=.+?/ant-contrib-v?(\d+(?:\.\d+)+(?:[a-z]\d+)?)-bin\.t}i)
   end
 end

--- a/Livecheckables/apcupsd.rb
+++ b/Livecheckables/apcupsd.rb
@@ -1,5 +1,6 @@
 class Apcupsd
   livecheck do
+    url :stable
     regex(%r{url=.+?/apcupsd%20-%20Stable/[^/]+/apcupsd-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/arduino-cli.rb
+++ b/Livecheckables/arduino-cli.rb
@@ -1,5 +1,6 @@
 class ArduinoCli
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/armadillo.rb
+++ b/Livecheckables/armadillo.rb
@@ -1,5 +1,6 @@
 class Armadillo
   livecheck do
+    url :stable
     regex(%r{url=.+?/armadillo-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/arx-libertatis.rb
+++ b/Livecheckables/arx-libertatis.rb
@@ -1,5 +1,6 @@
 class ArxLibertatis
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/asymptote.rb
+++ b/Livecheckables/asymptote.rb
@@ -1,5 +1,6 @@
 class Asymptote
   livecheck do
+    url :stable
     regex(%r{url=.+?/asymptote-v?(\d+(?:\.\d+)+)\.src\.t})
   end
 end

--- a/Livecheckables/ats2-postiats.rb
+++ b/Livecheckables/ats2-postiats.rb
@@ -1,5 +1,6 @@
 class Ats2Postiats
   livecheck do
+    url :stable
     regex(/ATS2-Postiats-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/automysqlbackup.rb
+++ b/Livecheckables/automysqlbackup.rb
@@ -1,5 +1,6 @@
 class Automysqlbackup
   livecheck do
+    url :stable
     regex(%r{url=.+?/automysqlbackup-v?(\d+(?:\.\d+)+(?:.rc\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/black.rb
+++ b/Livecheckables/black.rb
@@ -1,5 +1,6 @@
 class Black
   livecheck do
+    url :stable
     regex(/black (\d+\.\d+(b\d+)?)/)
   end
 end

--- a/Livecheckables/bower.rb
+++ b/Livecheckables/bower.rb
@@ -1,5 +1,6 @@
 class Bower
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/buildkit.rb
+++ b/Livecheckables/buildkit.rb
@@ -1,5 +1,6 @@
 class Buildkit
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/camellia.rb
+++ b/Livecheckables/camellia.rb
@@ -1,5 +1,6 @@
 class Camellia
   livecheck do
+    url :stable
     regex(%r{url=.+?/CamelliaLib-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/castxml.rb
+++ b/Livecheckables/castxml.rb
@@ -1,5 +1,6 @@
 class Castxml
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/cdrtools.rb
+++ b/Livecheckables/cdrtools.rb
@@ -1,5 +1,6 @@
 class Cdrtools
   livecheck do
+    url :stable
     regex(%r{url=.+?/cdrtools-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/chadwick.rb
+++ b/Livecheckables/chadwick.rb
@@ -1,5 +1,6 @@
 class Chadwick
   livecheck do
+    url :stable
     regex(%r{url=.+?/chadwick-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/chordii.rb
+++ b/Livecheckables/chordii.rb
@@ -1,5 +1,6 @@
 class Chordii
   livecheck do
+    url :stable
     regex(%r{url=.+?/chordii-v?(\d+(?:\.\d+)+[a-z]?)\.t})
   end
 end

--- a/Livecheckables/cling.rb
+++ b/Livecheckables/cling.rb
@@ -1,5 +1,6 @@
 class Cling
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/cmu-pocketsphinx.rb
+++ b/Livecheckables/cmu-pocketsphinx.rb
@@ -1,5 +1,6 @@
 class CmuPocketsphinx
   livecheck do
+    url :stable
     regex(%r{url=.+?/pocketsphinx-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/cmu-sphinxbase.rb
+++ b/Livecheckables/cmu-sphinxbase.rb
@@ -1,5 +1,6 @@
 class CmuSphinxbase
   livecheck do
+    url :stable
     regex(%r{url=.+?/sphinxbase-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/cntlm.rb
+++ b/Livecheckables/cntlm.rb
@@ -1,5 +1,6 @@
 class Cntlm
   livecheck do
+    url :stable
     regex(%r{url=.+?/cntlm-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/coccinelle.rb
+++ b/Livecheckables/coccinelle.rb
@@ -1,5 +1,6 @@
 class Coccinelle
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/consul.rb
+++ b/Livecheckables/consul.rb
@@ -1,5 +1,6 @@
 class Consul
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/cppcms.rb
+++ b/Livecheckables/cppcms.rb
@@ -1,5 +1,6 @@
 class Cppcms
   livecheck do
+    url :stable
     regex(%r{url=.+?/cppcms-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/cracklib.rb
+++ b/Livecheckables/cracklib.rb
@@ -1,5 +1,6 @@
 class Cracklib
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/crystal.rb
+++ b/Livecheckables/crystal.rb
@@ -1,5 +1,6 @@
 class Crystal
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/csvq.rb
+++ b/Livecheckables/csvq.rb
@@ -1,5 +1,6 @@
 class Csvq
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/dbus.rb
+++ b/Livecheckables/dbus.rb
@@ -1,5 +1,6 @@
 class Dbus
   livecheck do
+    url :head
     regex(/^dbus-v?(\d+\.\d*?[02468](?:\.\d+)*)$/)
   end
 end

--- a/Livecheckables/ddclient.rb
+++ b/Livecheckables/ddclient.rb
@@ -1,5 +1,6 @@
 class Ddclient
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/dex2jar.rb
+++ b/Livecheckables/dex2jar.rb
@@ -1,5 +1,6 @@
 class Dex2jar
   livecheck do
+    url :stable
     regex(%r{url=.+?/dex2jar-v?(\d+(?:\.\d+)+)\.(?:t|z)})
   end
 end

--- a/Livecheckables/disktype.rb
+++ b/Livecheckables/disktype.rb
@@ -1,5 +1,6 @@
 class Disktype
   livecheck do
+    url :head
     regex(/release_(\d+)/)
   end
 end

--- a/Livecheckables/dita-ot.rb
+++ b/Livecheckables/dita-ot.rb
@@ -1,5 +1,6 @@
 class DitaOt
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/djview4.rb
+++ b/Livecheckables/djview4.rb
@@ -1,5 +1,6 @@
 class Djview4
   livecheck do
+    url :stable
     regex(%r{url=.+?/djview-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/dnscontrol.rb
+++ b/Livecheckables/dnscontrol.rb
@@ -1,5 +1,6 @@
 class Dnscontrol
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/dnscrypt-proxy.rb
+++ b/Livecheckables/dnscrypt-proxy.rb
@@ -1,5 +1,6 @@
 class DnscryptProxy
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/docker-compose-completion.rb
+++ b/Livecheckables/docker-compose-completion.rb
@@ -1,5 +1,6 @@
 class DockerComposeCompletion
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/docker-compose.rb
+++ b/Livecheckables/docker-compose.rb
@@ -1,5 +1,6 @@
 class DockerCompose
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/docker-credential-helper-ecr.rb
+++ b/Livecheckables/docker-credential-helper-ecr.rb
@@ -1,5 +1,6 @@
 class DockerCredentialHelperEcr
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/docker-swarm.rb
+++ b/Livecheckables/docker-swarm.rb
@@ -1,5 +1,6 @@
 class DockerSwarm
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/dosbox-x.rb
+++ b/Livecheckables/dosbox-x.rb
@@ -1,5 +1,6 @@
 class DosboxX
   livecheck do
+    url :head
     regex(/^dosbox-x-v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/dust.rb
+++ b/Livecheckables/dust.rb
@@ -1,5 +1,6 @@
 class Dust
   livecheck do
+    url :head
     regex(/v([\d.]+)/)
   end
 end

--- a/Livecheckables/elinks.rb
+++ b/Livecheckables/elinks.rb
@@ -1,5 +1,6 @@
 class Elinks
   livecheck do
+    url :head
     regex(/^elinks-(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/emacs.rb
+++ b/Livecheckables/emacs.rb
@@ -1,5 +1,6 @@
 class Emacs
   livecheck do
+    url :head
     regex(/emacs-(\d+\.\d+)$/)
   end
 end

--- a/Livecheckables/entr.rb
+++ b/Livecheckables/entr.rb
@@ -1,5 +1,6 @@
 class Entr
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/epsilon.rb
+++ b/Livecheckables/epsilon.rb
@@ -1,5 +1,6 @@
 class Epsilon
   livecheck do
+    url :stable
     regex(%r{/epsilon-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/espeak.rb
+++ b/Livecheckables/espeak.rb
@@ -1,5 +1,6 @@
 class Espeak
   livecheck do
+    url :stable
     regex(%r{url=.+?/espeak-v?(\d+(?:\.\d+)+)(?:-source)?\.(?:t|z)}i)
   end
 end

--- a/Livecheckables/etl.rb
+++ b/Livecheckables/etl.rb
@@ -1,5 +1,6 @@
 class Etl
   livecheck do
+    url :stable
     regex(%r{url=.+?/releases/.+?/ETL-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/ex-vi.rb
+++ b/Livecheckables/ex-vi.rb
@@ -1,5 +1,6 @@
 class ExVi
   livecheck do
+    url :stable
     regex(%r{url=.+?/ex-v?(\d+)\.t}i)
   end
 end

--- a/Livecheckables/expect.rb
+++ b/Livecheckables/expect.rb
@@ -1,5 +1,6 @@
 class Expect
   livecheck do
+    url :stable
     regex(%r{url=.+?/expect-?v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/faad2.rb
+++ b/Livecheckables/faad2.rb
@@ -1,5 +1,6 @@
 class Faad2
   livecheck do
+    url :stable
     regex(/url=.+faad2-(\d+(?:\.\d+)*)\.t/)
   end
 end

--- a/Livecheckables/faiss.rb
+++ b/Livecheckables/faiss.rb
@@ -1,5 +1,6 @@
 class Faiss
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/fetchmail.rb
+++ b/Livecheckables/fetchmail.rb
@@ -1,5 +1,6 @@
 class Fetchmail
   livecheck do
+    url :stable
     regex(%r{url=.+?/branch_\d+(?:\.\d+)*?/fetchmail-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/fifechan.rb
+++ b/Livecheckables/fifechan.rb
@@ -1,5 +1,6 @@
 class Fifechan
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/findent.rb
+++ b/Livecheckables/findent.rb
@@ -1,5 +1,6 @@
 class Findent
   livecheck do
+    url :stable
     regex(%r{url=.+?/findent-v?(\d+(?:\.\d+)+)\.(?:t|z)})
   end
 end

--- a/Livecheckables/fish.rb
+++ b/Livecheckables/fish.rb
@@ -1,5 +1,6 @@
 class Fish
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/fluxctl.rb
+++ b/Livecheckables/fluxctl.rb
@@ -1,5 +1,6 @@
 class Fluxctl
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/freeradius-server.rb
+++ b/Livecheckables/freeradius-server.rb
@@ -1,5 +1,6 @@
 class FreeradiusServer
   livecheck do
+    url :head
     regex(/^release_(\d+(?:[_.]\d+)+)$/)
   end
 end

--- a/Livecheckables/freeswitch.rb
+++ b/Livecheckables/freeswitch.rb
@@ -1,5 +1,6 @@
 class Freeswitch
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/freetype.rb
+++ b/Livecheckables/freetype.rb
@@ -1,5 +1,6 @@
 class Freetype
   livecheck do
+    url :stable
     regex(%r{freetype2/([a-zA-Z0-9.]+(?:\.[a-zA-Z0-9.]+)*)})
   end
 end

--- a/Livecheckables/ftgl.rb
+++ b/Livecheckables/ftgl.rb
@@ -1,5 +1,6 @@
 class Ftgl
   livecheck do
+    url :stable
     regex(%r{url=.+?/ftgl-v?(\d+(?:\.\d+)+(?:-rc\d*)?)\.t}i)
   end
 end

--- a/Livecheckables/ghostscript.rb
+++ b/Livecheckables/ghostscript.rb
@@ -1,5 +1,6 @@
 class Ghostscript
   livecheck do
+    url :head
     regex(/^ghostscript-(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/giflib.rb
+++ b/Livecheckables/giflib.rb
@@ -1,5 +1,6 @@
 class Giflib
   livecheck do
+    url :stable
     regex(%r{/giflib-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/gitlab-runner.rb
+++ b/Livecheckables/gitlab-runner.rb
@@ -1,5 +1,6 @@
 class GitlabRunner
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/gnu-cobol.rb
+++ b/Livecheckables/gnu-cobol.rb
@@ -1,5 +1,6 @@
 class GnuCobol
   livecheck do
+    url :stable
     regex(%r{url=.+?/gnucobol-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/goenv.rb
+++ b/Livecheckables/goenv.rb
@@ -1,5 +1,6 @@
 class Goenv
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/gpcslots2.rb
+++ b/Livecheckables/gpcslots2.rb
@@ -1,5 +1,6 @@
 class Gpcslots2
   livecheck do
+    url :stable
     regex(%r{url=.+?/gpcslots2.v?(\d+(?:[-_.]\d+)+[a-z]?)})
   end
 end

--- a/Livecheckables/gplcver.rb
+++ b/Livecheckables/gplcver.rb
@@ -2,6 +2,7 @@ class Gplcver
   # This regex intentionally matches seemingly unstable versions, as the only
   # available version at the time of writing was `2.12a`.
   livecheck do
+    url :stable
     regex(%r{url=.+?/gplcver-v?(\d+(?:\.\d+)+[a-z]?)\.src\.}i)
   end
 end

--- a/Livecheckables/gqview.rb
+++ b/Livecheckables/gqview.rb
@@ -1,5 +1,6 @@
 class Gqview
   livecheck do
+    url :stable
     regex(%r{url=.+?/gqview/[^/]+/gqview-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/grok.rb
+++ b/Livecheckables/grok.rb
@@ -1,5 +1,6 @@
 class Grok
   livecheck do
+    url :head
     regex(/^v?(\d+\.\d{,3}(\.\d+)+)$/)
   end
 end

--- a/Livecheckables/htop.rb
+++ b/Livecheckables/htop.rb
@@ -1,5 +1,6 @@
 class Htop
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/hypre.rb
+++ b/Livecheckables/hypre.rb
@@ -1,5 +1,6 @@
 class Hypre
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/ibex.rb
+++ b/Livecheckables/ibex.rb
@@ -1,5 +1,6 @@
 class Ibex
   livecheck do
+    url :head
     regex(/^ibex-(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/imageoptim-cli.rb
+++ b/Livecheckables/imageoptim-cli.rb
@@ -1,5 +1,6 @@
 class ImageoptimCli
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/infer.rb
+++ b/Livecheckables/infer.rb
@@ -1,5 +1,6 @@
 class Infer
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/influxdb.rb
+++ b/Livecheckables/influxdb.rb
@@ -1,5 +1,6 @@
 class Influxdb
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/inlets.rb
+++ b/Livecheckables/inlets.rb
@@ -1,5 +1,6 @@
 class Inlets
   livecheck do
+    url :stable
     regex(/^(\d+\.\d+.\d+)$/)
   end
 end

--- a/Livecheckables/ipfs.rb
+++ b/Livecheckables/ipfs.rb
@@ -1,5 +1,6 @@
 class Ipfs
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/itk.rb
+++ b/Livecheckables/itk.rb
@@ -1,5 +1,6 @@
 class Itk
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/jags.rb
+++ b/Livecheckables/jags.rb
@@ -1,5 +1,6 @@
 class Jags
   livecheck do
+    url :stable
     regex(%r{url=.+?/JAGS-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/jenkins.rb
+++ b/Livecheckables/jenkins.rb
@@ -1,5 +1,6 @@
 class Jenkins
   livecheck do
+    url :head
     regex(/^jenkins-(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/jnettop.rb
+++ b/Livecheckables/jnettop.rb
@@ -1,5 +1,6 @@
 class Jnettop
   livecheck do
+    url :stable
     regex(%r{url=.+?/jnettop-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/kapacitor.rb
+++ b/Livecheckables/kapacitor.rb
@@ -1,5 +1,6 @@
 class Kapacitor
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/kettle.rb
+++ b/Livecheckables/kettle.rb
@@ -1,5 +1,6 @@
 class Kettle
   livecheck do
+    url :stable
     regex(%r{url=.+?/pdi-ce-v?(\d+(?:\.\d+)+(?:-\d+)?)\.(?:z|t)})
   end
 end

--- a/Livecheckables/kitchen-sync.rb
+++ b/Livecheckables/kitchen-sync.rb
@@ -1,5 +1,6 @@
 class KitchenSync
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/kops.rb
+++ b/Livecheckables/kops.rb
@@ -1,5 +1,6 @@
 class Kops
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/kustomize.rb
+++ b/Livecheckables/kustomize.rb
@@ -1,5 +1,6 @@
 class Kustomize
   livecheck do
+    url :head
     regex(%r{kustomize/v?(\d+(?:\.\d+)+)$})
   end
 end

--- a/Livecheckables/lablgtk.rb
+++ b/Livecheckables/lablgtk.rb
@@ -1,5 +1,6 @@
 class Lablgtk
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/latex2html.rb
+++ b/Livecheckables/latex2html.rb
@@ -1,5 +1,6 @@
 class Latex2html
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)*)$/)
   end
 end

--- a/Livecheckables/libdnet.rb
+++ b/Livecheckables/libdnet.rb
@@ -1,5 +1,6 @@
 class Libdnet
   livecheck do
+    url :homepage
     regex(/^libdnet-(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/libid3tag.rb
+++ b/Livecheckables/libid3tag.rb
@@ -1,5 +1,6 @@
 class Libid3tag
   livecheck do
+    url :stable
     regex(%r{url=.+?/libid3tag-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end

--- a/Livecheckables/libmetalink.rb
+++ b/Livecheckables/libmetalink.rb
@@ -1,5 +1,6 @@
 class Libmetalink
   livecheck do
+    url :stable
     regex(/libmetalink-(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/libpano.rb
+++ b/Livecheckables/libpano.rb
@@ -1,5 +1,6 @@
 class Libpano
   livecheck do
+    url :stable
     regex(%r{url=.+?/libpano(\d+-\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/libplctag.rb
+++ b/Livecheckables/libplctag.rb
@@ -1,5 +1,6 @@
 class Libplctag
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/libquvi.rb
+++ b/Livecheckables/libquvi.rb
@@ -1,5 +1,6 @@
 class Libquvi
   livecheck do
+    url :stable
     regex(%r{url=.+?/libquvi-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/librdkafka.rb
+++ b/Livecheckables/librdkafka.rb
@@ -1,5 +1,6 @@
 class Librdkafka
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/libsoxr.rb
+++ b/Livecheckables/libsoxr.rb
@@ -1,5 +1,6 @@
 class Libsoxr
   livecheck do
+    url :stable
     regex(%r{/soxr-v?(\d+(?:\.\d+)+)(?:-Source)?\.t}i)
   end
 end

--- a/Livecheckables/libspnav.rb
+++ b/Livecheckables/libspnav.rb
@@ -1,5 +1,6 @@
 class Libspnav
   livecheck do
+    url :stable
     regex(%r{url=.+?/libspnav-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/libtorrent-rasterbar.rb
+++ b/Livecheckables/libtorrent-rasterbar.rb
@@ -1,5 +1,6 @@
 class LibtorrentRasterbar
   livecheck do
+    url :head
     regex(/^libtorrent.v?(\d+(?:[-_.]\d+)+)$/i)
   end
 end

--- a/Livecheckables/libupnp.rb
+++ b/Livecheckables/libupnp.rb
@@ -1,5 +1,6 @@
 class Libupnp
   livecheck do
+    url :stable
     regex(/^release-(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/libusb-compat.rb
+++ b/Livecheckables/libusb-compat.rb
@@ -1,5 +1,6 @@
 class LibusbCompat
   livecheck do
+    url :stable
     regex(%r{/libusb-compat-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/libvterm.rb
+++ b/Livecheckables/libvterm.rb
@@ -1,5 +1,6 @@
 class Libvterm
   livecheck do
+    url :homepage
     regex(/libvterm-(\d+(?:\.\d+)+)\./)
   end
 end

--- a/Livecheckables/libwmf.rb
+++ b/Livecheckables/libwmf.rb
@@ -1,5 +1,6 @@
 class Libwmf
   livecheck do
+    url :stable
     regex(%r{url=.+?/libwmf-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/libxml++.rb
+++ b/Livecheckables/libxml++.rb
@@ -1,5 +1,6 @@
 class Libxmlxx
   livecheck do
+    url :stable
     regex(/libxml\+\+-(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/)
   end
 end

--- a/Livecheckables/little-cms.rb
+++ b/Livecheckables/little-cms.rb
@@ -1,5 +1,6 @@
 class LittleCms
   livecheck do
+    url :stable
     regex(%r{url=.+?/lcms-v?(1(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/locateme.rb
+++ b/Livecheckables/locateme.rb
@@ -1,5 +1,6 @@
 class Locateme
   livecheck do
+    url :stable
     regex(%r{url=.+?/LocateMe-v?(\d+(?:\.\d+)+)\.(?:t|z)}i)
   end
 end

--- a/Livecheckables/log4c.rb
+++ b/Livecheckables/log4c.rb
@@ -1,5 +1,6 @@
 class Log4c
   livecheck do
+    url :stable
     regex(%r{url=.+?/log4c-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/logstash.rb
+++ b/Livecheckables/logstash.rb
@@ -1,5 +1,6 @@
 class Logstash
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/mad.rb
+++ b/Livecheckables/mad.rb
@@ -1,5 +1,6 @@
 class Mad
   livecheck do
+    url :stable
     regex(%r{url=.+?/libmad-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end

--- a/Livecheckables/madplay.rb
+++ b/Livecheckables/madplay.rb
@@ -1,5 +1,6 @@
 class Madplay
   livecheck do
+    url :stable
     regex(%r{url=.+?/madplay-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end

--- a/Livecheckables/makepp.rb
+++ b/Livecheckables/makepp.rb
@@ -1,5 +1,6 @@
 class Makepp
   livecheck do
+    url :stable
     regex(%r{url=.+?/makepp-v?(\d+\.\d+)\.t})
   end
 end

--- a/Livecheckables/mcpp.rb
+++ b/Livecheckables/mcpp.rb
@@ -1,5 +1,6 @@
 class Mcpp
   livecheck do
+    url :stable
     regex(%r{url=.+?/mcpp-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/mhash.rb
+++ b/Livecheckables/mhash.rb
@@ -1,5 +1,6 @@
 class Mhash
   livecheck do
+    url :stable
     regex(%r{url=.+?/mhash-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/mingw-w64.rb
+++ b/Livecheckables/mingw-w64.rb
@@ -1,5 +1,6 @@
 class MingwW64
   livecheck do
+    url :stable
     regex(%r{url=.+?release/mingw-w64-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/mkvalidator.rb
+++ b/Livecheckables/mkvalidator.rb
@@ -1,5 +1,6 @@
 class Mkvalidator
   livecheck do
+    url :stable
     regex(%r{url=.+?/mkvalidator-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/mozjpeg.rb
+++ b/Livecheckables/mozjpeg.rb
@@ -1,5 +1,6 @@
 class Mozjpeg
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/mp3wrap.rb
+++ b/Livecheckables/mp3wrap.rb
@@ -1,5 +1,6 @@
 class Mp3wrap
   livecheck do
+    url :stable
     regex(%r{url=.+?/mp3wrap-v?(\d+(?:\.\d+)+)(?:-src)?\.t})
   end
 end

--- a/Livecheckables/mpgtx.rb
+++ b/Livecheckables/mpgtx.rb
@@ -1,5 +1,6 @@
 class Mpgtx
   livecheck do
+    url :stable
     regex(%r{url=.+?/mpgtx-v?(\d+(?:\.\d+)+(?:-\d+)?)(?:-src)?\.t})
   end
 end

--- a/Livecheckables/msdl.rb
+++ b/Livecheckables/msdl.rb
@@ -1,5 +1,6 @@
 class Msdl
   livecheck do
+    url :stable
     regex(%r{url=.+?/msdl-v?(\d+(?:\.\d+)+(?:-r\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/naturaldocs.rb
+++ b/Livecheckables/naturaldocs.rb
@@ -1,5 +1,6 @@
 class Naturaldocs
   livecheck do
+    url :stable
     regex(%r{url=.+?/Natural.?Docs.v?(\d+(?:\.\d+)+)\.(?:t|z)}i)
   end
 end

--- a/Livecheckables/netcdf.rb
+++ b/Livecheckables/netcdf.rb
@@ -1,5 +1,6 @@
 class Netcdf
   livecheck do
+    url :head
     regex(/^(?:netcdf-|v)?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/netdata.rb
+++ b/Livecheckables/netdata.rb
@@ -1,5 +1,6 @@
 class Netdata
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/nethack.rb
+++ b/Livecheckables/nethack.rb
@@ -1,5 +1,6 @@
 class Nethack
   livecheck do
+    url :head
     regex(/^NetHack-(\d+(?:\.\d+)+)_Released?$/)
   end
 end

--- a/Livecheckables/node-build.rb
+++ b/Livecheckables/node-build.rb
@@ -1,5 +1,6 @@
 class NodeBuild
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/nrpe.rb
+++ b/Livecheckables/nrpe.rb
@@ -1,5 +1,6 @@
 class Nrpe
   livecheck do
+    url :stable
     regex(%r{url=.+?/nrpe-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/ntfs-3g.rb
+++ b/Livecheckables/ntfs-3g.rb
@@ -1,5 +1,6 @@
 class Ntfs3g
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/olsrd.rb
+++ b/Livecheckables/olsrd.rb
@@ -1,5 +1,6 @@
 class Olsrd
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/opencv.rb
+++ b/Livecheckables/opencv.rb
@@ -1,5 +1,6 @@
 class Opencv
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/openshift-cli.rb
+++ b/Livecheckables/openshift-cli.rb
@@ -1,5 +1,6 @@
 class OpenshiftCli
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/osrm-backend.rb
+++ b/Livecheckables/osrm-backend.rb
@@ -1,5 +1,6 @@
 class OsrmBackend
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/pdftohtml.rb
+++ b/Livecheckables/pdftohtml.rb
@@ -1,5 +1,6 @@
 class Pdftohtml
   livecheck do
+    url :stable
     regex(%r{url=.+?/pdftohtml-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end

--- a/Livecheckables/perltidy.rb
+++ b/Livecheckables/perltidy.rb
@@ -1,5 +1,6 @@
 class Perltidy
   livecheck do
+    url :stable
     regex(%r{url=.+?/Perl-Tidy-(\d+)\.t}i)
   end
 end

--- a/Livecheckables/pidgin.rb
+++ b/Livecheckables/pidgin.rb
@@ -1,5 +1,6 @@
 class Pidgin
   livecheck do
+    url :stable
     regex(%r{url=.+?/pidgin-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/pjproject.rb
+++ b/Livecheckables/pjproject.rb
@@ -1,5 +1,6 @@
 class Pjproject
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/pngcheck.rb
+++ b/Livecheckables/pngcheck.rb
@@ -1,5 +1,6 @@
 class Pngcheck
   livecheck do
+    url :stable
     regex(%r{url=.+?/pngcheck-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/portmidi.rb
+++ b/Livecheckables/portmidi.rb
@@ -1,5 +1,6 @@
 class Portmidi
   livecheck do
+    url :stable
     regex(%r{url=.+?/portmidi-src-(\d+)\.}i)
   end
 end

--- a/Livecheckables/povray.rb
+++ b/Livecheckables/povray.rb
@@ -1,5 +1,6 @@
 class Povray
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+\.\d{1,4})$/)
   end
 end

--- a/Livecheckables/primer3.rb
+++ b/Livecheckables/primer3.rb
@@ -1,5 +1,6 @@
 class Primer3
   livecheck do
+    url :stable
     regex(%r{url=.+?/primer3-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/proctools.rb
+++ b/Livecheckables/proctools.rb
@@ -1,5 +1,6 @@
 class Proctools
   livecheck do
+    url :stable
     regex(%r{url=.+?/proctools/[^/]+/proctools-v?(\d+(?:\.\d+)+(?:pre\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/putmail-queue.rb
+++ b/Livecheckables/putmail-queue.rb
@@ -1,5 +1,6 @@
 class PutmailQueue
   livecheck do
+    url :stable
     regex(%r{url=.+?/putmail-queue-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/py2cairo.rb
+++ b/Livecheckables/py2cairo.rb
@@ -1,5 +1,6 @@
 class Py2cairo
   livecheck do
+    url :stable
     regex(/^v?(1\.18(?:\.\d+)*)$/)
   end
 end

--- a/Livecheckables/qt.rb
+++ b/Livecheckables/qt.rb
@@ -1,5 +1,6 @@
 class Qt
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/quvi.rb
+++ b/Livecheckables/quvi.rb
@@ -1,5 +1,6 @@
 class Quvi
   livecheck do
+    url :stable
     regex(%r{url=.+?/quvi-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/rabbitmq.rb
+++ b/Livecheckables/rabbitmq.rb
@@ -1,5 +1,6 @@
 class Rabbitmq
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/rav1e.rb
+++ b/Livecheckables/rav1e.rb
@@ -1,5 +1,6 @@
 class Rav1e
   livecheck do
+    url :stable
     regex(/v([\d.]+)/)
   end
 end

--- a/Livecheckables/rebar3.rb
+++ b/Livecheckables/rebar3.rb
@@ -1,5 +1,6 @@
 class Rebar3
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/rlwrap.rb
+++ b/Livecheckables/rlwrap.rb
@@ -1,5 +1,6 @@
 class Rlwrap
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/rtf2latex2e.rb
+++ b/Livecheckables/rtf2latex2e.rb
@@ -1,5 +1,6 @@
 class Rtf2latex2e
   livecheck do
+    url :stable
     regex(%r{url=.+?/rtf2latex2e-v?(\d+(?:[-_.]\d+)+)\.t})
   end
 end

--- a/Livecheckables/saxon.rb
+++ b/Livecheckables/saxon.rb
@@ -1,5 +1,6 @@
 class Saxon
   livecheck do
+    url :stable
     regex(%r{url=.+?/SaxonHE(\d+(?:[-.]\d+)+)J?\.(?:t|z)}i)
   end
 end

--- a/Livecheckables/sc68.rb
+++ b/Livecheckables/sc68.rb
@@ -1,5 +1,6 @@
 class Sc68
   livecheck do
+    url :stable
     regex(%r{url=.+?/sc68-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/sdedit.rb
+++ b/Livecheckables/sdedit.rb
@@ -1,5 +1,6 @@
 class Sdedit
   livecheck do
+    url :stable
     regex(%r{url=.+?/sdedit-v?(\d+(?:\.\d+)+)\.jar})
   end
 end

--- a/Livecheckables/slashem.rb
+++ b/Livecheckables/slashem.rb
@@ -1,5 +1,6 @@
 class Slashem
   livecheck do
+    url :stable
     regex(%r{url=.+?/slashem-source/([^/]+)/[^.]+\.t})
   end
 end

--- a/Livecheckables/source-highlight.rb
+++ b/Livecheckables/source-highlight.rb
@@ -1,5 +1,6 @@
 class SourceHighlight
   livecheck do
+    url :stable
     regex(/source-highlight-(\d+(?:\.\d+)+)/)
   end
 end

--- a/Livecheckables/spotifyd.rb
+++ b/Livecheckables/spotifyd.rb
@@ -1,5 +1,6 @@
 class Spotifyd
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/squirrel.rb
+++ b/Livecheckables/squirrel.rb
@@ -1,5 +1,6 @@
 class Squirrel
   livecheck do
+    url :stable
     regex(%r{url=.+?/squirrel.v?(\d+(?:[-_]\d+)+).stable\.t})
   end
 end

--- a/Livecheckables/sshfs.rb
+++ b/Livecheckables/sshfs.rb
@@ -1,5 +1,6 @@
 class Sshfs
   livecheck do
+    url :stable
     regex(/^sshfs-(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/ssldump.rb
+++ b/Livecheckables/ssldump.rb
@@ -2,6 +2,7 @@ class Ssldump
   # This regex intentionally matches unstable versions, as only a beta version
   # (0.9b3) is available at the time of writing.
   livecheck do
+    url :stable
     regex(%r{url=.+?/ssldump/([^/]+)/[^/]+\.t})
   end
 end

--- a/Livecheckables/sstp-client.rb
+++ b/Livecheckables/sstp-client.rb
@@ -1,5 +1,6 @@
 class SstpClient
   livecheck do
+    url :stable
     regex(%r{url=.+?/sstp-client-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/streamripper.rb
+++ b/Livecheckables/streamripper.rb
@@ -1,5 +1,6 @@
 class Streamripper
   livecheck do
+    url :stable
     regex(%r{url=.+?/streamripper-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/suite-sparse.rb
+++ b/Livecheckables/suite-sparse.rb
@@ -1,5 +1,6 @@
 class SuiteSparse
   livecheck do
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/syncthing.rb
+++ b/Livecheckables/syncthing.rb
@@ -1,5 +1,6 @@
 class Syncthing
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/telegraf.rb
+++ b/Livecheckables/telegraf.rb
@@ -1,5 +1,6 @@
 class Telegraf
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/tesseract.rb
+++ b/Livecheckables/tesseract.rb
@@ -1,5 +1,6 @@
 class Tesseract
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/tfenv.rb
+++ b/Livecheckables/tfenv.rb
@@ -1,5 +1,6 @@
 class Tfenv
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/tidy-html5.rb
+++ b/Livecheckables/tidy-html5.rb
@@ -1,5 +1,6 @@
 class TidyHtml5
   livecheck do
+    url :head
     regex(/^v?(\d+\.\d*?[02468]\.\d+)$/)
   end
 end

--- a/Livecheckables/timidity.rb
+++ b/Livecheckables/timidity.rb
@@ -1,5 +1,6 @@
 class Timidity
   livecheck do
+    url :stable
     regex(%r{url=.+?/TiMidity%2B%2B-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/tivodecode.rb
+++ b/Livecheckables/tivodecode.rb
@@ -1,5 +1,6 @@
 class Tivodecode
   livecheck do
+    url :stable
     regex(%r{url=.+?/tivodecode-v?(\d+(?:\.\d+)+(?:pre\d+)?)\.t})
   end
 end

--- a/Livecheckables/tta.rb
+++ b/Livecheckables/tta.rb
@@ -1,5 +1,6 @@
 class Tta
   livecheck do
+    url :stable
     regex(%r{url=.+?/libtta-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/unzip.rb
+++ b/Livecheckables/unzip.rb
@@ -1,5 +1,6 @@
 class Unzip
   livecheck do
+    url :stable
     regex(%r{url=.+?(?:%20)?v?(\d+(?:\.\d+)+)/unzip\d+\.t}i)
   end
 end

--- a/Livecheckables/v2ray-plugin.rb
+++ b/Livecheckables/v2ray-plugin.rb
@@ -1,5 +1,6 @@
 class V2rayPlugin
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/vapoursynth.rb
+++ b/Livecheckables/vapoursynth.rb
@@ -1,5 +1,6 @@
 class Vapoursynth
   livecheck do
+    url :head
     regex(/^R(\d+(?:\.\d+)*?)$/)
   end
 end

--- a/Livecheckables/vde.rb
+++ b/Livecheckables/vde.rb
@@ -1,5 +1,6 @@
 class Vde
   livecheck do
+    url :stable
     regex(%r{/vde\d*?-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/vncsnapshot.rb
+++ b/Livecheckables/vncsnapshot.rb
@@ -1,5 +1,6 @@
 class Vncsnapshot
   livecheck do
+    url :stable
     regex(%r{url=.+?/vncsnapshot-v?(\d+(?:\.\d+)+[a-z]?)-src\.t}i)
   end
 end

--- a/Livecheckables/voldemort.rb
+++ b/Livecheckables/voldemort.rb
@@ -1,5 +1,6 @@
 class Voldemort
   livecheck do
+    url :stable
     regex(/(?:release-)?v?(\d+(?:\.\d+)+)(?:-cutoff)?/)
   end
 end

--- a/Livecheckables/watchman.rb
+++ b/Livecheckables/watchman.rb
@@ -2,6 +2,7 @@ class Watchman
   # The Git repo contains a few tags like `2020.05.18.00`, so we have to
   # restrict matching to versions with two to three parts (e.g., 1.2, 1.2.3).
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+){,2})$/i)
   end
 end

--- a/Livecheckables/websocat.rb
+++ b/Livecheckables/websocat.rb
@@ -1,5 +1,6 @@
 class Websocat
   livecheck do
+    url :stable
     regex(/v([\d.]+$)/)
   end
 end

--- a/Livecheckables/wv2.rb
+++ b/Livecheckables/wv2.rb
@@ -1,5 +1,6 @@
 class Wv2
   livecheck do
+    url :stable
     regex(%r{url=.+?/wv2-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/xmlsh.rb
+++ b/Livecheckables/xmlsh.rb
@@ -1,5 +1,6 @@
 class Xmlsh
   livecheck do
+    url :stable
     regex(%r{url=.+?/v?(\d+(?:\.\d+)+)/xmlsh}i)
   end
 end

--- a/Livecheckables/zboy.rb
+++ b/Livecheckables/zboy.rb
@@ -1,5 +1,6 @@
 class Zboy
   livecheck do
+    url :head
     regex(%r{url=.+?/zboy-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/zeromq.rb
+++ b/Livecheckables/zeromq.rb
@@ -1,5 +1,6 @@
 class Zeromq
   livecheck do
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/zip.rb
+++ b/Livecheckables/zip.rb
@@ -1,5 +1,6 @@
 class Zip
   livecheck do
+    url :stable
     regex(%r{url=.+?/v?(\d+(?:\.\d+)+)/zip\d+\.(?:t|z)})
   end
 end

--- a/Livecheckables/zssh.rb
+++ b/Livecheckables/zssh.rb
@@ -1,5 +1,6 @@
 class Zssh
   livecheck do
+    url :stable
     regex(%r{url=.+?/zssh-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end


### PR DESCRIPTION
This PR adds a `url` reference to all Livecheckables which did not explicitly have them earlier. These Livecheckables used URLs from the Formula (such as `head`, `homepage`, `stable` or `devel`) and explicitly mentioning them could reduce the effort taken by livecheck to find the versions (by not having to go through all Formula URLs till it succeeds with one).

182 Livecheckables have been changed and I've locally verified that the changes don't break anything. Three Livecheckables (`biosig`, `darkice` and `x3270`) have been ignored for now, as discussed with @samford.