### PR TITLE
python: rename to python@3.8, update regex

### DIFF
--- a/Livecheckables/python.rb
+++ b/Livecheckables/python.rb
@@ -1,6 +1,0 @@
-class Python
-  livecheck do
-    url "https://www.python.org/downloads/"
-    regex(%r{href="https://www.python.org/ftp/python/([0-9.]+)})
-  end
-end

--- a/Livecheckables/python@3.8.rb
+++ b/Livecheckables/python@3.8.rb
@@ -1,6 +1,6 @@
 class PythonAT38
   livecheck do
-    url "https://www.python.org/downloads/"
-    regex(%r{href=.*?ftp/python/(\d+(?:\.\d+)+)/}i)
+    url "https://www.python.org/ftp/python/"
+    regex(%r{href=.*?v?(3\.8(?:\.\d+)*)/?["' >]}i)
   end
 end

--- a/Livecheckables/python@3.8.rb
+++ b/Livecheckables/python@3.8.rb
@@ -1,0 +1,6 @@
+class PythonAT38
+  livecheck do
+    url "https://www.python.org/downloads/"
+    regex(%r{href=.*?ftp/python/(\d+(?:\.\d+)+)/}i)
+  end
+end


### PR DESCRIPTION
Renaming `python.rb` to `python@3.8.rb` as the Formula in core is `python@3.8`. Prior to this change, livecheck would give `python@3.8 : versioned` as the output for `brew livecheck python`.