### PR TITLE
Address new style warnings

### DIFF
--- a/livecheck/livecheck_strategy/git.rb
+++ b/livecheck/livecheck_strategy/git.rb
@@ -17,7 +17,7 @@ module LivecheckStrategy
       tags.each do |tag|
         # Skip tag if it has a 'debian/' prefix and upstream does not do only
         # 'debian/' prefixed tags
-        next if tag =~ %r{debian/} && !tags_only_debian
+        next if tag =~ %r{^debian/} && !tags_only_debian
 
         captures = regex.is_a?(Regexp) ? tag.scan(regex) : []
         tag_cleaned = if captures[0].is_a?(Array)

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -26,7 +26,7 @@ module LivecheckStrategy
     private_constant :SPECIAL_CASES
 
     def self.match?(url)
-      url =~ /gnu\.org/ && SPECIAL_CASES.none? { |sc| url.include? sc }
+      url.include?("gnu.org") && SPECIAL_CASES.none? { |sc| url.include? sc }
     end
 
     def self.find_versions(url, regex)


### PR DESCRIPTION
We seem to have a new audit that's giving us warnings about a couple strategies.

```
== /usr/local/Homebrew/Library/Taps/homebrew/homebrew-livecheck/livecheck/livecheck_strategy/git.rb ==
C: 20: 17: Use String#include? instead of a regex match with literal-only pattern.
== /usr/local/Homebrew/Library/Taps/homebrew/homebrew-livecheck/livecheck/livecheck_strategy/gnu.rb ==
C: 29:  7: Use String#include? instead of a regex match with literal-only pattern.
```

This PR addresses both of these issues in a contextually-appropriate manner.

Edit: A comparison of output before and after these changes showed that everything is still working the same, so this should be fine to merge.