### PR TITLE
jhiccup: update regex

### DIFF
--- a/Livecheckables/jhiccup.rb
+++ b/Livecheckables/jhiccup.rb
@@ -1,6 +1,6 @@
 class Jhiccup
   livecheck do
     url :homepage
-    regex(%r{href=".*?/jHiccup-([0-9.]+)-dist})
+    regex(/href=.*?jHiccup[._-]v?(\d+(?:\.\d+)+)-dist\.zip/i)
   end
 end


### PR DESCRIPTION
This brings the existing `jhiccup` livecheckable up to current standards:

* Use `href=.*?` (instead of `href=".*?/`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regex case insensitive unless case sensitivity is needed