### PR TITLE
iozone: update url and regex

### DIFF
--- a/Livecheckables/iozone.rb
+++ b/Livecheckables/iozone.rb
@@ -1,6 +1,6 @@
 class Iozone
   livecheck do
     url "http://www.iozone.org/src/current"
-    regex(/href=.*?iozone[._-]?v?(\d+(?:[._-]\d+)+)\.t/i)
+    regex(/href=.*?iozone[._-]?v?(\d+(?:[._]\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/iozone.rb
+++ b/Livecheckables/iozone.rb
@@ -1,6 +1,6 @@
 class Iozone
   livecheck do
-    url :homepage
-    regex(%r{HREF="src/current/iozone(3_[0-9]+)\.tar">Stable})
+    url "http://www.iozone.org/src/current"
+    regex(/href=.*?iozone[._-]?v?(\d+(?:[._-]\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR modifies `iozone`'s Livecheckable to match our current standards.

I had a hard time deciding what to do for this one, due to multiple possible variants that would work. I'll try to outline the rationale behind my final choice here:

1. The `:homepage` check isn't as reliable checking the index page with all versions. Sp I've used `http://www.iozone.org/src/current`.
2. The URL for the Stable releases page and Current releases (or Latest releases) is the same – on the homepage there are two `<a>` tags, one for Stable files and the other for Latest files. Both have the same `href=` attribute values (which is the `url` I've used here).
3. The filename patterns have changed over the years.
    * Sometimes there has been a delimiter between `iozone` and `3`, now there isn't. Hence I've used `[._-]?`.
    * It is possible that the `3` may change later (I wasn't sure) so I replaced that to `\d+`.
    * Overall the version matching group has been changed to `(\d+(?:[._-]\d+)+)` to account for versions like `3_489`.
    * And as usual, there are other updates such as `v?`, `\.t` and the `i` flag.

There might be changes to this one to make it better, I'll wait for your feedback @samford.