### PR TITLE
libtrng: update regex

### DIFF
--- a/Livecheckables/libtrng.rb
+++ b/Livecheckables/libtrng.rb
@@ -1,6 +1,6 @@
 class Libtrng
   livecheck do
     url :homepage
-    regex(/href=trng-([0-9.]+)\.t.*?latest/)
+    regex(/href=.*?trng[._-]v?(\d+(?:\.\d+)+)\.t.*?latest/i)
   end
 end


### PR DESCRIPTION
This brings the existing `libtrng` livecheckable up to current standards:

* Use `href=.*?` (instead of `href=`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regexes case insensitive unless case sensitivity is needed