### PR TITLE
mono: update livecheckable

### DIFF
--- a/Livecheckables/mono.rb
+++ b/Livecheckables/mono.rb
@@ -1,6 +1,6 @@
 class Mono
   livecheck do
-    url "https://download.mono-project.com/sources/mono/"
-    regex(/mono-([0-9,.]+)\./)
+    url "https://www.mono-project.com/download/stable/"
+    regex(/href=.*?(\d+(?:\.\d+)+)\.macos/i)
   end
 end

--- a/Livecheckables/mono.rb
+++ b/Livecheckables/mono.rb
@@ -1,6 +1,6 @@
 class Mono
   livecheck do
     url "https://www.mono-project.com/download/stable/"
-    regex(/href=.*?(\d+(?:\.\d+)+)\.macos/i)
+    regex(/href=.*?(\d+(?:\.\d+)+)[._-]macos/i)
   end
 end


### PR DESCRIPTION
I have updated the `livecheckable` for `mono` to use the `url` at `https://www.mono-project.com/download/stable/` for its stable version. 

Looking at the source of this page, I see the following:
```
href="https://download.mono-project.com/archive/6.8.0/macos-10-universal/MonoFramework-MDK-6.8.0.123.macos10.xamarin.universal.pkg"
```
hence the addition of `\.macos` in the regex, which I think will prevent other numerical matches that may have nothing to do with the stable version.

Output before:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck mono
mono : 6.8.0.123 ==> 6.10.0.104
```

Output after:
```
-bash-5.0.17- /Users/miccal (29) [> brew livecheck mono
mono : 6.8.0.123 ==> 6.8.0.123
```

Closes https://github.com/Homebrew/homebrew-livecheck/issues/1048

Thanks.