### PR TITLE
bind: update regex

### DIFF
--- a/Livecheckables/bind.rb
+++ b/Livecheckables/bind.rb
@@ -1,6 +1,8 @@
 class Bind
+  # BIND indicates stable releases with an even-numbered minor (e.g., x.2.x)
+  # and the regex below only matches these versions.
   livecheck do
     url "https://www.isc.org/downloads/"
-    regex(/Current-Stable.*?href=".*?bind-([A-Za-z0-9.\-]+)\.t/m)
+    regex(/href=.*?bind[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `bind` livecheckable up to current standards:

* Use `href=.*?` (instead of `href=".*?`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)` `([A-Za-z0-9.\-]+)` in this case)
* Make regex case insensitive unless case sensitivity is needed

Besides the changes above, BIND uses an even-numbered minor (e.g., x.2.x) to indicate stable releases, so this updates the regex to only match those versions. This approach mimics what we do in similar formula that use an even-numbered minor for stable releases and is generally more in line with what we do in most other checks these days.