### PR TITLE
Replace empty_version with version.empty?

### DIFF
--- a/livecheck/heuristic.rb
+++ b/livecheck/heuristic.rb
@@ -101,9 +101,8 @@ def latest_version(formula)
       puts "Regex (strategy): #{strategy_data[:regex].inspect}\n" if strategy_data[:regex] != livecheck_regex
     end
 
-    empty_version = Version.new("")
     match_version_map.delete_if do |_match, version|
-      next true if version == empty_version
+      next true if version.empty?
       next false if has_livecheckable
 
       UNSTABLE_VERSION_KEYWORDS.any? do |rejection|


### PR DESCRIPTION
After some discussion in #1025, I added `.empty?` to the `Version` class in Homebrew/brew#7846. This allows us to remove the code in `latest_version()` that creates an empty `Version` and replace the `version == empty_version` comparison with `version.empty?`. This accomplishes the same goal without an unnecessary allocation.