### PR TITLE
libflowmanager: update regex

### DIFF
--- a/Livecheckables/libflowmanager.rb
+++ b/Livecheckables/libflowmanager.rb
@@ -1,6 +1,6 @@
 class Libflowmanager
   livecheck do
     url :homepage
-    regex(%r{latest version is.*?href=".*?/libflowmanager-([0-9.]+)\.t}m)
+    regex(/href=.*?libflowmanager[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `libflowmanager ` livecheckable up to current standards:

* Use `href=.*?` (instead of `href=".*?/`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regex case insensitive unless case sensitivity is needed