### PR TITLE
Change \.tar variants to \.t in regex

### DIFF
--- a/Livecheckables/aalib.rb
+++ b/Livecheckables/aalib.rb
@@ -1,6 +1,6 @@
 class Aalib
   livecheck do
     url "https://sourceforge.net/projects/aa-project/files/aa-lib/"
-    regex(/aalib-(\d+(?:\.\d+)+.*?)\.tar/)
+    regex(/aalib-(\d+(?:\.\d+)+.*?)\.t/)
   end
 end

--- a/Livecheckables/aamath.rb
+++ b/Livecheckables/aamath.rb
@@ -1,6 +1,6 @@
 class Aamath
   livecheck do
     url :homepage
-    regex(/aamath-(\d+(?:\.\d+)+)\.tar/)
+    regex(/aamath-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/aardvark_shell_utils.rb
+++ b/Livecheckables/aardvark_shell_utils.rb
@@ -1,6 +1,6 @@
 class AardvarkShellUtils
   livecheck do
     url "http://downloads.laffeycomputer.com/current_builds/shellutils/"
-    regex(/aardvark_shell_utils-(\d+(?:\.\d+)+)\.tar/)
+    regex(/aardvark_shell_utils-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/abuse.rb
+++ b/Livecheckables/abuse.rb
@@ -1,6 +1,6 @@
 class Abuse
   livecheck do
     url "http://abuse.zoy.org/wiki/download"
-    regex(/abuse-(\d+(?:\.\d+)+)\.tar/)
+    regex(/abuse-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/ansifilter.rb
+++ b/Livecheckables/ansifilter.rb
@@ -1,6 +1,6 @@
 class Ansifilter
   livecheck do
     url "http://www.andre-simon.de/zip/download.php"
-    regex(/href="ansifilter-([0-9,.]+)\.tar/)
+    regex(/href="ansifilter-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/argus.rb
+++ b/Livecheckables/argus.rb
@@ -1,6 +1,6 @@
 class Argus
   livecheck do
     url "https://qosient.com/argus/src/"
-    regex(/href="argus-([0-9,.]+)\.tar/)
+    regex(/href="argus-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/augeas.rb
+++ b/Livecheckables/augeas.rb
@@ -1,6 +1,6 @@
 class Augeas
   livecheck do
     url "http://download.augeas.net/"
-    regex(/href="augeas-([0-9,.]+)\.tar/)
+    regex(/href="augeas-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/bmake.rb
+++ b/Livecheckables/bmake.rb
@@ -1,6 +1,6 @@
 class Bmake
   livecheck do
     url "http://www.crufty.net/ftp/pub/sjg/"
-    regex(/href="bmake-([0-9,.]+)\.tar/)
+    regex(/href="bmake-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/bonnie++.rb
+++ b/Livecheckables/bonnie++.rb
@@ -1,6 +1,6 @@
 class Bonniexx
   livecheck do
     url "https://www.coker.com.au/bonnie++/experimental/"
-    regex(/bonnie\+\+-([0-9,.]+)\.tgz/)
+    regex(/bonnie\+\+-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/colordiff.rb
+++ b/Livecheckables/colordiff.rb
@@ -1,6 +1,6 @@
 class Colordiff
   livecheck do
     url :homepage
-    regex(/colordiff-([0-9.]+)\.tar/)
+    regex(/colordiff-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/creduce.rb
+++ b/Livecheckables/creduce.rb
@@ -1,6 +1,6 @@
 class Creduce
   livecheck do
     url :homepage
-    regex(/href="creduce-([0-9,.]+)\.tar/)
+    regex(/href="creduce-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/curl.rb
+++ b/Livecheckables/curl.rb
@@ -1,6 +1,6 @@
 class Curl
   livecheck do
     url "https://curl.haxx.se/download/"
-    regex(/curl-(.*?)\.tar\.gz/)
+    regex(/curl-(.*?)\.t/)
   end
 end

--- a/Livecheckables/dmenu.rb
+++ b/Livecheckables/dmenu.rb
@@ -1,6 +1,6 @@
 class Dmenu
   livecheck do
     url "https://dl.suckless.org/tools/"
-    regex(/href="dmenu-([0-9,.]+)\.tar/)
+    regex(/href="dmenu-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/dnsmasq.rb
+++ b/Livecheckables/dnsmasq.rb
@@ -1,6 +1,6 @@
 class Dnsmasq
   livecheck do
     url "http://www.thekelleys.org.uk/dnsmasq/"
-    regex(/href="dnsmasq-([0-9,.]+)\.tar/)
+    regex(/href="dnsmasq-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/dnsperf.rb
+++ b/Livecheckables/dnsperf.rb
@@ -1,6 +1,6 @@
 class Dnsperf
   livecheck do
     url :homepage
-    regex(/dnsperf-(\d+(?:\.\d+)+)\.tar/)
+    regex(/dnsperf-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/dovecot.rb
+++ b/Livecheckables/dovecot.rb
@@ -1,6 +1,6 @@
 class Dovecot
   livecheck do
     url "https://dovecot.org/releases/2.3/"
-    regex(/dovecot-(\d+\.\d+([0-9rc.]+)?)\.tar/)
+    regex(/dovecot-(\d+\.\d+([0-9rc.]+)?)\.t/)
   end
 end

--- a/Livecheckables/dwarfutils.rb
+++ b/Livecheckables/dwarfutils.rb
@@ -1,6 +1,6 @@
 class Dwarfutils
   livecheck do
     url :homepage
-    regex(/HREF="libdwarf-([0-9.]+).tar.gz/)
+    regex(/HREF="libdwarf-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/fetch-crl.rb
+++ b/Livecheckables/fetch-crl.rb
@@ -1,6 +1,6 @@
 class FetchCrl
   livecheck do
     url "https://dist.eugridpma.info/distribution/util/fetch-crl/"
-    regex(/href="fetch-crl-([0-9,.]+)\.tar/)
+    regex(/href="fetch-crl-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/gegl.rb
+++ b/Livecheckables/gegl.rb
@@ -1,6 +1,6 @@
 class Gegl
   livecheck do
     url "https://download.gimp.org/pub/gegl/0.4/"
-    regex(/gegl-(\d+(?:\.\d+)*)\.tar/)
+    regex(/gegl-(\d+(?:\.\d+)*)\.t/)
   end
 end

--- a/Livecheckables/gnutls.rb
+++ b/Livecheckables/gnutls.rb
@@ -1,6 +1,6 @@
 class Gnutls
   livecheck do
     url "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/"
-    regex(/gnutls-(\d+(?:\.\d+)*)\.tar/)
+    regex(/gnutls-(\d+(?:\.\d+)*)\.t/)
   end
 end

--- a/Livecheckables/graphviz.rb
+++ b/Livecheckables/graphviz.rb
@@ -1,6 +1,6 @@
 class Graphviz
   livecheck do
     url "https://www2.graphviz.org/Packages/stable/portable_source/"
-    regex(/href="graphviz-(\d+(?:\.\d+)+)\.tar/)
+    regex(/href="graphviz-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/haproxy.rb
+++ b/Livecheckables/haproxy.rb
@@ -1,6 +1,6 @@
 class Haproxy
   livecheck do
     url :homepage
-    regex(/haproxy-([0-9.]+)\.tar/)
+    regex(/haproxy-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/jsonschema2pojo.rb
+++ b/Livecheckables/jsonschema2pojo.rb
@@ -1,6 +1,6 @@
 class Jsonschema2pojo
   livecheck do
     url "https://github.com/joelittlejohn/jsonschema2pojo/releases"
-    regex(%r{releases/download/jsonschema2pojo-.*/jsonschema2pojo-([0-9,.]+)\.tar})
+    regex(%r{releases/download/jsonschema2pojo-.*/jsonschema2pojo-([0-9,.]+)\.t})
   end
 end

--- a/Livecheckables/libarchive.rb
+++ b/Livecheckables/libarchive.rb
@@ -1,6 +1,6 @@
 class Libarchive
   livecheck do
     url "https://libarchive.org/downloads/"
-    regex(/libarchive-([0-9.]+)\.tar.gz/)
+    regex(/libarchive-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libmikmod.rb
+++ b/Livecheckables/libmikmod.rb
@@ -1,6 +1,6 @@
 class Libmikmod
   livecheck do
     url "http://mikmod.sourceforge.net/"
-    regex(/href=.*libmikmod-([0-9,.]+)\.tar/)
+    regex(/href=.*libmikmod-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/libraw.rb
+++ b/Livecheckables/libraw.rb
@@ -1,6 +1,6 @@
 class Libraw
   livecheck do
     url "https://www.libraw.org/download/"
-    regex(/LibRaw-(\d+(?:\.\d+)*)\.tar/)
+    regex(/LibRaw-(\d+(?:\.\d+)*)\.t/)
   end
 end

--- a/Livecheckables/libsndfile.rb
+++ b/Livecheckables/libsndfile.rb
@@ -1,6 +1,6 @@
 class Libsndfile
   livecheck do
     url :homepage
-    regex(/libsndfile-([\d.]+)\.tar\.gz/)
+    regex(/libsndfile-([\d.]+)\.t/)
   end
 end

--- a/Livecheckables/libtermkey.rb
+++ b/Livecheckables/libtermkey.rb
@@ -1,6 +1,6 @@
 class Libtermkey
   livecheck do
     url :homepage
-    regex(/href="libtermkey-([0-9,.]+)\.tar/)
+    regex(/href="libtermkey-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/libvirt-glib.rb
+++ b/Livecheckables/libvirt-glib.rb
@@ -1,6 +1,6 @@
 class LibvirtGlib
   livecheck do
     url "https://libvirt.org/sources/glib/"
-    regex(/libvirt-glib-([\d.]+)\.tar\.gz/)
+    regex(/libvirt-glib-([\d.]+)\.t/)
   end
 end

--- a/Livecheckables/libvirt.rb
+++ b/Livecheckables/libvirt.rb
@@ -1,6 +1,6 @@
 class Libvirt
   livecheck do
     url "https://libvirt.org/sources/"
-    regex(/href="libvirt-([\d.]+)\.tar/)
+    regex(/href="libvirt-([\d.]+)\.t/)
   end
 end

--- a/Livecheckables/logcheck.rb
+++ b/Livecheckables/logcheck.rb
@@ -1,6 +1,6 @@
 class Logcheck
   livecheck do
     url "https://packages.debian.org/unstable/logcheck"
-    regex(/logcheck_([0-9,.]+)\.tar/)
+    regex(/logcheck_([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/lrzip.rb
+++ b/Livecheckables/lrzip.rb
@@ -1,6 +1,6 @@
 class Lrzip
   livecheck do
     url "http://ck.kolivas.org/apps/lrzip"
-    regex(/lrzip-(\d+(?:\.\d+)+)\.tar/)
+    regex(/lrzip-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/mikmod.rb
+++ b/Livecheckables/mikmod.rb
@@ -1,6 +1,6 @@
 class Mikmod
   livecheck do
     url "http://mikmod.sourceforge.net/"
-    regex(/href=.*[^b]mikmod-([0-9,.]+)\.tar/)
+    regex(/href=.*[^b]mikmod-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/mksh.rb
+++ b/Livecheckables/mksh.rb
@@ -1,6 +1,6 @@
 class Mksh
   livecheck do
     url "https://www.mirbsd.org/MirOS/dist/mir/mksh/"
-    regex(/mksh-R([0-9]+[a-z]*)\.tgz/)
+    regex(/mksh-R([0-9]+[a-z]*)\.t/)
   end
 end

--- a/Livecheckables/nagios-plugins.rb
+++ b/Livecheckables/nagios-plugins.rb
@@ -1,6 +1,6 @@
 class NagiosPlugins
   livecheck do
     url "https://nagios-plugins.org/download/"
-    regex(/href="nagios-plugins-([\d.]+)\.tar/)
+    regex(/href="nagios-plugins-([\d.]+)\.t/)
   end
 end

--- a/Livecheckables/nagios.rb
+++ b/Livecheckables/nagios.rb
@@ -1,6 +1,6 @@
 class Nagios
   livecheck do
     url "https://sourceforge.net/projects/nagios/"
-    regex(%r{/.*nagios-.*/nagios-([0-9,.]+)\.tar})
+    regex(%r{/.*nagios-.*/nagios-([0-9,.]+)\.t})
   end
 end

--- a/Livecheckables/nano.rb
+++ b/Livecheckables/nano.rb
@@ -1,6 +1,6 @@
 class Nano
   livecheck do
     url "https://www.nano-editor.org/download.php"
-    regex(/nano-([0-9.]+)\.tar\.xz/)
+    regex(/nano-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ncmpc.rb
+++ b/Livecheckables/ncmpc.rb
@@ -1,6 +1,6 @@
 class Ncmpc
   livecheck do
     url "https://www.musicpd.org/download/ncmpc/0/"
-    regex(/href="ncmpc-([0-9,.]+)\.tar/)
+    regex(/href="ncmpc-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/opencore-amr.rb
+++ b/Livecheckables/opencore-amr.rb
@@ -1,6 +1,6 @@
 class OpencoreAmr
   livecheck do
     url "https://sourceforge.net/projects/opencore-amr/files/opencore-amr/"
-    regex(/>opencore-amr-([\d.]+)\.tar\.gz/)
+    regex(/>opencore-amr-([\d.]+)\.t/)
   end
 end

--- a/Livecheckables/openrtsp.rb
+++ b/Livecheckables/openrtsp.rb
@@ -1,6 +1,6 @@
 class Openrtsp
   livecheck do
     url "http://www.live555.com/liveMedia/public/"
-    regex(/live\.([0-9a-z.]+)\.tar\.gz/)
+    regex(/live\.([0-9a-z.]+)\.t/)
   end
 end

--- a/Livecheckables/pdnsrec.rb
+++ b/Livecheckables/pdnsrec.rb
@@ -1,6 +1,6 @@
 class Pdnsrec
   livecheck do
     url "https://downloads.powerdns.com/releases/"
-    regex(/pdns-recursor-(\d+(?:\.\d+)*)\.tar/)
+    regex(/pdns-recursor-(\d+(?:\.\d+)*)\.t/)
   end
 end

--- a/Livecheckables/pgcli.rb
+++ b/Livecheckables/pgcli.rb
@@ -1,6 +1,6 @@
 class Pgcli
   livecheck do
     url "https://pypi.org/simple/pgcli/"
-    regex(/href=".*pgcli-([0-9,.]+)\.tar/)
+    regex(/href=".*pgcli-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/r.rb
+++ b/Livecheckables/r.rb
@@ -1,6 +1,6 @@
 class R
   livecheck do
     url "https://cran.rstudio.com/banner.shtml"
-    regex(%r{href="src/base/R-.*>R-([\d.]+)\.tar})
+    regex(%r{href="src/base/R-.*>R-([\d.]+)\.t})
   end
 end

--- a/Livecheckables/redis.rb
+++ b/Livecheckables/redis.rb
@@ -1,6 +1,6 @@
 class Redis
   livecheck do
     url "http://download.redis.io/releases/"
-    regex(/href="redis-([0-9,.]+)\.tar/)
+    regex(/href="redis-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/rtmpdump.rb
+++ b/Livecheckables/rtmpdump.rb
@@ -1,6 +1,6 @@
 class Rtmpdump
   livecheck do
     url "https://cdn-aws.deb.debian.org/debian/pool/main/r/rtmpdump/"
-    regex(/rtmpdump_(\d.\d\+\d*).*.orig\.tar\.gz/)
+    regex(/rtmpdump_(\d.\d\+\d*).*.orig\.t/)
   end
 end

--- a/Livecheckables/socat.rb
+++ b/Livecheckables/socat.rb
@@ -1,6 +1,6 @@
 class Socat
   livecheck do
     url "http://www.dest-unreach.org/socat/download/"
-    regex(/socat-([0-9.]+)\.tar\.gz/)
+    regex(/socat-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/sord.rb
+++ b/Livecheckables/sord.rb
@@ -1,6 +1,6 @@
 class Sord
   livecheck do
     url "https://download.drobilla.net"
-    regex(/href="sord-(\d+.\d+.\d+)\.tar/)
+    regex(/href="sord-(\d+.\d+.\d+)\.t/)
   end
 end

--- a/Livecheckables/tor.rb
+++ b/Livecheckables/tor.rb
@@ -1,6 +1,6 @@
 class Tor
   livecheck do
     url "https://dist.torproject.org/"
-    regex(/tor-([0-9.]+)\.tar\.gz/)
+    regex(/tor-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/tree.rb
+++ b/Livecheckables/tree.rb
@@ -1,6 +1,6 @@
 class Tree
   livecheck do
     url "http://mama.indstate.edu/users/ice/tree/src"
-    regex(/tree-(.*?)\.tgz/)
+    regex(/tree-(.*?)\.t/)
   end
 end

--- a/Livecheckables/unrar.rb
+++ b/Livecheckables/unrar.rb
@@ -1,6 +1,6 @@
 class Unrar
   livecheck do
     url "https://www.rarlab.com/rar_add.htm"
-    regex(%r{href="rar/unrarsrc-([0-9,.]+).tar})
+    regex(%r{href="rar/unrarsrc-([0-9,.]+)\.t})
   end
 end

--- a/Livecheckables/usbredir.rb
+++ b/Livecheckables/usbredir.rb
@@ -1,6 +1,6 @@
 class Usbredir
   livecheck do
     url "https://www.spice-space.org/download/usbredir/"
-    regex(/usbredir-([\d.]+)\.tar\.bz2/)
+    regex(/usbredir-([\d.]+)\.t/)
   end
 end

--- a/Livecheckables/xrootd.rb
+++ b/Livecheckables/xrootd.rb
@@ -1,6 +1,6 @@
 class Xrootd
   livecheck do
     url "http://xrootd.org/dload.html"
-    regex(%r{href="/download/.*/xrootd-([0-9,.]+)\.tar})
+    regex(%r{href="/download/.*/xrootd-([0-9,.]+)\.t})
   end
 end

--- a/Livecheckables/yubico-piv-tool.rb
+++ b/Livecheckables/yubico-piv-tool.rb
@@ -1,6 +1,6 @@
 class YubicoPivTool
   livecheck do
     url "https://developers.yubico.com/yubico-piv-tool/Releases/"
-    regex(/href="yubico-piv-tool-([0-9.]+)\.tar/)
+    regex(/href="yubico-piv-tool-([0-9.]+)\.t/)
   end
 end


### PR DESCRIPTION
This PR changes `\.tar`, `\.tgz`, `\.tar\.gz` and variants to `\.t` in the regex. Out of 68 Livecheckables in need of this change, only 53 have been carried out as part of this PR. They are:

```
     1	aalib
     2	aamath
     3	aardvark_shell_utils
     4	abuse
     5	ansifilter
     6	argus
     7	augeas
     8	bmake
     9	bonnie++
    10	colordiff
    11	creduce
    12	curl
    13	dmenu
    14	dnsmasq
    15	dnsperf
    16	dovecot
    17	dwarfutils
    18	fetch-crl
    19	gegl
    20	gnutls
    21	graphviz
    22	haproxy
    23	jsonschema2pojo
    24	libarchive
    25	libmikmod
    26	libraw
    27	libsndfile
    28	libtermkey
    29	libvirt-glib
    30	libvirt
    31	logcheck
    32	lrzip
    33	mikmod
    34	mksh
    35	nagios-plugins
    36	nagios
    37	nano
    38	ncmpc
    39	opencore-amr
    40	openrtsp
    41	pdnsrec
    42	pgcli
    43	r
    44	redis
    45	rtmpdump
    46	socat
    47	sord
    48	tor
    49	tree
    50	unrar
    51	usbredir
    52	xrootd
    53	yubico-piv-tool
```

The following were not changed due to the presence of `"` in the regex.

```
     1	bcftools
     2	byacc
     3	c-ares
     4	iozone
     5	libpst
     6	libsamplerate
     7	lua
     8	lynx
     9	lzip
    10	rsync
    11	siege
    12	spandsp
    13	speex
    14	tokyo-cabinet
    15	xvid
```

I had earlier mentioned that there would be 54 changes out of all 68, but my script did not account for Livecheckables with errors – `spandsp` has a `"` in the regex but both before and after the updation, the Livecheckable errors (TCP Connection failure, if I'm not wrong).

The 15 Livecheckables that couldn't be updated automatically will be handled in separate PRs.