### PR TITLE
django-completion: update url and regex

### DIFF
--- a/Livecheckables/django-completion.rb
+++ b/Livecheckables/django-completion.rb
@@ -1,6 +1,6 @@
 class DjangoCompletion
   livecheck do
-    url "https://www.djangoproject.com/download/"
-    regex(%r{Latest.*?href=".*?/([0-9.]+)/}m)
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end


### PR DESCRIPTION
This brings the existing `django-completion` livecheckable up to current standards:

* Align the check with the location of the stable archive, when possible
* Use the standard regex for Git tags like `1.2.3` or `v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`)
* Make regex case insensitive unless case sensitivity is needed