### PR TITLE
easy-git: update regex

### DIFF
--- a/Livecheckables/easy-git.rb
+++ b/Livecheckables/easy-git.rb
@@ -1,6 +1,6 @@
 class EasyGit
   livecheck do
     url "https://people.gnome.org/~newren/eg/download/"
-    regex(%r{href="(\d+(?:\.\d+)+)/eg"})
+    regex(%r{href=.*?(\d+(?:\.\d+)+)/eg["' >]}i)
   end
 end


### PR DESCRIPTION
This brings the existing `easy-git` livecheckable up to current standards:

* Use `href=.*?` (instead of `href="`, in this case)
* Use `["' >]` instead of the trailing `"`
* Make regex case insensitive unless case sensitivity is needed