### PR TITLE
eprover: update regex

### DIFF
--- a/Livecheckables/eprover.rb
+++ b/Livecheckables/eprover.rb
@@ -1,6 +1,6 @@
 class Eprover
   livecheck do
     url "https://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/"
-    regex(%r{href="V_([0-9.]+)/">V})
+    regex(%r{href=.*?V?[._-]?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
This brings the existing `eprover` livecheckable up to current standards:

* Use `href=.*?` (instead of `href="`, in this case)
* Use some flavor of `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regexes case insensitive unless case sensitivity is needed

Though the folders on this directory listing page have a format like `V_1.2/`, this loosens the regex a bit, in case the directory name format is changed to `1.2` in the future. This also brings the regex more in line with other checks that match versions in folder names on a directory listing page.