### PR TITLE
artifactory: update regex

### DIFF
--- a/Livecheckables/artifactory.rb
+++ b/Livecheckables/artifactory.rb
@@ -1,6 +1,6 @@
 class Artifactory
   livecheck do
     url "https://dl.bintray.com/jfrog/artifactory/"
-    regex(/href="jfrog-artifactory-oss-([0-9.]+)\.[^0-9]/)
+    regex(/href=.*?jfrog-artifactory-oss[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 end


### PR DESCRIPTION
This brings the existing `artifactory` livecheckable up to current standards:

* Use `href=.*?` (instead of `href="`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regex case insensitive unless case sensitivity is needed