### PR TITLE
Improve regexes containing `href=.*`

### DIFF
--- a/Livecheckables/aqbanking.rb
+++ b/Livecheckables/aqbanking.rb
@@ -1,6 +1,6 @@
 class Aqbanking
   livecheck do
     url "https://www.aquamaniac.de/rdm/projects/aqbanking/files"
-    regex(/href=.*aqbanking-([0-9.]+)\.t/)
+    regex(/href=.*?aqbanking[._-](\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libmikmod.rb
+++ b/Livecheckables/libmikmod.rb
@@ -1,6 +1,6 @@
 class Libmikmod
   livecheck do
     url "http://mikmod.sourceforge.net/"
-    regex(/href=.*libmikmod-([0-9,.]+)\.t/)
+    regex(/href=.*?libmikmod[._-](\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/mikmod.rb
+++ b/Livecheckables/mikmod.rb
@@ -1,6 +1,6 @@
 class Mikmod
   livecheck do
     url "http://mikmod.sourceforge.net/"
-    regex(/href=.*[^b]mikmod-([0-9,.]+)\.t/)
+    regex(/href=.*?[^b]mikmod[._-](\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR improves regexes containing `href=.*` in the following ways:
* `href=.*` –> `href=.*?`
* `[0-9.]+` or `[0-9.,]+` –> `(\d+(?:\.\d+)+)`
* Delimiter between software name and version string, `-` –> `[._-]`
* The regexes are now case-insensitive

The Livecheckables affected are `aqbanking`, `libmikmod` and `mikmod`.