### PR TITLE
mit-scheme: update livecheckable

### DIFF
--- a/Livecheckables/mit-scheme.rb
+++ b/Livecheckables/mit-scheme.rb
@@ -1,6 +1,6 @@
 class MitScheme
   livecheck do
     url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/?C=M&O=D"
-    regex(/href=.*?(\d+(?:\.\d+)+)/)
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?[ '">]}i)
   end
 end

--- a/Livecheckables/mit-scheme.rb
+++ b/Livecheckables/mit-scheme.rb
@@ -1,6 +1,6 @@
 class MitScheme
   livecheck do
-    url :homepage
-    regex(/href=.*?mit-scheme-v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/?C=M&O=D"
+    regex(/href=.*?(\d+(?:\.\d+)+)/)
   end
 end


### PR DESCRIPTION
The `:homepage` lists versions for both the stable and testing releases, so I have changed the `url` as suggested in https://github.com/Homebrew/homebrew-livecheck/issues/1049 and updated the regex accordingly.

Output before:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck mit-scheme
mit-scheme : 10.1.11 ==> 11.0.90
```

Output after:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck mit-scheme
mit-scheme : 10.1.11 ==> 10.1.11
```

Closes https://github.com/Homebrew/homebrew-livecheck/issues/1049

Thanks.