### PR TITLE
Integrate strategy functions into strategies

### DIFF
--- a/livecheck/livecheck_strategy/page_match.rb
+++ b/livecheck/livecheck_strategy/page_match.rb
@@ -1,10 +1,19 @@
 # frozen_string_literal: true
 
+require "open-uri"
+
 module LivecheckStrategy
   class PageMatch
     NAME = name.demodulize
     NICE_NAME = "Page match"
     PRIORITY = 0
+
+    def self.page_matches(url, regex)
+      page = URI.open(url).read
+      matches = page.scan(regex)
+      matches.map(&:first).uniq
+    end
+    private_class_method :page_matches
 
     def self.find_versions(url, regex)
       match_data = { :matches => {}, :regex => regex, :url => url }

--- a/livecheck/utils.rb
+++ b/livecheck/utils.rb
@@ -1,5 +1,3 @@
-require "open-uri"
-
 def checkable_urls(formula)
   urls = []
   urls << formula.head.url if formula.head
@@ -14,20 +12,4 @@ end
 
 def formula_name(formula)
   Homebrew.args.full_name? ? formula.full_name : formula
-end
-
-def git_tags(repo_url, filter = nil)
-  raw_tags = `GIT_TERMINAL_PROMPT=0 git ls-remote --tags #{repo_url}`
-  raw_tags.gsub!(%r{^.*\trefs/tags/}, "")
-  raw_tags.delete_suffix!("^{}")
-
-  tags = raw_tags.split("\n").uniq.sort
-  tags.select! { |t| t =~ filter } if filter
-  tags
-end
-
-def page_matches(url, regex)
-  page = URI.open(url).read
-  matches = page.scan(regex)
-  matches.map(&:first).uniq
 end


### PR DESCRIPTION
This incorporates strategy-related functions from `utils.rb` into the strategies where they're used. Namely, `git_tags()` is incorporated into the `Git` strategy and `page_matches()` is added to the `PageMatch` strategy.

The reason why I'm renaming `git_tags()` to `tag_info()` here is because others have asked that we surface the commit hash in the future, if possible. I have a local implementation of this but I likely won't be able to add it until sometime after the Homebrew/brew migration.

This is part of a larger refactoring effort that I'm currently working on (and should be finished by the end of the week) but I'm trying to decompose it into topical PRs, when possible.