### PR TITLE
byacc: update regex

### DIFF
--- a/Livecheckables/byacc.rb
+++ b/Livecheckables/byacc.rb
@@ -1,6 +1,6 @@
 class Byacc
   livecheck do
     url "https://invisible-mirror.net/archives/byacc/"
-    regex(/href=.*?byacc[._-]v?(\d{8})\.t/i)
+    regex(/href=.*?byacc[._-]v?(\d{6,8})\.t/i)
   end
 end

--- a/Livecheckables/byacc.rb
+++ b/Livecheckables/byacc.rb
@@ -1,6 +1,6 @@
 class Byacc
   livecheck do
     url "https://invisible-mirror.net/archives/byacc/"
-    regex(/href="byacc-([0-9,.]+)\.tgz"/)
+    regex(/href=.*?byacc[._-]v?(\d{8})\.t/i)
   end
 end


### PR DESCRIPTION
This PR updates `byacc`'s `regex` to match current standards. I didn't use our standard `(\d+(?:\.\d+)+)` for two reasons:
1. All versions have been of the form `YYYYMMDD`
2. There is just one `byacc-1.9` at the bottom of the page we're checking, and I didn't want to match it.

Then again,`\d{8}` may be too strict or there might be better alternatives.