### PR TITLE
libtrace: update regex

### DIFF
--- a/Livecheckables/libtrace.rb
+++ b/Livecheckables/libtrace.rb
@@ -1,6 +1,6 @@
 class Libtrace
   livecheck do
     url :homepage
-    regex(%r{stable version is.*?href=".*?/libtrace-([0-9.]+)\.t})
+    regex(/href=.*?libtrace[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `libtrace ` livecheckable up to current standards:

* Use `href=.*?` (instead of `href=".*?/`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regex case insensitive unless case sensitivity is needed