### PR TITLE
libcello: update regex

### DIFF
--- a/Livecheckables/libcello.rb
+++ b/Livecheckables/libcello.rb
@@ -1,6 +1,6 @@
 class Libcello
   livecheck do
     url :homepage
-    regex(%r{href=".*?/libCello-([0-9.]+)\.t.*?>Download})
+    regex(/href=.*?libCello[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `libcello` livecheckable up to current standards:

* Use `href=.*?` (instead of `href=".*?/`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regex case insensitive unless case sensitivity is needed

This also removes the trailing `.*?>Download}`, as it's unnecessary.