### PR TITLE
bcftools: update url and regex

### DIFF
--- a/Livecheckables/bcftools.rb
+++ b/Livecheckables/bcftools.rb
@@ -1,6 +1,6 @@
 class Bcftools
   livecheck do
     url "https://github.com/samtools/bcftools/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["']}i)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/bcftools.rb
+++ b/Livecheckables/bcftools.rb
@@ -1,6 +1,6 @@
 class Bcftools
   livecheck do
-    url "https://github.com/samtools/bcftools/releases"
-    regex(%r{href="/samtools/bcftools/releases/download/.*/bcftools-([0-9.]+).tar.bz2"})
+    url "https://github.com/samtools/bcftools/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["']}i)
   end
 end


### PR DESCRIPTION
Update `bcftools` to conform to current standards.