### PR TITLE
wiggle: update url and regex

### DIFF
--- a/Livecheckables/wiggle.rb
+++ b/Livecheckables/wiggle.rb
@@ -1,5 +1,6 @@
 class Wiggle
   livecheck do
-    url "https://github.com/neilbrown/wiggle"
+    url "https://neil.brown.name/wiggle/"
+    regex(/href=.*?wiggle[._-](\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
I was going through the Livecheckables that needed updates with `href`, and I noticed that this one could use the index page instead. Sorry to make a single Livecheckable PR but I thought we could make the change anyway as it's 'cleanup'.