### PR TITLE
Update Livecheckables using GitHub releases page

### DIFF
--- a/Livecheckables/advancemame.rb
+++ b/Livecheckables/advancemame.rb
@@ -1,6 +1,6 @@
 class Advancemame
   livecheck do
-    url "https://github.com/amadvance/advancemame/releases"
-    regex(%r{Latest.*?href="/amadvance/advancemame/tree/v?([0-9.]+)}m)
+    url "https://github.com/amadvance/advancemame/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/akka.rb
+++ b/Livecheckables/akka.rb
@@ -1,6 +1,6 @@
 class Akka
   livecheck do
     url "https://github.com/akka/akka/releases/latest"
-    regex(%r{href=.+?/tag/v?(\d+(?:\.\d+)+)["']}i)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/algernon.rb
+++ b/Livecheckables/algernon.rb
@@ -1,6 +1,6 @@
 class Algernon
   livecheck do
-    url "https://github.com/xyproto/algernon/releases"
-    regex(%r{Latest.*?href="/xyproto/algernon/tree/v?([0-9.]+)}m)
+    url "https://github.com/xyproto/algernon/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/atari800.rb
+++ b/Livecheckables/atari800.rb
@@ -1,6 +1,6 @@
 class Atari800
   livecheck do
-    url "https://github.com/atari800/atari800/releases"
-    regex(%r{.*?/atari800-([0-9.]+)-src\.t})
+    url "https://github.com/atari800/atari800/releases/latest"
+    regex(%r{href=.*?/tag/ATARI800[._-]v?(\d+(?:[._]\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/autopsy.rb
+++ b/Livecheckables/autopsy.rb
@@ -1,6 +1,6 @@
 class Autopsy
   livecheck do
     url "https://github.com/sleuthkit/autopsy/releases/latest"
-    regex(%r{href=.+?/tag/autopsy-v?(\d+(?:\.\d+)+)})
+    regex(%r{href=.*?/tag/autopsy[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/azure-cli.rb
+++ b/Livecheckables/azure-cli.rb
@@ -1,6 +1,6 @@
 class AzureCli
   livecheck do
-    url "https://github.com/Azure/azure-cli/releases"
-    regex(%r{href="/Azure/azure-cli/releases/tag/azure-cli-([\d.]+)"})
+    url "https://github.com/Azure/azure-cli/releases/latest"
+    regex(%r{href=.*?/tag/azure-cli[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/bash-completion@2.rb
+++ b/Livecheckables/bash-completion@2.rb
@@ -1,6 +1,6 @@
 class BashCompletionAT2
   livecheck do
-    url "https://github.com/scop/bash-completion/releases"
-    regex(/href=".*bash-completion-([\d.]+\.[\d.]+)\.t/)
+    url "https://github.com/scop/bash-completion/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/bcal.rb
+++ b/Livecheckables/bcal.rb
@@ -1,6 +1,6 @@
 class Bcal
   livecheck do
-    url "https://github.com/jarun/bcal/releases"
-    regex(%r{Latest.*?href="/jarun/bcal/tree/v?([0-9.]+)}m)
+    url "https://github.com/jarun/bcal/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/beast.rb
+++ b/Livecheckables/beast.rb
@@ -1,6 +1,6 @@
 class Beast
   livecheck do
-    url "https://github.com/beast-dev/beast-mcmc/releases"
-    regex(%r{href="/beast-dev/beast-mcmc/tree/v([0-9.]+)"})
+    url :head
+    regex(/^(?:beast[._-]release[._-])?v?(\d+(?:[._]\d+)+)$/i)
   end
 end

--- a/Livecheckables/beast.rb
+++ b/Livecheckables/beast.rb
@@ -1,6 +1,6 @@
 class Beast
   livecheck do
     url :head
-    regex(/^(?:beast[._-]release[._-])?v?(\d+(?:[._]\d+)+)$/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/bluepill.rb
+++ b/Livecheckables/bluepill.rb
@@ -1,6 +1,6 @@
 class Bluepill
   livecheck do
-    url "https://github.com/linkedin/bluepill/releases"
-    regex(%r{Latest.*?href="/linkedin/bluepill/tree/v?([0-9.]+)}m)
+    url "https://github.com/linkedin/bluepill/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/caffe.rb
+++ b/Livecheckables/caffe.rb
@@ -1,6 +1,6 @@
 class Caffe
   livecheck do
-    url "https://github.com/BVLC/caffe/releases"
-    regex(%r{Latest.*?href="/BVLC/caffe/tree/v?([0-9.]+)}m)
+    url "https://github.com/BVLC/caffe/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/cdogs-sdl.rb
+++ b/Livecheckables/cdogs-sdl.rb
@@ -1,6 +1,6 @@
 class CdogsSdl
   livecheck do
-    url "https://github.com/cxong/cdogs-sdl/releases"
-    regex(%r{Latest.*?href="/cxong/cdogs-sdl/tree/v?([0-9.]+)}m)
+    url "https://github.com/cxong/cdogs-sdl/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/ckan.rb
+++ b/Livecheckables/ckan.rb
@@ -1,6 +1,6 @@
 class Ckan
   livecheck do
-    url "https://github.com/KSP-CKAN/CKAN/releases"
-    regex(%r{Latest.*?href="/KSP-CKAN/CKAN/tree/v?([0-9.]+)}m)
+    url "https://github.com/KSP-CKAN/CKAN/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/clang-format.rb
+++ b/Livecheckables/clang-format.rb
@@ -1,6 +1,6 @@
 class ClangFormat
   livecheck do
     url "https://github.com/llvm/llvm-project/releases/latest"
-    regex(%r{href=.+?/tag/llvmorg-v?(\d+(?:\.\d+)+)}i)
+    regex(%r{href=.*?/tag/llvmorg[._-]v?(\d+(?:\.\d+)+)}i)
   end
 end

--- a/Livecheckables/clingo.rb
+++ b/Livecheckables/clingo.rb
@@ -1,6 +1,6 @@
 class Clingo
   livecheck do
-    url "https://github.com/potassco/clingo/releases"
-    regex(%r{Latest.*?href="/potassco/clingo/tree/v?([0-9.]+)}m)
+    url "https://github.com/potassco/clingo/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/clojurescript.rb
+++ b/Livecheckables/clojurescript.rb
@@ -1,6 +1,6 @@
 class Clojurescript
   livecheck do
-    url "https://github.com/clojure/clojurescript/releases"
-    regex(%r{Latest.*?href="/clojure/clojurescript/tree/r([0-9.]+)}m)
+    url "https://github.com/clojure/clojurescript/releases/latest"
+    regex(%r{href=.*?/tag/r?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/clozure-cl.rb
+++ b/Livecheckables/clozure-cl.rb
@@ -1,6 +1,6 @@
 class ClozureCl
   livecheck do
-    url "https://github.com/Clozure/ccl/releases"
-    regex(%r{Latest.*?href="/Clozure/ccl/tree/v?([0-9.]+)}m)
+    url "https://github.com/Clozure/ccl/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/conan.rb
+++ b/Livecheckables/conan.rb
@@ -1,6 +1,6 @@
 class Conan
   livecheck do
-    url "https://github.com/conan-io/conan/releases"
-    regex(%r{Latest.*?href="/conan-io/conan/tree/v?([0-9.]+)}m)
+    url "https://github.com/conan-io/conan/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/conserver.rb
+++ b/Livecheckables/conserver.rb
@@ -1,6 +1,6 @@
 class Conserver
   livecheck do
-    url "https://github.com/conserver/conserver/releases"
-    regex(%r{href="/conserver/conserver/tree/v?([0-9.]+)})
+    url "https://github.com/conserver/conserver/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/dcm2niix.rb
+++ b/Livecheckables/dcm2niix.rb
@@ -1,6 +1,6 @@
 class Dcm2niix
   livecheck do
-    url "https://github.com/rordenlab/dcm2niix/releases"
-    regex(%r{href="/rordenlab/dcm2niix/tree/v([0-9.]+)"})
+    url "https://github.com/rordenlab/dcm2niix/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/dcos-cli.rb
+++ b/Livecheckables/dcos-cli.rb
@@ -1,6 +1,6 @@
 class DcosCli
   livecheck do
-    url "https://github.com/dcos/dcos-cli/releases"
-    regex(%r{releases/latest.*?href="/dcos/dcos-cli/tree/([0-9.]+)"}m)
+    url "https://github.com/dcos/dcos-cli/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/dub.rb
+++ b/Livecheckables/dub.rb
@@ -1,6 +1,6 @@
 class Dub
   livecheck do
-    url "https://github.com/dlang/dub/releases"
-    regex(%r{href="/dlang/dub/releases/tag/v([0-9,.]+)"})
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/duti.rb
+++ b/Livecheckables/duti.rb
@@ -1,6 +1,6 @@
 class Duti
   livecheck do
     url :head
-    regex(/^duti[._-]v?(\d+(?:[.-]\d+)+)$/)
+    regex(/^duti[._-]v?(\d+(?:[.-]\d+)+)$/i)
   end
 end

--- a/Livecheckables/duti.rb
+++ b/Livecheckables/duti.rb
@@ -1,6 +1,6 @@
 class Duti
   livecheck do
-    url "https://github.com/moretension/duti/releases"
-    regex(/duti-([0-9.]+)/)
+    url :head
+    regex(/^duti[._-]v?(\d+(?:[.-]\d+)+)$/)
   end
 end

--- a/Livecheckables/dynamips.rb
+++ b/Livecheckables/dynamips.rb
@@ -1,6 +1,6 @@
 class Dynamips
   livecheck do
-    url "https://github.com/GNS3/dynamips/releases"
-    regex(%r{href="/GNS3/dynamips/tree/v?([0-9.]+)"})
+    url "https://github.com/GNS3/dynamips/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/elektra.rb
+++ b/Livecheckables/elektra.rb
@@ -1,6 +1,6 @@
 class Elektra
   livecheck do
-    url "https://github.com/ElektraInitiative/libelektra/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url "https://www.libelektra.org/ftp/elektra/releases/"
+    regex(/href=.*?elektra[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/elektra.rb
+++ b/Livecheckables/elektra.rb
@@ -1,6 +1,6 @@
 class Elektra
   livecheck do
-    url "https://github.com/ElektraInitiative/libelektra/releases"
-    regex(%r{Latest.*?href="/ElektraInitiative/libelektra/tree/v?([0-9.]+)}m)
+    url "https://github.com/ElektraInitiative/libelektra/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/emscripten.rb
+++ b/Livecheckables/emscripten.rb
@@ -1,6 +1,6 @@
 class Emscripten
   livecheck do
-    url "https://github.com/kripken/emscripten/releases"
-    regex(%r{href="/.*/emscripten/releases/tag/([0-9.]+)"})
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/ethereum.rb
+++ b/Livecheckables/ethereum.rb
@@ -1,6 +1,6 @@
 class Ethereum
   livecheck do
-    url "https://github.com/ethereum/go-ethereum/releases"
-    regex(%r{Latest.*?href="/ethereum/go-ethereum/tree/v?([0-9.]+)}m)
+    url "https://github.com/ethereum/go-ethereum/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/exa.rb
+++ b/Livecheckables/exa.rb
@@ -1,6 +1,6 @@
 class Exa
   livecheck do
-    url "https://github.com/ogham/exa/releases"
-    regex(%r{latest.*?href="/ogham/exa/tree/v?([0-9.]+)}m)
+    url "https://github.com/ogham/exa/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/exercism.rb
+++ b/Livecheckables/exercism.rb
@@ -1,6 +1,6 @@
 class Exercism
   livecheck do
-    url "https://github.com/exercism/cli/releases"
-    regex(%r{Latest.*?href="/exercism/cli/tree/v?([0-9.]+)}m)
+    url "https://github.com/exercism/cli/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/fabric.rb
+++ b/Livecheckables/fabric.rb
@@ -1,6 +1,6 @@
 class Fabric
   livecheck do
-    url "https://github.com/fabric/fabric/releases"
-    regex(%r{href="/fabric/fabric/releases/tag/([0-9.]+)"})
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/fail2ban.rb
+++ b/Livecheckables/fail2ban.rb
@@ -1,6 +1,6 @@
 class Fail2ban
   livecheck do
-    url "https://github.com/fail2ban/fail2ban/releases"
-    regex(%r{href="/fail2ban/fail2ban/tree/([0-9.]+)})
+    url "https://github.com/fail2ban/fail2ban/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/frege.rb
+++ b/Livecheckables/frege.rb
@@ -1,6 +1,6 @@
 class Frege
   livecheck do
     url "https://github.com/Frege/frege/releases/latest"
-    regex(/href=.*?frege[._-]?(\d+(?:\.\d+)+)\.jar/)
+    regex(/href=.*?frege[._-]?(\d+(?:\.\d+)+)\.jar/i)
   end
 end

--- a/Livecheckables/frege.rb
+++ b/Livecheckables/frege.rb
@@ -1,6 +1,6 @@
 class Frege
   livecheck do
     url "https://github.com/Frege/frege/releases/latest"
-    regex(/href=.+?frege(\d+(?:\.\d+)+)\.jar/)
+    regex(/href=.*?frege[._-]?(\d+(?:\.\d+)+)\.jar/)
   end
 end

--- a/Livecheckables/frei0r.rb
+++ b/Livecheckables/frei0r.rb
@@ -1,6 +1,6 @@
 class Frei0r
   livecheck do
-    url "https://github.com/dyne/frei0r.git"
-    regex(/^v(\d+(?:\.\d+)+)$/i)
+    url "https://files.dyne.org/frei0r/releases/"
+    regex(/href=.*?frei0r-plugins[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/frei0r.rb
+++ b/Livecheckables/frei0r.rb
@@ -1,6 +1,6 @@
 class Frei0r
   livecheck do
-    url "https://github.com/dyne/frei0r/releases"
-    regex(%r{<a href="/dyne/frei0r/releases/tag/v([\d.]+)"})
+    url "https://github.com/dyne/frei0r.git"
+    regex(/^v(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/genders.rb
+++ b/Livecheckables/genders.rb
@@ -1,6 +1,6 @@
 class Genders
   livecheck do
     url "https://github.com/chaos/genders/releases/latest"
-    regex(%r{href=.*?/tag/genders-v?(\d+(?:-\d+)+)["']}i)
+    regex(%r{href=.*?/tag/genders[._-]v?(\d+(?:[.-]\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/getdns.rb
+++ b/Livecheckables/getdns.rb
@@ -4,6 +4,6 @@ class Getdns
   # `execution expired` error.
   livecheck do
     url "https://github.com/getdnsapi/getdns/releases/latest"
-    regex(%r{href=.+?/tag/v?(\d+(?:\.\d+)+)["']})
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/glm.rb
+++ b/Livecheckables/glm.rb
@@ -1,6 +1,6 @@
 class Glm
   livecheck do
-    url "https://github.com/g-truc/glm/releases"
-    regex(%r{latest.*?href="/g-truc/glm/tree/([0-9.]+)}m)
+    url "https://github.com/g-truc/glm/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/gnupg-pkcs11-scd.rb
+++ b/Livecheckables/gnupg-pkcs11-scd.rb
@@ -1,6 +1,6 @@
 class GnupgPkcs11Scd
   livecheck do
-    url "https://github.com/alonbl/gnupg-pkcs11-scd/releases"
-    regex(%r{href="/alonbl/gnupg-pkcs11-scd/releases/tag/gnupg-pkcs11-scd-([0-9,.]+)"})
+    url "https://github.com/alonbl/gnupg-pkcs11-scd/releases/latest"
+    regex(%r{href=.*?/tag/gnupg-pkcs11-scd[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/gperftools.rb
+++ b/Livecheckables/gperftools.rb
@@ -1,6 +1,6 @@
 class Gperftools
   livecheck do
-    url "https://github.com/gperftools/gperftools/releases"
-    regex(%r{Latest.*?href="/gperftools/gperftools/tree/gperftools-([0-9.]+)}m)
+    url "https://github.com/gperftools/gperftools/releases/latest"
+    regex(%r{href=.*?/tag/gperftools[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/grpc.rb
+++ b/Livecheckables/grpc.rb
@@ -1,6 +1,6 @@
 class Grpc
   livecheck do
-    url "https://github.com/grpc/grpc/releases"
-    regex(%r{latest.*?href="/grpc/grpc/tree/v?([0-9.]+)}m)
+    url "https://github.com/grpc/grpc/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/hackrf.rb
+++ b/Livecheckables/hackrf.rb
@@ -1,6 +1,6 @@
 class Hackrf
   livecheck do
-    url "https://github.com/mossmann/hackrf/releases"
-    regex(%r{Latest.*?href="/mossmann/hackrf/tree/v?([0-9.]+)"}m)
+    url "https://github.com/mossmann/hackrf/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/hashpump.rb
+++ b/Livecheckables/hashpump.rb
@@ -1,6 +1,6 @@
 class Hashpump
   livecheck do
-    url "https://github.com/bwall/HashPump/releases"
-    regex(%r{Latest.*?href="/bwall/HashPump/tree/v?([0-9.]+)"}m)
+    url "https://github.com/bwall/HashPump/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/haskell-stack.rb
+++ b/Livecheckables/haskell-stack.rb
@@ -1,6 +1,6 @@
 class HaskellStack
   livecheck do
-    url "https://github.com/commercialhaskell/stack/releases"
-    regex(%r{latest.*?href="/commercialhaskell/stack/tree/v?([0-9.]+)}m)
+    url "https://github.com/commercialhaskell/stack/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/heimdal.rb
+++ b/Livecheckables/heimdal.rb
@@ -1,6 +1,6 @@
 class Heimdal
   livecheck do
-    url "https://github.com/heimdal/heimdal/releases"
-    regex(%r{Latest.*?href="/heimdal/heimdal/tree/heimdal-([0-9.]+)"}m)
+    url "https://github.com/heimdal/heimdal/releases/latest"
+    regex(%r{href=.*?/tag/heimdal[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/hfstospell.rb
+++ b/Livecheckables/hfstospell.rb
@@ -1,6 +1,6 @@
 class Hfstospell
   livecheck do
     url "https://github.com/hfst/hfst-ospell/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["']}i)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/htslib.rb
+++ b/Livecheckables/htslib.rb
@@ -1,6 +1,6 @@
 class Htslib
   livecheck do
-    url "https://github.com/samtools/htslib/releases"
-    regex(%r{href="/samtools/htslib/tree/([0-9.]+)})
+    url "https://github.com/samtools/htslib/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/ice.rb
+++ b/Livecheckables/ice.rb
@@ -1,6 +1,6 @@
 class Ice
   livecheck do
-    url "https://github.com/zeroc-ice/ice/releases"
-    regex(%r{latest.*?href="/zeroc-ice/ice/tree/v?([0-9.]+)}m)
+    url "https://github.com/zeroc-ice/ice/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/icu4c.rb
+++ b/Livecheckables/icu4c.rb
@@ -1,6 +1,6 @@
 class Icu4c
   livecheck do
-    url "https://github.com/unicode-org/icu/releases"
-    regex(%r{href="/unicode-org/icu/releases/tag/release-[^"]+"[^>]*>ICU ([\d.]+)<})
+    url "https://github.com/unicode-org/icu/releases/latest"
+    regex(%r{href=.*?/tag/release[._-]v?(\d+(?:[.-]\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/javacc.rb
+++ b/Livecheckables/javacc.rb
@@ -1,6 +1,6 @@
 class Javacc
   livecheck do
     url "https://github.com/javacc/javacc/releases/latest"
-    regex(%r{href=.+?/tag/javacc-v?(\d+(?:\.\d+)+)}i)
+    regex(%r{href=.*?/tag/javacc[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/jbig2dec.rb
+++ b/Livecheckables/jbig2dec.rb
@@ -1,6 +1,6 @@
 class Jbig2dec
   livecheck do
     url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/latest"
-    regex(%r{href=.+?/jbig2dec-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{href=.*?/jbig2dec[._-]v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/jbig2dec.rb
+++ b/Livecheckables/jbig2dec.rb
@@ -1,6 +1,6 @@
 class Jbig2dec
   livecheck do
     url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/latest"
-    regex(%r{href=.*?/jbig2dec[._-]v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{href=.*?/jbig2dec[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/jdnssec-tools.rb
+++ b/Livecheckables/jdnssec-tools.rb
@@ -1,6 +1,6 @@
 class JdnssecTools
   livecheck do
     url "https://github.com/dblacka/jdnssec-tools/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["']}i)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/jdupes.rb
+++ b/Livecheckables/jdupes.rb
@@ -1,6 +1,6 @@
 class Jdupes
   livecheck do
-    url "https://github.com/jbruchon/jdupes/releases"
-    regex(%r{Latest.*?href="/jbruchon/jdupes/tree/v?([0-9.]+)}m)
+    url "https://github.com/jbruchon/jdupes/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/jpeg-turbo.rb
+++ b/Livecheckables/jpeg-turbo.rb
@@ -1,6 +1,5 @@
 class JpegTurbo
   livecheck do
-    url "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
   end
 end

--- a/Livecheckables/jpeg-turbo.rb
+++ b/Livecheckables/jpeg-turbo.rb
@@ -1,6 +1,6 @@
 class JpegTurbo
   livecheck do
-    url "https://github.com/libjpeg-turbo/libjpeg-turbo/releases"
-    regex(%r{href="/libjpeg-turbo/libjpeg-turbo/tree/([0-9.]+)})
+    url "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/jq.rb
+++ b/Livecheckables/jq.rb
@@ -1,6 +1,6 @@
 class Jq
   livecheck do
-    url "https://github.com/stedolan/jq/releases"
-    regex(%r{Latest.*?href="/stedolan/jq/tree/jq-?([0-9.]+)}m)
+    url "https://github.com/stedolan/jq/releases/latest"
+    regex(%r{href=.*?/tag/jq[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/json-c.rb
+++ b/Livecheckables/json-c.rb
@@ -1,6 +1,6 @@
 class JsonC
   livecheck do
     url :head
-    regex(/^json-c[._-](\d+(?:\.\d+)+)[._-]\d{6,8}$/i)
+    regex(/^json-c[._-](\d+(?:\.\d+)+)(?:[._-]\d{6,8})?$/i)
   end
 end

--- a/Livecheckables/json-c.rb
+++ b/Livecheckables/json-c.rb
@@ -1,6 +1,6 @@
 class JsonC
   livecheck do
-    url "https://github.com/json-c/json-c/releases"
-    regex(%r{href="/json-c/json-c/releases/tag/json-c-([0-9.]+)-[0-9]+"})
+    url :head
+    regex(/^json-c[._-](\d+(?:\.\d+)+)[._-]\d{6,8}$/i)
   end
 end

--- a/Livecheckables/jsoncpp.rb
+++ b/Livecheckables/jsoncpp.rb
@@ -1,6 +1,6 @@
 class Jsoncpp
   livecheck do
     url "https://github.com/open-source-parsers/jsoncpp/releases/latest"
-    regex(%r{href=.+?/tag/v?(\d+(?:\.\d+)+)["']}i)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/jsonnet.rb
+++ b/Livecheckables/jsonnet.rb
@@ -1,6 +1,6 @@
 class Jsonnet
   livecheck do
-    url "https://github.com/google/jsonnet/releases"
-    regex(%r{href="/.*/jsonnet/releases/tag/v?([0-9.]+)"})
+    url "https://github.com/google/jsonnet/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/jsonschema2pojo.rb
+++ b/Livecheckables/jsonschema2pojo.rb
@@ -1,6 +1,6 @@
 class Jsonschema2pojo
   livecheck do
-    url "https://github.com/joelittlejohn/jsonschema2pojo/releases"
-    regex(%r{releases/download/jsonschema2pojo-.*/jsonschema2pojo-([0-9,.]+)\.t})
+    url "https://github.com/joelittlejohn/jsonschema2pojo/releases/latest"
+    regex(%r{href=.*?/tag/jsonschema2pojo[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/kakoune.rb
+++ b/Livecheckables/kakoune.rb
@@ -1,6 +1,6 @@
 class Kakoune
   livecheck do
-    url "https://github.com/mawww/kakoune/releases"
-    regex(%r{Latest.*?href="/mawww/kakoune/tree/v?([0-9.]+)}m)
+    url "https://github.com/mawww/kakoune/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/keychain.rb
+++ b/Livecheckables/keychain.rb
@@ -1,6 +1,6 @@
 class Keychain
   livecheck do
-    url "https://github.com/funtoo/keychain/releases"
-    regex(%r{href="/funtoo/keychain/tree/([0-9.]+)})
+    url "https://github.com/funtoo/keychain/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/kotlin.rb
+++ b/Livecheckables/kotlin.rb
@@ -1,6 +1,6 @@
 class Kotlin
   livecheck do
-    url "https://api.github.com/repos/JetBrains/kotlin/releases/latest"
-    regex(/([0-9.]+\.[0-9.]+)"/)
+    url "https://github.com/JetBrains/kotlin/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/kvazaar.rb
+++ b/Livecheckables/kvazaar.rb
@@ -1,6 +1,6 @@
 class Kvazaar
   livecheck do
-    url "https://github.com/ultravideo/kvazaar/releases"
-    regex(%r{href="/ultravideo/kvazaar/tree/v?([0-9.]+)})
+    url "https://github.com/ultravideo/kvazaar/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/ldc.rb
+++ b/Livecheckables/ldc.rb
@@ -1,6 +1,6 @@
 class Ldc
   livecheck do
-    url "https://github.com/ldc-developers/ldc/releases"
-    regex(%r{Latest.*?href="/ldc-developers/ldc/tree/v?([0-9.]+)}m)
+    url "https://github.com/ldc-developers/ldc/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/le.rb
+++ b/Livecheckables/le.rb
@@ -1,6 +1,6 @@
 class Le
   livecheck do
-    url "https://github.com/lavv17/le/releases"
-    regex(%r{href="/lavv17/le/tree/v?([0-9.]+)"})
+    url "https://github.com/lavv17/le/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/lean.rb
+++ b/Livecheckables/lean.rb
@@ -1,6 +1,6 @@
 class Lean
   livecheck do
-    url "https://github.com/leanprover/lean/releases"
-    regex(%r{Latest.*?href="/leanprover/lean/tree/v?([0-9.]+)}m)
+    url "https://github.com/leanprover/lean/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/lean.rb
+++ b/Livecheckables/lean.rb
@@ -1,6 +1,8 @@
 class Lean
+  # The Lean 3 repository (https://github.com/leanprover/lean/) is archived
+  # and there won't be any new releases. Lean 4 is being developed but is still
+  # a work in progress: https://github.com/leanprover/lean4
   livecheck do
-    url "https://github.com/leanprover/lean/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    skip "Lean 3 is archived; add a new check once Lean 4 is stable"
   end
 end

--- a/Livecheckables/leptonica.rb
+++ b/Livecheckables/leptonica.rb
@@ -1,6 +1,6 @@
 class Leptonica
   livecheck do
-    url "https://github.com/DanBloomberg/leptonica/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url "http://www.leptonica.org/download.html"
+    regex(/href=.*?leptonica[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/leptonica.rb
+++ b/Livecheckables/leptonica.rb
@@ -1,6 +1,6 @@
 class Leptonica
   livecheck do
-    url "https://github.com/DanBloomberg/leptonica/releases"
-    regex(%r{href="/DanBloomberg/leptonica/releases/tag/([\d.]+)"})
+    url "https://github.com/DanBloomberg/leptonica/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/libatomic_ops.rb
+++ b/Livecheckables/libatomic_ops.rb
@@ -1,6 +1,6 @@
 class LibatomicOps
   livecheck do
-    url "https://github.com/ivmai/libatomic_ops/releases"
-    regex(%r{latest.*?href="/ivmai/libatomic_ops/tree/v?([0-9.]+)}m)
+    url "https://github.com/ivmai/libatomic_ops/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/libgit2.rb
+++ b/Livecheckables/libgit2.rb
@@ -1,6 +1,6 @@
 class Libgit2
   livecheck do
     url "https://github.com/libgit2/libgit2/releases/latest"
-    regex(%r{href=.+?/tag/v?(\d+(?:\.\d+)+)})
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/librealsense.rb
+++ b/Livecheckables/librealsense.rb
@@ -1,6 +1,6 @@
 class Librealsense
   livecheck do
-    url "https://github.com/IntelRealSense/librealsense/releases"
-    regex(%r{href="/IntelRealSense/librealsense/tree/v?([0-9.]+)})
+    url "https://github.com/IntelRealSense/librealsense/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/libsass.rb
+++ b/Livecheckables/libsass.rb
@@ -1,6 +1,6 @@
 class Libsass
   livecheck do
-    url "https://github.com/sass/libsass/releases"
-    regex(%r{latest.*?href="/sass/libsass/tree/v?([0-9.]+)}m)
+    url "https://github.com/sass/libsass/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/libtorch.rb
+++ b/Livecheckables/libtorch.rb
@@ -1,6 +1,6 @@
 class Libtorch
   livecheck do
     url "https://github.com/pytorch/pytorch/releases/latest"
-    regex(%r{href=.+/tag/v?(\d+(?:\.\d+)+)})
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/libusb.rb
+++ b/Livecheckables/libusb.rb
@@ -1,6 +1,6 @@
 class Libusb
   livecheck do
-    url "https://github.com/libusb/libusb/releases"
-    regex(%r{latest.*?href="/libusb/libusb/tree/v?([0-9.]+)}m)
+    url "https://github.com/libusb/libusb/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/libyaml.rb
+++ b/Livecheckables/libyaml.rb
@@ -1,6 +1,6 @@
 class Libyaml
   livecheck do
-    url "https://github.com/yaml/libyaml/releases"
-    regex(%r{href="/yaml/libyaml/releases/tag/([0-9.]+)"})
+    url "https://github.com/yaml/libyaml/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/linkerd.rb
+++ b/Livecheckables/linkerd.rb
@@ -1,6 +1,6 @@
 class Linkerd
   livecheck do
     url :stable
-    regex(/^stable[._-]v?(\d+(?:\.\d+)+)$/)
+    regex(/^stable[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/linkerd.rb
+++ b/Livecheckables/linkerd.rb
@@ -1,6 +1,6 @@
 class Linkerd
   livecheck do
-    url "https://github.com/linkerd/linkerd2/releases"
-    regex(%r{href="/linkerd/linkerd2/tree/stable-([0-9.]+)"})
+    url :stable
+    regex(/^stable[._-]v?(\d+(?:\.\d+)+)$/)
   end
 end

--- a/Livecheckables/lz4.rb
+++ b/Livecheckables/lz4.rb
@@ -1,6 +1,6 @@
 class Lz4
   livecheck do
-    url "https://github.com/lz4/lz4/releases"
-    regex(%r{href="/lz4/lz4/releases/tag/v([0-9.]+)"})
+    url "https://github.com/lz4/lz4/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/mapnik.rb
+++ b/Livecheckables/mapnik.rb
@@ -1,6 +1,6 @@
 class Mapnik
   livecheck do
-    url "https://github.com/mapnik/mapnik/releases"
-    regex(%r{href="/mapnik/mapnik/tree/v?([0-9.]+)})
+    url "https://github.com/mapnik/mapnik/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/maxwell.rb
+++ b/Livecheckables/maxwell.rb
@@ -1,6 +1,6 @@
 class Maxwell
   livecheck do
-    url "https://github.com/zendesk/maxwell/releases"
-    regex(%r{Latest.*?href="/zendesk/maxwell/tree/v?([0-9.]+)}m)
+    url "https://github.com/zendesk/maxwell/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/metabase.rb
+++ b/Livecheckables/metabase.rb
@@ -1,6 +1,6 @@
 class Metabase
   livecheck do
-    url "https://github.com/metabase/metabase/releases"
-    regex(%r{Latest.*?href="/metabase/metabase/tree/v?([0-9.]+)}m)
+    url "https://github.com/metabase/metabase/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/mgba.rb
+++ b/Livecheckables/mgba.rb
@@ -1,6 +1,6 @@
 class Mgba
   livecheck do
-    url "https://github.com/mgba-emu/mgba/releases"
-    regex(%r{href="/mgba-emu/mgba/tree/([0-9.]+)})
+    url "https://github.com/mgba-emu/mgba/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/micronaut.rb
+++ b/Livecheckables/micronaut.rb
@@ -1,6 +1,6 @@
 class Micronaut
   livecheck do
     url "https://github.com/micronaut-projects/micronaut-core/releases/latest"
-    regex(%r{href=.+?/tag/v?(\d+(?:\.\d+)+)["']}i)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/minetest.rb
+++ b/Livecheckables/minetest.rb
@@ -1,6 +1,6 @@
 class Minetest
   livecheck do
-    url "https://github.com/minetest/minetest/releases"
-    regex(%r{Latest.*?href="/minetest/minetest/tree/v?([0-9.]+)}m)
+    url "https://github.com/minetest/minetest/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/mupen64plus.rb
+++ b/Livecheckables/mupen64plus.rb
@@ -1,6 +1,6 @@
 class Mupen64plus
   livecheck do
     url "https://github.com/mupen64plus/mupen64plus-core/releases/latest"
-    regex(%r{href=.+/tag/v?(\d+(?:\.\d+)+)})
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/nanomsg.rb
+++ b/Livecheckables/nanomsg.rb
@@ -1,6 +1,6 @@
 class Nanomsg
   livecheck do
-    url "https://github.com/nanomsg/nanomsg/releases"
-    regex(%r{latest.*?href="/nanomsg/nanomsg/tree/([0-9.]+)}m)
+    url "https://github.com/nanomsg/nanomsg/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/ninja.rb
+++ b/Livecheckables/ninja.rb
@@ -1,6 +1,6 @@
 class Ninja
   livecheck do
-    url "https://github.com/ninja-build/ninja/releases"
-    regex(%r{href="/ninja-build/ninja/tree/v([\d.]+\.[\d.]+\.[\d.]+)"})
+    url "https://github.com/ninja-build/ninja/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/ocamlbuild.rb
+++ b/Livecheckables/ocamlbuild.rb
@@ -1,6 +1,6 @@
 class Ocamlbuild
   livecheck do
-    url "https://github.com/ocaml/ocamlbuild/releases"
-    regex(%r{href="/ocaml/ocamlbuild/tree/v?([0-9.]+)})
+    url "https://github.com/ocaml/ocamlbuild/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/openimageio.rb
+++ b/Livecheckables/openimageio.rb
@@ -1,6 +1,6 @@
 class Openimageio
   livecheck do
-    url "https://github.com/OpenImageIO/oiio/releases.atom"
-    regex(%r{/Release-([0-9.]+)"})
+    url "https://github.com/OpenImageIO/oiio/releases/latest"
+    regex(%r{href=.*?/tag/Release[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/opensc.rb
+++ b/Livecheckables/opensc.rb
@@ -1,6 +1,6 @@
 class Opensc
   livecheck do
-    url "https://github.com/OpenSC/OpenSC/releases"
-    regex(%r{Latest.*?href="/OpenSC/OpenSC/tree/v?([0-9.]+)}m)
+    url "https://github.com/OpenSC/OpenSC/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/opentsdb.rb
+++ b/Livecheckables/opentsdb.rb
@@ -1,6 +1,6 @@
 class Opentsdb
   livecheck do
-    url "https://github.com/OpenTSDB/opentsdb/releases"
-    regex(%r{Latest release.*?href="/OpenTSDB/opentsdb/tree/v?([0-9.]+)"}m)
+    url "https://github.com/OpenTSDB/opentsdb/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/ott.rb
+++ b/Livecheckables/ott.rb
@@ -1,6 +1,6 @@
 class Ott
   livecheck do
-    url "https://github.com/ott-lang/ott/releases"
-    regex(%r{href="/ott-lang/ott/tree/([0-9.]+)})
+    url "https://github.com/ott-lang/ott/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/pandoc-citeproc.rb
+++ b/Livecheckables/pandoc-citeproc.rb
@@ -1,6 +1,5 @@
 class PandocCiteproc
   livecheck do
-    url "https://github.com/jgm/pandoc-citeproc/releases"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url :stable
   end
 end

--- a/Livecheckables/pandoc-citeproc.rb
+++ b/Livecheckables/pandoc-citeproc.rb
@@ -1,6 +1,6 @@
 class PandocCiteproc
   livecheck do
     url "https://github.com/jgm/pandoc-citeproc/releases"
-    regex(%r{href="/jgm/pandoc-citeproc/releases/tag/([0-9.]+)"})
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/par2.rb
+++ b/Livecheckables/par2.rb
@@ -1,6 +1,6 @@
 class Par2
   livecheck do
-    url "https://github.com/Parchive/par2cmdline/releases"
-    regex(%r{href="/Parchive/par2cmdline/tree/v?([0-9.]+)})
+    url "https://github.com/Parchive/par2cmdline/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/pgrouting.rb
+++ b/Livecheckables/pgrouting.rb
@@ -1,6 +1,6 @@
 class Pgrouting
   livecheck do
-    url "https://github.com/pgRouting/pgrouting/releases"
-    regex(%r{href="/pgRouting/pgrouting/tree/v?([0-9.]+)"})
+    url "https://github.com/pgRouting/pgrouting/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/picard-tools.rb
+++ b/Livecheckables/picard-tools.rb
@@ -1,6 +1,6 @@
 class PicardTools
   livecheck do
-    url "https://github.com/broadinstitute/picard/releases"
-    regex(%r{href="/broadinstitute/picard/tree/([0-9.]+)})
+    url "https://github.com/broadinstitute/picard/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/pkcs11-helper.rb
+++ b/Livecheckables/pkcs11-helper.rb
@@ -1,6 +1,6 @@
 class Pkcs11Helper
   livecheck do
-    url "https://github.com/OpenSC/pkcs11-helper/releases"
-    regex(%r{Latest.*?href="/OpenSC/pkcs11-helper/tree/pkcs11-helper-([0-9.]+)}m)
+    url "https://github.com/OpenSC/pkcs11-helper/releases/latest"
+    regex(%r{href=.*?/tag/pkcs11-helper[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/prodigal.rb
+++ b/Livecheckables/prodigal.rb
@@ -1,6 +1,6 @@
 class Prodigal
   livecheck do
-    url "https://github.com/hyattpd/Prodigal/releases"
-    regex(%r{href="/hyattpd/Prodigal/tree/v([0-9]\.[0-9]\.[0-9])"})
+    url "https://github.com/hyattpd/Prodigal/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/prometheus.rb
+++ b/Livecheckables/prometheus.rb
@@ -1,6 +1,6 @@
 class Prometheus
   livecheck do
-    url "https://api.github.com/repos/prometheus/prometheus/releases/latest"
-    regex(/([0-9.]+\.[0-9.]+)"/)
+    url "https://github.com/prometheus/prometheus/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/protobuf.rb
+++ b/Livecheckables/protobuf.rb
@@ -1,6 +1,6 @@
 class Protobuf
   livecheck do
-    url "https://github.com/protocolbuffers/protobuf/releases"
-    regex(%r{latest.*?href="/protocolbuffers/protobuf/tree/v?([0-9.]+)}m)
+    url "https://github.com/protocolbuffers/protobuf/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/pyenv-virtualenv.rb
+++ b/Livecheckables/pyenv-virtualenv.rb
@@ -1,6 +1,6 @@
 class PyenvVirtualenv
   livecheck do
-    url "https://api.github.com/repos/pyenv/pyenv-virtualenv/releases/latest"
-    regex(/([0-9.]+\.[0-9.]+)"/)
+    url "https://github.com/pyenv/pyenv-virtualenv/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/pyenv.rb
+++ b/Livecheckables/pyenv.rb
@@ -1,6 +1,6 @@
 class Pyenv
   livecheck do
-    url "https://github.com/pyenv/pyenv/releases"
-    regex(%r{Latest.*?href="/pyenv/pyenv/tree/v?([0-9.]+)}m)
+    url "https://github.com/pyenv/pyenv/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/rancher-cli.rb
+++ b/Livecheckables/rancher-cli.rb
@@ -1,6 +1,6 @@
 class RancherCli
   livecheck do
-    url "https://github.com/rancher/cli/releases"
-    regex(%r{latest.*?href="/rancher/cli/tree/v?([0-9.]+)}m)
+    url "https://github.com/rancher/cli/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/rhino.rb
+++ b/Livecheckables/rhino.rb
@@ -1,6 +1,6 @@
 class Rhino
   livecheck do
-    url "https://github.com/mozilla/rhino/releases"
-    regex(/Latest.*?Release">Rhino ([0-9.]+)</m)
+    url "https://github.com/mozilla/rhino/releases/latest"
+    regex(%r{href=.*?/tag/.*?>Rhino (\d+(?:\.\d+)+)<}i)
   end
 end

--- a/Livecheckables/ripgrep.rb
+++ b/Livecheckables/ripgrep.rb
@@ -1,6 +1,6 @@
 class Ripgrep
   livecheck do
-    url "https://github.com/BurntSushi/ripgrep/releases"
-    regex(%r{href="/BurntSushi/ripgrep/tree/([0-9.]+)})
+    url "https://github.com/BurntSushi/ripgrep/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/scalariform.rb
+++ b/Livecheckables/scalariform.rb
@@ -1,6 +1,6 @@
 class Scalariform
   livecheck do
-    url "https://github.com/scala-ide/scalariform/releases"
-    regex(%r{href="/scala-ide/scalariform/tree/v?([0-9.]+)})
+    url "https://github.com/scala-ide/scalariform/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/sentencepiece.rb
+++ b/Livecheckables/sentencepiece.rb
@@ -1,6 +1,6 @@
 class Sentencepiece
   livecheck do
     url "https://github.com/google/sentencepiece/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["']}i)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/shairport-sync.rb
+++ b/Livecheckables/shairport-sync.rb
@@ -1,6 +1,6 @@
 class ShairportSync
   livecheck do
     url "https://github.com/mikebrady/shairport-sync/releases/latest"
-    regex(%r{latest.*?href="/mikebrady/shairport-sync/tree/([0-9.]+)"}m)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/sleuthkit.rb
+++ b/Livecheckables/sleuthkit.rb
@@ -1,6 +1,6 @@
 class Sleuthkit
   livecheck do
-    url "https://github.com/sleuthkit/sleuthkit/releases"
-    regex(%r{Latest.*?href="/sleuthkit/sleuthkit/tree/sleuthkit-?([0-9.]+)}m)
+    url "https://github.com/sleuthkit/sleuthkit/releases/latest"
+    regex(%r{href=.*?/tag/sleuthkit[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/srtp.rb
+++ b/Livecheckables/srtp.rb
@@ -1,6 +1,6 @@
 class Srtp
   livecheck do
-    url "https://github.com/cisco/libsrtp/releases"
-    regex(%r{href="/cisco/libsrtp/tree/v([0-9,.]+)"})
+    url "https://github.com/cisco/libsrtp/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/supertux.rb
+++ b/Livecheckables/supertux.rb
@@ -1,6 +1,6 @@
 class Supertux
   livecheck do
     url "https://github.com/SuperTux/supertux/releases/latest"
-    regex(%r{href=.+/tag/v?(\d+(?:\.\d+)+)})
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/sysdig.rb
+++ b/Livecheckables/sysdig.rb
@@ -1,6 +1,6 @@
 class Sysdig
   livecheck do
-    url "https://api.github.com/repos/draios/sysdig/releases/latest"
-    regex(/([0-9.]+\.[0-9.]+)"/)
+    url "https://github.com/draios/sysdig/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/teleport.rb
+++ b/Livecheckables/teleport.rb
@@ -1,6 +1,6 @@
 class Teleport
   livecheck do
-    url "https://github.com/gravitational/teleport/releases"
-    regex(%r{Latest.*?href="/gravitational/teleport/tree/v?([0-9.]+)}m)
+    url "https://github.com/gravitational/teleport/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/tmux.rb
+++ b/Livecheckables/tmux.rb
@@ -1,6 +1,6 @@
 class Tmux
   livecheck do
     url "https://github.com/tmux/tmux/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+[a-z]+)["' >]}i)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+[a-z]?)["' >]}i)
   end
 end

--- a/Livecheckables/tmux.rb
+++ b/Livecheckables/tmux.rb
@@ -1,6 +1,6 @@
 class Tmux
   livecheck do
     url "https://github.com/tmux/tmux/releases/latest"
-    regex(%r{href=.+/tag/v?(\d+(?:\.\d+)+[a-z]?)}i)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+[a-z]+)["' >]}i)
   end
 end

--- a/Livecheckables/tundra.rb
+++ b/Livecheckables/tundra.rb
@@ -1,6 +1,6 @@
 class Tundra
   livecheck do
-    url "https://github.com/deplinenoise/tundra/releases"
-    regex(%r{Latest.*?href="/deplinenoise/tundra/tree/v?([0-9.]+)}m)
+    url "https://github.com/deplinenoise/tundra/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/uhd.rb
+++ b/Livecheckables/uhd.rb
@@ -1,6 +1,6 @@
 class Uhd
   livecheck do
-    url "https://github.com/EttusResearch/uhd/releases"
-    regex(%r{Latest.*?href="/EttusResearch/uhd/tree/v?([0-9.]+)}m)
+    url "https://github.com/EttusResearch/uhd/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/unison.rb
+++ b/Livecheckables/unison.rb
@@ -1,6 +1,6 @@
 class Unison
   livecheck do
-    url "https://github.com/bcpierce00/unison/releases"
-    regex(%r{Latest.*?href="/bcpierce00/unison/tree/v?([a-z0-9.]+)}m)
+    url "https://github.com/bcpierce00/unison/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+(?:v\d+)?)["' >]}i)
   end
 end

--- a/Livecheckables/vdirsyncer.rb
+++ b/Livecheckables/vdirsyncer.rb
@@ -1,6 +1,6 @@
 class Vdirsyncer
   livecheck do
-    url "https://github.com/pimutils/vdirsyncer/releases"
-    regex(%r{href=".*?/tag/([0-9.]+)"})
+    url "https://github.com/pimutils/vdirsyncer/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/wabt.rb
+++ b/Livecheckables/wabt.rb
@@ -1,6 +1,6 @@
 class Wabt
   livecheck do
     url "https://github.com/WebAssembly/wabt/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["']}i)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/wapm.rb
+++ b/Livecheckables/wapm.rb
@@ -1,6 +1,6 @@
 class Wapm
   livecheck do
     url "https://github.com/wasmerio/wapm-cli/releases/latest"
-    regex(%r{href=.+?/tag/v?(\d+(?:\.\d+)+)["']}i)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/wolfssl.rb
+++ b/Livecheckables/wolfssl.rb
@@ -1,6 +1,6 @@
 class Wolfssl
   livecheck do
-    url "https://github.com/wolfSSL/wolfssl/releases"
-    regex(%r{href="/wolfSSL/wolfssl/tree/v?([0-9.]+)-stable})
+    url "https://github.com/wolfSSL/wolfssl/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)[._-]stable["' >]}i)
   end
 end

--- a/Livecheckables/wp-cli.rb
+++ b/Livecheckables/wp-cli.rb
@@ -1,6 +1,6 @@
 class WpCli
   livecheck do
     url "https://github.com/wp-cli/wp-cli/releases/latest"
-    regex(/href=".*?v?(\d+(?:\.\d+)+)"/)
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/wxmac.rb
+++ b/Livecheckables/wxmac.rb
@@ -1,6 +1,6 @@
 class Wxmac
   livecheck do
-    url "https://github.com/wxWidgets/wxWidgets/releases"
-    regex(%r{Latest.*?href="/wxWidgets/wxWidgets/tree/v?([0-9.]+)}m)
+    url "https://github.com/wxWidgets/wxWidgets/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/xmrig.rb
+++ b/Livecheckables/xmrig.rb
@@ -1,6 +1,6 @@
 class Xmrig
   livecheck do
-    url "https://github.com/xmrig/xmrig/releases"
-    regex(%r{latest.*?href="/xmrig/xmrig/tree/v?([0-9.]+)}m)
+    url "https://github.com/xmrig/xmrig/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/xxhash.rb
+++ b/Livecheckables/xxhash.rb
@@ -1,6 +1,6 @@
 class Xxhash
   livecheck do
-    url "https://github.com/Cyan4973/xxHash/releases"
-    regex(%r{href="/Cyan4973/xxHash/tree/v?([0-9.]+)})
+    url "https://github.com/Cyan4973/xxHash/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/yaws.rb
+++ b/Livecheckables/yaws.rb
@@ -1,6 +1,6 @@
 class Yaws
   livecheck do
-    url "https://github.com/klacke/yaws/releases"
-    regex(/href=".*yaws-([0-9.]+)\.t/)
+    url "https://github.com/erlyaws/yaws/releases/latest"
+    regex(%r{href=.*?/tag/yaws[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/yuicompressor.rb
+++ b/Livecheckables/yuicompressor.rb
@@ -1,6 +1,6 @@
 class Yuicompressor
   livecheck do
-    url "https://github.com/yui/yuicompressor/releases/"
-    regex(%r{href="/yui/yuicompressor/tree/v([\d.]+)"})
+    url "https://github.com/yui/yuicompressor/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/z.rb
+++ b/Livecheckables/z.rb
@@ -1,6 +1,6 @@
 class Z
   livecheck do
     url "https://github.com/rupa/z/releases/latest"
-    regex(%r{href=.+/tag/v?(\d+(?:\.\d+)+)})
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/z3.rb
+++ b/Livecheckables/z3.rb
@@ -1,6 +1,6 @@
 class Z3
   livecheck do
-    url "https://github.com/Z3Prover/z3/releases"
-    regex(%r{Latest.*?href="/Z3Prover/z3/tree/z3-([0-9.]+)}m)
+    url "https://github.com/Z3Prover/z3/releases/latest"
+    regex(%r{href=.*?/tag/z3[._-]v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end


### PR DESCRIPTION
Updates to Livecheckables using the GitHub releases page.

* Replace GitHub use of "releases" pages (e.g., https://github.com/example/example/releases/)
    * If GitHub repo marks "latest" release on releases page, use `.../releases/latest` URL and some version of this regex to match the tag on the page: `%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}I`
    * If GitHub repo doesn't mark "latest" release on releases page, use the Git repo (i.e., to check the Git tags) and use some version of the standard regex (`/^v?(\d+(?:\.\d+)+)$/i`). Use `url :head` if the Git repo is `head` in the formula, otherwise use the Git repo URL.

I tried to follow this as much as I could, but there were some places I had to deviate slightly.

Of the 127 Livecheckables that _possibly_ needed changes,

1. Updated and _may need_ changes
```
     1	beast:

        many issues, used beast_release_1_8_1 until 1.8.1, then used 1.8.2, then used v1.8.3,
        latest marked seems to be unrelated (TempEst) and actual latest seems to be v1.10.4,
        pre-release is v1.10.5

     2	clojurescript:

        uses `r?` instead of `v?`

     3	dub:

        pre-release `rc` marked as Latest Release, using tags with `url :head`

     4	frege:

        only changed .+? to .*? and added [._-]?, probably not a good idea to modify anything else

     5	icu4c:

        might want to check regex as tag contains `release`

     6	jbig2dec:

        uses a separate repo for downloads, shouldn't check tag for version, changed `.+?` to `.*?`
        and delimiter - to [._-]

     7	json-c:

        might want to have a look at the regex

     8	linkerd:

        edge or unstable marked as latest so using :stable which points to the repo
        (no head, but same URL), matching stable tags only

     9	micronaut:

        the homebrew-core version is an RC version but our regex (even the older one)
        doesn't match RC versions, need to check this

    10	pandoc-citeproc:

        only regex updated, they have used versions like 1.x in 2013 but somewhere down
        the line this changed and the latest version is 0.17.0.1, but the Latest
        release hasn't been updated on GitHub

    11	rhino:

        regex needs to be checked, they've had highly varying tag naming schemes in the past

    12	tmux:

        needs a look at the regex part which matches [a-z], may need to be a
        non-capturing group (not a group now)

    13	unison:

        need to check regex, they use tags like 2.48.15, v2.51.2, 2.48.15v2 and also
        v2.48.15v4

    14	yuicompressor:

        they changed their tag naming and version scheme, regex matches this but it might
        need to be less strict
```

2. Updated and _may not need_ changes
<details>
<summary>111 Livecheckables</summary>
<pre>
     1	advancemame
     2	akka
     3	algernon
     4	atari800
     5	autopsy
     6	azure-cli
     7	bash-completion@2
     8	bcal
     9	bluepill
    10	caffe
    11	cdogs-sdl
    12	ckan
    13	clang-format
    14	clingo
    15	clozure-cl
    16	conan
    17	conserver
    18	dcm2niix
    19	dcos-cli
    20	duti
    21	dynamips
    22	elektra
    23	emscripten
    24	ethereum
    25	exa
    26	exercism
    27	fabric
    28	fail2ban
    29	frei0r
    30	genders
    31	getdns
    32	glm
    33	gnupg-pkcs11-scd
    34	gperftools
    35	grpc
    36	hackrf
    37	hashpump
    38	haskell-stack
    39	heimdal
    40	hfstospell
    41	htslib
    42	ice
    43	javacc
    44	jdnssec-tools
    45	jdupes
    46	jpeg-turbo
    47	jq
    48	jsoncpp
    49	jsonnet
    50	jsonschema2pojo
    51	kakoune
    52	keychain
    53	kotlin
    54	kvazaar
    55	ldc
    56	le
    57	lean
    58	leptonica
    59	libatomic_ops
    60	libgit2
    61	librealsense
    62	libsass
    63	libtorch
    64	libusb
    65	libyaml
    66	lz4
    67	mapnik
    68	maxwell
    69	metabase
    70	mgba
    71	minetest
    72	mupen64plus
    73	nanomsg
    74	ninja
    75	ocamlbuild
    76	openimageio
    77	opensc
    78	opentsdb
    79	ott
    80	par2
    81	pgrouting
    82	picard-tools
    83	pkcs11-helper
    84	prodigal
    85	prometheus
    86	protobuf
    87	pyenv-virtualenv
    88	pyenv
    89	rancher-cli
    90	ripgrep
    91	scalariform
    92	sentencepiece
    93	shairport-sync
    94	sleuthkit
    95	srtp
    96	supertux
    97	sysdig
    98	teleport
    99	tundra
   100	uhd
   101	vdirsyncer
   102	wabt
   103	wapm
   104	wolfssl
   105	wp-cli
   106	wxmac
   107	xmrig
   108	xxhash
   109	yaws
   110	z
   111	z3
</pre>
</details>

3. Already OK
```
    1 bcftools
    2 cataclysm (existing issues related to version comparison, updated by @samford)
```

Apologies for the wall of text, let me know if this PR has to be split up or if any changes are required @samford. Thanks!