### PR TITLE
mafft: update regex

### DIFF
--- a/Livecheckables/mafft.rb
+++ b/Livecheckables/mafft.rb
@@ -3,6 +3,6 @@ class Mafft
   # text after the link for the archive.
   livecheck do
     url "https://mafft.cbrc.jp/alignment/software/source.html"
-    regex(%r{href=.+?mafft-v?(\d+(?:\.\d+)+)-with-extensions-src\.t.+?</a>\s*?<(?:br[^>]*?|/li|/ul)>}i)
+    regex(%r{href=.*?mafft[._-]v?(\d+(?:\.\d+)+)-with-extensions-src\.t.+?</a>\s*?<(?:br[^>]*?|/li|/ul)>}i)
   end
 end


### PR DESCRIPTION
This brings the existing `mafft` livecheckable up to current standards:

* Use `href=.*?` (instead of `href=.+?`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`