### PR TITLE
ephemeralpg: update url and regex

### DIFF
--- a/Livecheckables/ephemeralpg.rb
+++ b/Livecheckables/ephemeralpg.rb
@@ -1,6 +1,6 @@
 class Ephemeralpg
   livecheck do
-    url :homepage
-    regex(/href=['"][^'"]*?ephemeralpg-(\d+(?:\.\d+)+)\.t/)
+    url "https://eradman.com/ephemeralpg/code/"
+    regex(/href=.*?ephemeralpg[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `ephemeralpg` livecheckable up to current standards:

* Align the check with the location of the stable archive, when possible
* Use `href=.*?` (instead of `href=['"][^'"]*?`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Make regex case insensitive unless case sensitivity is needed