### PR TITLE
Update [_.] delimiters to [._]

### DIFF
--- a/Livecheckables/cern-ndiff.rb
+++ b/Livecheckables/cern-ndiff.rb
@@ -1,6 +1,6 @@
 class CernNdiff
   livecheck do
     url :head
-    regex(/^(?:mad-?X.)?v?(\d+(?:[_.]\d+)+)$/i)
+    regex(/^(?:mad-?X.)?v?(\d+(?:[._]\d+)+)$/i)
   end
 end

--- a/Livecheckables/freeradius-server.rb
+++ b/Livecheckables/freeradius-server.rb
@@ -1,6 +1,6 @@
 class FreeradiusServer
   livecheck do
     url :head
-    regex(/^release_(\d+(?:[_.]\d+)+)$/)
+    regex(/^release[._-](\d+(?:[._]\d+)+)$/)
   end
 end

--- a/Livecheckables/simgrid.rb
+++ b/Livecheckables/simgrid.rb
@@ -1,6 +1,6 @@
 class Simgrid
   livecheck do
     url "https://framagit.org/simgrid/simgrid.git"
-    regex(/^v?(\d+(?:[_.]\d+)+)$/i)
+    regex(/^v?(\d+(?:[._]\d+)+)$/i)
   end
 end

--- a/Livecheckables/smpeg.rb
+++ b/Livecheckables/smpeg.rb
@@ -1,6 +1,6 @@
 class Smpeg
   livecheck do
     url "http://svn.icculus.org/smpeg/tags/"
-    regex(%r{href=.*?release.v?(\d+(?:[_.]\d+)+)/}i)
+    regex(%r{href=.*?release[._-]v?(\d+(?:[._]\d+)+)/}i)
   end
 end


### PR DESCRIPTION
In reference to my [comment in #1067](https://github.com/Homebrew/homebrew-livecheck/pull/1067#pullrequestreview-443533365), this updates the existing use of `[_.]` in livecheckables to `[._]`. This is functionally identical but it's stylistically in line with the order we use in `[._-]`, which we use in other contexts. It's not a meaningful change but standardizing the order simply makes it easier to search for across livecheckables.