### PR TITLE
npth: update regex

### DIFF
--- a/Livecheckables/npth.rb
+++ b/Livecheckables/npth.rb
@@ -1,6 +1,6 @@
 class Npth
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/npth/"
-    regex(/href="npth-(\d+\.\d+(\.\d+)?)/)
+    regex(/href=.*?npth[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `npth` livecheckable up to current standards:

* Use `href=.*?` (instead of `href="`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `(\d+\.\d+(\.\d+)?)`
* Make regex case insensitive unless case sensitivity is needed