### PR TITLE
mpich: update url and regex

### DIFF
--- a/Livecheckables/mpich.rb
+++ b/Livecheckables/mpich.rb
@@ -1,6 +1,6 @@
 class Mpich
   livecheck do
-    url "https://www.mpich.org/downloads/"
-    regex(%r{stable.*?href=".*?/mpich-([0-9a-z.]+)\.t})
+    url "https://www.mpich.org/static/downloads/"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
This brings the existing `mpich ` livecheckable up to current standards:

* Align the check with the location of the stable archive, when possible
* Use `href=.*?` (instead of `href=".*?/`, in this case)
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)` (`([0-9a-z.]+)` in this case)
* Make regex case insensitive unless case sensitivity is needed

Generally speaking, this brings the regex in line with the other checks that identify version numbers from directories on a directory listing page like `1.2.3/`.