### PR TITLE
src: update regex

### DIFF
--- a/Livecheckables/src.rb
+++ b/Livecheckables/src.rb
@@ -1,6 +1,6 @@
 class Src
   livecheck do
     url :homepage
-    regex(%r{href='.*?/src-([0-9.]+)\.t})
+    regex(/href=.*?src[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `src` livecheckable up to current standards:

* Use `href=.*?` (instead of `href='.*?`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regex case insensitive unless case sensitivity is needed