### PR TITLE
lcdf-typetools: update regex

### DIFF
--- a/Livecheckables/lcdf-typetools.rb
+++ b/Livecheckables/lcdf-typetools.rb
@@ -1,6 +1,6 @@
 class LcdfTypetools
   livecheck do
     url :homepage
-    regex(/href='lcdf-typetools-([0-9.]+)\.t/)
+    regex(/href=.*?lcdf-typetools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `lcdf-typetools` livecheckable up to current standards:

* Use `href=.*?` (instead of `href='`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regex case insensitive unless case sensitivity is needed