### PR TITLE
cassandra: update url and regex

### DIFF
--- a/Livecheckables/cassandra.rb
+++ b/Livecheckables/cassandra.rb
@@ -1,6 +1,6 @@
 class Cassandra
   livecheck do
-    url :homepage
-    regex(%r{href=".*?refs/tags/cassandra-([0-9.]+)"})
+    url "https://cassandra.apache.org/download/"
+    regex(/href=.*?apache-cassandra[._-]v?(\d+(?:\.\d+)+)(?:-bin)?\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `cassandra` livecheckable up to current standards:

* Use `href=.*?` (instead of `href=".*?`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regex case insensitive unless case sensitivity is needed