### PR TITLE
moarvm: add livecheckable

### DIFF
--- a/Livecheckables/moarvm.rb
+++ b/Livecheckables/moarvm.rb
@@ -1,0 +1,6 @@
+class Moarvm
+  livecheck do
+    url "https://github.com/MoarVM/MoarVM.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
Adding Livecheckable for `moarvm`. Closes #1054.