### PR TITLE
Allow to livecheck formulae without tap

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -83,9 +83,7 @@ module Homebrew
     # Identify any non-homebrew/core taps in use for current formulae
     non_core_taps = {}
     formulae_to_check.each do |f|
-      unless f.tap.nil?
-        non_core_taps[f.tap.name] = true unless f.tap.name == "homebrew/core" || non_core_taps.key?(f.tap.name)
-      end
+      non_core_taps[f.tap.name] = true unless f.tap.nil? || f.tap.name == "homebrew/core"
     end
     non_core_taps = non_core_taps.keys.sort
 

--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -83,7 +83,9 @@ module Homebrew
     # Identify any non-homebrew/core taps in use for current formulae
     non_core_taps = {}
     formulae_to_check.each do |f|
-      non_core_taps[f.tap.name] = true unless f.tap.name == "homebrew/core" || non_core_taps.key?(f.tap.name)
+      unless f.tap.nil?
+        non_core_taps[f.tap.name] = true unless f.tap.name == "homebrew/core" || non_core_taps.key?(f.tap.name)
+      end
     end
     non_core_taps = non_core_taps.keys.sort
 


### PR DESCRIPTION
Formula.tap can be nil in some cases. Currently this make livecheck fail without any useful error message. I think the simplest fix is to skip those when looking at non-core taps.