### PR TITLE
libuecc: update regex

### DIFF
--- a/Livecheckables/libuecc.rb
+++ b/Livecheckables/libuecc.rb
@@ -1,6 +1,6 @@
 class Libuecc
   livecheck do
     url :head
-    regex(%r{href='/libuecc/tag/\?h=v([0-9]+)'>})
+    regex(/href=.*?libuecc[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `libuecc` livecheckable up to current standards:

* Use `href=.*?` (instead of `href='`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use a flavor of `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regex case insensitive unless case sensitivity is needed

In general, this modifies this check to get the version from the tarball instead of the tag on the page. The updated version-matching also identifies the `0.1` version, which wasn't matched by the previous regex. Most versions these days are like `2`, `3`, etc. but this will continue to work if there are versions like `1.2`, `1.2.3`, etc. in the future.