### PR TITLE
Make find_versions regex param explicitly optional

### DIFF
--- a/livecheck_strategy/apache.rb
+++ b/livecheck_strategy/apache.rb
@@ -8,7 +8,7 @@ module LivecheckStrategy
       %r{www\.apache\.org/dyn}.match?(url)
     end
 
-    def self.find_versions(url, regex)
+    def self.find_versions(url, regex = nil)
       path, prefix, suffix = url.match(%r{path=(.+?)/([^/]*?)\d+(?:\.\d+)+(/|[^/]*)})[1, 3]
 
       page_url = "https://archive.apache.org/dist/#{path}/"

--- a/livecheck_strategy/bitbucket.rb
+++ b/livecheck_strategy/bitbucket.rb
@@ -8,7 +8,7 @@ module LivecheckStrategy
       %r{bitbucket\.org(/[^/]+){4}\.\w+}.match?(url)
     end
 
-    def self.find_versions(url, regex)
+    def self.find_versions(url, regex = nil)
       path, kind, suffix =
         url.match(%r{bitbucket\.org/(.+?)/(get|downloads)/(?:.*?[-_])?v?\d+(?:\.\d+)+([^/]+)})[1, 3]
 

--- a/livecheck_strategy/git.rb
+++ b/livecheck_strategy/git.rb
@@ -20,7 +20,7 @@ module LivecheckStrategy
       DownloadStrategyDetector.detect(url) <= GitDownloadStrategy
     end
 
-    def self.find_versions(url, regex)
+    def self.find_versions(url, regex = nil)
       tags = tag_info(url, regex)
       tags_only_debian = tags.all? { |tag| tag.start_with?("debian/") }
 

--- a/livecheck_strategy/gnome.rb
+++ b/livecheck_strategy/gnome.rb
@@ -20,7 +20,7 @@ module LivecheckStrategy
       /download\.gnome\.org/.match?(url)
     end
 
-    def self.find_versions(url, regex)
+    def self.find_versions(url, regex = nil)
       package_name = url.match(%r{/sources/(.*?)/})[1]
 
       page_url = "https://download.gnome.org/sources/#{package_name}/cache.json"

--- a/livecheck_strategy/gnu.rb
+++ b/livecheck_strategy/gnu.rb
@@ -29,7 +29,7 @@ module LivecheckStrategy
       url.include?("gnu.org") && SPECIAL_CASES.none? { |sc| url.include? sc }
     end
 
-    def self.find_versions(url, regex)
+    def self.find_versions(url, regex = nil)
       match_list = PROJECT_NAME_REGEXES.map { |r| url.match(r) }.compact
       return { :matches => {}, :regex => regex, :url => url } if match_list.empty?
 

--- a/livecheck_strategy/hackage.rb
+++ b/livecheck_strategy/hackage.rb
@@ -8,7 +8,7 @@ module LivecheckStrategy
       /hackage\.haskell\.org/.match?(url)
     end
 
-    def self.find_versions(url, regex)
+    def self.find_versions(url, regex = nil)
       package_name = ((url.split("/")[4]).split("-")[0..-2]).join("-")
 
       page_url = "https://hackage.haskell.org/package/#{package_name}/src"

--- a/livecheck_strategy/launchpad.rb
+++ b/livecheck_strategy/launchpad.rb
@@ -8,7 +8,7 @@ module LivecheckStrategy
       /launchpad\.net/.match?(url)
     end
 
-    def self.find_versions(url, regex)
+    def self.find_versions(url, regex = nil)
       package_name = url.match(%r{launchpad\.net/([^/]*)})[1]
 
       page_url = "https://launchpad.net/#{package_name}"

--- a/livecheck_strategy/npm.rb
+++ b/livecheck_strategy/npm.rb
@@ -9,7 +9,7 @@ module LivecheckStrategy
       /registry\.npmjs\.org/.match?(url)
     end
 
-    def self.find_versions(url, regex)
+    def self.find_versions(url, regex = nil)
       package_name = url.split("/")[3..-3].reject { |s| s == "-" }.join("/")
 
       page_url = "https://www.npmjs.com/package/#{package_name}?activeTab=versions"

--- a/livecheck_strategy/pypi.rb
+++ b/livecheck_strategy/pypi.rb
@@ -9,7 +9,7 @@ module LivecheckStrategy
       /files\.pythonhosted\.org/.match?(url)
     end
 
-    def self.find_versions(url, regex)
+    def self.find_versions(url, regex = nil)
       package_name = url[%r{https://files.pythonhosted.org/packages/.*/.*/(.*)-.*}, 1]
 
       page_url = "https://pypi.org/project/#{package_name}"

--- a/livecheck_strategy/sourceforge.rb
+++ b/livecheck_strategy/sourceforge.rb
@@ -27,7 +27,7 @@ module LivecheckStrategy
         SPECIAL_CASES.none? { |sc| url.include? sc }
     end
 
-    def self.find_versions(url, regex)
+    def self.find_versions(url, regex = nil)
       project_name = if url.include?("/project")
         url.match(%r{/projects?/([^/]+)/})[1]
       elsif url.include?(".net/p/")


### PR DESCRIPTION
The `regex` parameter for each strategy's `#find_versions` method was technically optional except for the `PageMatch` strategy. This updates the function definitions to use `find_versions(url, regex = nil)` (instead of `find_versions(url, regex)`).

This doesn't create any functional changes for livecheck, since `latest_versions()` uses a `nil` value as the `regex` argument when one isn't provided. However, I think it's simply better to be explicit in the function definition about `regex` being optional.