### PR TITLE
abcl: update url and regex

### DIFF
--- a/Livecheckables/abcl.rb
+++ b/Livecheckables/abcl.rb
@@ -1,6 +1,6 @@
 class Abcl
   livecheck do
-    url "https://common-lisp.net/project/armedbear/releases/"
-    regex(%r{<a href="([0-9,.]+)/">})
+    url "https://abcl.org/releases/"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
This brings the existing `abcl` livecheckable up to current standards:

* Align the check with the location of the stable archive, when possible
* Use `href=.*?` (instead of `href="`, in this case)
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)` (`([0-9,.]+)` in this case)
* Make regexes case insensitive unless case sensitivity is needed

Generally speaking, this brings the regex in line with the other checks that identify version numbers from directories on a directory listing page like `1.2.3/`.