### PR TITLE
ocaml: update regex

### DIFF
--- a/Livecheckables/ocaml.rb
+++ b/Livecheckables/ocaml.rb
@@ -1,6 +1,6 @@
 class Ocaml
   livecheck do
     url "https://ocaml.org/releases"
-    regex(/<a href='([\d.]+\.[\d.]+\.?[\d.]?)\.html'>/)
+    regex(/href=.*?v?(\d+(?:\.\d+)+)\.html/i)
   end
 end


### PR DESCRIPTION
This brings the existing `ocaml` livecheckable up to current standards:

* Use `href=.*?` (instead of `href='`, in this case)
* Use `v?(\d+(?:\.\d+)+)` instead of `([\d.]+\.[\d.]+\.?[\d.]?)`
* Make regex case insensitive unless case sensitivity is needed

This also removes the leading `<a ` and trailing `'>`, as they're unnecessary in this context.