### PR TITLE
spandsp: update regex

### DIFF
--- a/Livecheckables/spandsp.rb
+++ b/Livecheckables/spandsp.rb
@@ -1,6 +1,6 @@
 class Spandsp
   livecheck do
     url "https://www.soft-switch.org/downloads/spandsp/?C=M&O=D"
-    regex(/href="spandsp-([\d.]+)\.tar\.gz"/)
+    regex(/href=.*?spandsp[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `spandsp` livecheckable up to current standards:

* Use `href=.*?` (instead of `href="`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([\d.]+)`
* Make regex case insensitive unless case sensitivity is needed

This also loosens the trailing `\.tar\.gz"` to the standard `\.t`, which allows it to match another version on the index page that we were missing (due to it using a `.tgz` extension).