### PR TITLE
nasm: update regex

### DIFF
--- a/Livecheckables/nasm.rb
+++ b/Livecheckables/nasm.rb
@@ -1,6 +1,6 @@
 class Nasm
   livecheck do
     url "https://www.nasm.us/pub/nasm/releasebuilds/"
-    regex(%r{href="([0-9.]+)/">})
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
This brings the existing `nasm` livecheckable up to current standards:

* Use `href=.*?` (instead of `href="`, in this case)
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regexes case insensitive unless case sensitivity is needed

Generally speaking, this brings the regex in line with the other checks that identify version numbers from directories on a directory listing page like `1.2.3/`.