### PR TITLE
gpa: update regex

### DIFF
--- a/Livecheckables/gpa.rb
+++ b/Livecheckables/gpa.rb
@@ -1,6 +1,6 @@
 class Gpa
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gpa/"
-    regex(/href="gpa-(\d+\.\d+(\.\d+)?)/)
+    regex(/href=.*?gpa[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `gpa` livecheckable up to current standards:

* Use `href=.*?` (instead of `href="`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `(\d+\.\d+(\.\d+)?)`
* Make regex case insensitive unless case sensitivity is needed