### PR TITLE
sonarqube-lts: update regex

### DIFF
--- a/Livecheckables/sonarqube-lts.rb
+++ b/Livecheckables/sonarqube-lts.rb
@@ -4,6 +4,6 @@ class SonarqubeLts
   # doesn't distinguish between current and LTS releases.
   livecheck do
     url "https://www.sonarqube.org/downloads/"
-    regex(/downloads-lts.+?href=.+?sonarqube-v?(\d+(?:\.\d+)+)\.(?:z|t)/m)
+    regex(/downloads-lts.+?href=.*?sonarqube[._-]v?(\d+(?:\.\d+)+)\.(?:zip|t)/im)
   end
 end


### PR DESCRIPTION
This brings the existing `sonarqube-lts` livecheckable up to current standards:

* Use `href=.*?` (instead of `href=.+?`, in this case)
* Replace the delimiter between software name and version in file name with `[._-]`
* Make regex case insensitive unless case sensitivity is needed