### PR TITLE
libprotoident: update regex

### DIFF
--- a/Livecheckables/libprotoident.rb
+++ b/Livecheckables/libprotoident.rb
@@ -1,6 +1,6 @@
 class Libprotoident
   livecheck do
     url :homepage
-    regex(%r{latest version is.*?href=".*?/libprotoident-([0-9.]+)\.t}m)
+    regex(/href=.*?libprotoident[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `libprotoident ` livecheckable up to current standards:

* Use `href=.*?` (instead of `href=".*?/`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regex case insensitive unless case sensitivity is needed