### PR TITLE
mupdf-tools: update regex

### DIFF
--- a/Livecheckables/mupdf-tools.rb
+++ b/Livecheckables/mupdf-tools.rb
@@ -1,6 +1,6 @@
 class MupdfTools
   livecheck do
     url "https://mupdf.com/downloads/archive/?C=M&O=D"
-    regex(/href="mupdf-(\d+(?:\.\d+)+)-source/)
+    regex(/href=.*?mupdf[._-]v?(\d+(?:\.\d+)+)-source\.(?:t|zip)/i)
   end
 end


### PR DESCRIPTION
This brings the existing `mupdf-tools` livecheckable up to current standards:

* Use `href=.*?` (instead of `href="`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Make regex case insensitive unless case sensitivity is needed

This uses `\.(?:t|zip)` for the file extension, as there's one zip archive among the tarballs.