### PR TITLE
zsh-lovers: update regex

### DIFF
--- a/Livecheckables/zsh-lovers.rb
+++ b/Livecheckables/zsh-lovers.rb
@@ -1,6 +1,6 @@
 class ZshLovers
   livecheck do
     url "https://deb.grml.org/pool/main/z/zsh-lovers/"
-    regex(/href="zsh-lovers_([0-9.]+)_all/)
+    regex(/href=.*?zsh-lovers[._-]v?(\d+(?:\.\d+)+)[._-]all/i)
   end
 end


### PR DESCRIPTION
This brings the existing `zsh-lovers` livecheckable up to current standards:

* Use `href=.*?` (instead of `href="`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regex case insensitive unless case sensitivity is needed