### PR TITLE
ragel: update url and regex

### DIFF
--- a/Livecheckables/ragel.rb
+++ b/Livecheckables/ragel.rb
@@ -1,6 +1,8 @@
 class Ragel
+  # TODO: Return to using `url :homepage` once the SSL certificate verification
+  # issue is resolved on the upstream server.
   livecheck do
-    url :homepage
-    regex(%r{Stable.*?href=".*?/ragel-([0-9.]+)\.t}m)
+    url "http://www.colm.net/open-source/ragel/"
+    regex(/Stable.*?href=.*?ragel[._-]v?(\d+(?:\.\d+)+)\.t/im)
   end
 end


### PR DESCRIPTION
This brings the existing `ragel ` livecheckable up to current standards:

* Use `href=.*?` (instead of `href=".*?/`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`
* Make regex case insensitive unless case sensitivity is needed

Unfortunately it's currently necessary to use the HTTP version of the homepage instead of the HTTPS URL in the formula, since there's an upstream SSL verification issue. I left a comment noting that we should return to using `url :homepage` once this is resolved upstream.