### PR TITLE
fluent-bit: update url and regex

### DIFF
--- a/Livecheckables/fluent-bit.rb
+++ b/Livecheckables/fluent-bit.rb
@@ -1,6 +1,6 @@
 class FluentBit
   livecheck do
-    url "https://fluentbit.io/announcements/"
-    regex(%r{href=".*?/announcements/v?([0-9]+\.[0-9.]+)/"})
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end


### PR DESCRIPTION
This brings the existing `fluent-bit` livecheckable up to current standards:

* Align the check with the location of the stable archive, when possible
* Use the standard regex for Git tags like `1.2.3` or `v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`)
* Make regex case insensitive unless case sensitivity is needed