### PR TITLE
wireguard-go: update regex

### DIFF
--- a/Livecheckables/wireguard-go.rb
+++ b/Livecheckables/wireguard-go.rb
@@ -1,6 +1,6 @@
 class WireguardGo
   livecheck do
     url :head
-    regex(/href=.*>wireguard-go-([0-9.]+)\.t/)
+    regex(/href=.*?wireguard-go[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `wireguard-go` livecheckable up to current standards:

* Use `href=.*?` (instead of `href=.*>`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regexes case insensitive unless case sensitivity is needed