### PR TITLE
Change \.j to \.jar in regex

### DIFF
--- a/Livecheckables/aspectj.rb
+++ b/Livecheckables/aspectj.rb
@@ -1,6 +1,6 @@
 class Aspectj
   livecheck do
     url "https://eclipse.org/aspectj/downloads.php"
-    regex(%r{Latest Stable Release.*?/aspectj-([0-9,.]+)\.j}m)
+    regex(%r{Latest Stable Release.*?/aspectj-([0-9,.]+)\.jar}m)
   end
 end

--- a/Livecheckables/cfr-decompiler.rb
+++ b/Livecheckables/cfr-decompiler.rb
@@ -1,6 +1,6 @@
 class CfrDecompiler
   livecheck do
     url :homepage
-    regex(/href=".*cfr-([0-9_.]+)\.j/)
+    regex(/href=".*cfr-([0-9_.]+)\.jar/)
   end
 end


### PR DESCRIPTION
This PR updates the Livecheckables which contain `\.j` in their regex to use `\.jar` instead. The Livecheckables affected are `aspectj` and `cfr-decompiler`.