### PR TITLE
tokyo-cabinet: update regex

### DIFF
--- a/Livecheckables/tokyo-cabinet.rb
+++ b/Livecheckables/tokyo-cabinet.rb
@@ -1,6 +1,6 @@
 class TokyoCabinet
   livecheck do
     url :homepage
-    regex(/href="tokyocabinet-([\d.]+)\.tar\.gz"/)
+    regex(/href=.*?tokyocabinet[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
Update `tokyo-cabinet`'s `regex` to conform to current standards.