### PR TITLE
libnatpmp: update regex

### DIFF
--- a/Livecheckables/libnatpmp.rb
+++ b/Livecheckables/libnatpmp.rb
@@ -1,6 +1,6 @@
 class Libnatpmp
   livecheck do
     url "http://miniupnp.free.fr/files/"
-    regex(/href='download.php\?file=libnatpmp-([0-9]+)\.t/)
+    regex(/href=.*?libnatpmp[._-]v?(\d{6,8})\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `libnatpmp` livecheckable up to current standards:

* Use `href=.*?` (instead of `href='download.php\?file=`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d{6,8})` instead of `([0-9]+)`
* Make regex case insensitive unless case sensitivity is needed