### PR TITLE
Change \.z to \.zip in regex

### DIFF
--- a/Livecheckables/antlr4-cpp-runtime.rb
+++ b/Livecheckables/antlr4-cpp-runtime.rb
@@ -1,6 +1,6 @@
 class Antlr4CppRuntime
   livecheck do
     url "https://www.antlr.org/download/"
-    regex(/antlr4-cpp-runtime-([0-9.]+)-source\.z/)
+    regex(/antlr4-cpp-runtime-([0-9.]+)-source\.zip/)
   end
 end

--- a/Livecheckables/exomizer.rb
+++ b/Livecheckables/exomizer.rb
@@ -1,6 +1,6 @@
 class Exomizer
   livecheck do
     url "https://bitbucket.org/magli143/exomizer/wiki/browse/downloads/"
-    regex(%r{href=".*?/exomizer-([0-9.]+)\.z})
+    regex(%r{href=".*?/exomizer-([0-9.]+)\.zip})
   end
 end

--- a/Livecheckables/groovy.rb
+++ b/Livecheckables/groovy.rb
@@ -1,6 +1,6 @@
 class Groovy
   livecheck do
     url "https://dl.bintray.com/groovy/maven/"
-    regex(/groovy-binary-([\d.]+)\.z/)
+    regex(/groovy-binary-([\d.]+)\.zip/)
   end
 end

--- a/Livecheckables/groovysdk.rb
+++ b/Livecheckables/groovysdk.rb
@@ -1,6 +1,6 @@
 class Groovysdk
   livecheck do
     url "https://dl.bintray.com/groovy/maven/"
-    regex(/apache-groovy-sdk-([\d.]+)\.z/)
+    regex(/apache-groovy-sdk-([\d.]+)\.zip/)
   end
 end

--- a/Livecheckables/gsoap.rb
+++ b/Livecheckables/gsoap.rb
@@ -1,6 +1,6 @@
 class Gsoap
   livecheck do
     url "https://sourceforge.net/projects/gsoap2/files/gsoap-2.8/"
-    regex(%r{/gsoap-2.8/gsoap_(2.8[0-9.]+)\.z})
+    regex(%r{/gsoap-2.8/gsoap_(2.8[0-9.]+)\.zip})
   end
 end

--- a/Livecheckables/ptex.rb
+++ b/Livecheckables/ptex.rb
@@ -1,6 +1,6 @@
 class Ptex
   livecheck do
     url "http://ptex.us/download.html"
-    regex(%r{href=".*?/v([0-9.]+)\.z})
+    regex(%r{href=".*?/v([0-9.]+)\.zip})
   end
 end

--- a/Livecheckables/sonarqube.rb
+++ b/Livecheckables/sonarqube.rb
@@ -1,6 +1,6 @@
 class Sonarqube
   livecheck do
     url "https://binaries.sonarsource.com/Distribution/sonarqube/"
-    regex(/sonarqube-([0-9.]+)\.z/)
+    regex(/sonarqube-([0-9.]+)\.zip/)
   end
 end

--- a/Livecheckables/spring-roo.rb
+++ b/Livecheckables/spring-roo.rb
@@ -1,6 +1,6 @@
 class SpringRoo
   livecheck do
     url :homepage
-    regex(%r{href=".*?/spring-roo-([0-9.]+)\.RELEASE\.z})
+    regex(%r{href=".*?/spring-roo-([0-9.]+)\.RELEASE\.zip})
   end
 end

--- a/Livecheckables/wirouter_keyrec.rb
+++ b/Livecheckables/wirouter_keyrec.rb
@@ -1,6 +1,6 @@
 class WirouterKeyrec
   livecheck do
     url :homepage
-    regex(%r{href=.*?/WiRouter_KeyRec_([0-9.]+)\.z})
+    regex(%r{href=.*?/WiRouter_KeyRec_([0-9.]+)\.zip})
   end
 end


### PR DESCRIPTION
In this PR, Livecheckable regexes containing `\.z` are modified to use `\.zip`. The Livecheckables affected are:
```
1 antlr4-cpp-runtime.rb
2 exomizer.rb
3 groovy.rb
4 groovysdk.rb
5 gsoap.rb
6 ptex.rb
7 sonarqube.rb
8 spring-roo.rb
9 wirouter_keyrec.rb
```