### PR TITLE
Improve regexes containing `href=.+` and `href=.+?`

### DIFF
--- a/Livecheckables/ant.rb
+++ b/Livecheckables/ant.rb
@@ -1,6 +1,6 @@
 class Ant
   livecheck do
     url "https://downloads.apache.org/ant/binaries/"
-    regex(/href=.+?apache-ant-v?(\d+(?:\.\d+)+)(?:-bin)?\.t/)
+    regex(/href=.*?apache-ant[._-]v?(\d+(?:\.\d+)+)(?:-bin)?\.t/i)
   end
 end

--- a/Livecheckables/ant@1.9.rb
+++ b/Livecheckables/ant@1.9.rb
@@ -1,6 +1,6 @@
 class AntAT19
   livecheck do
     url "https://downloads.apache.org/ant/binaries/"
-    regex(/href=.+?apache-ant-v?(1\.9(?:\.\d+)*)(?:-bin)?\.t/)
+    regex(/href=.*?apache-ant[._-]v?(1\.9(?:\.\d+)*)(?:-bin)?\.t/i)
   end
 end

--- a/Livecheckables/aspell.rb
+++ b/Livecheckables/aspell.rb
@@ -1,6 +1,6 @@
 class Aspell
   livecheck do
     url "https://ftp.gnu.org/gnu/aspell/?C=M&O=D"
-    regex(/href=.+aspell-v?(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?aspell[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/cppunit.rb
+++ b/Livecheckables/cppunit.rb
@@ -1,6 +1,6 @@
 class Cppunit
   livecheck do
     url :homepage
-    regex(/href=.+cppunit-v?(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?cppunit[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/cvsync.rb
+++ b/Livecheckables/cvsync.rb
@@ -1,6 +1,6 @@
 class Cvsync
   livecheck do
     url :homepage
-    regex(/href=.+cvsync-v?(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?cvsync[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dterm.rb
+++ b/Livecheckables/dterm.rb
@@ -1,6 +1,6 @@
 class Dterm
   livecheck do
     url :homepage
-    regex(/href=.+dterm-v?(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?dterm[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/geos.rb
+++ b/Livecheckables/geos.rb
@@ -1,6 +1,6 @@
 class Geos
   livecheck do
     url "https://download.osgeo.org/geos/"
-    regex(/href=.+geos-v?(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?geos[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gl2ps.rb
+++ b/Livecheckables/gl2ps.rb
@@ -1,6 +1,6 @@
 class Gl2ps
   livecheck do
     url "http://geuz.org/gl2ps/src/"
-    regex(/href=.+gl2ps-v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?gl2ps[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gnu-prolog.rb
+++ b/Livecheckables/gnu-prolog.rb
@@ -1,6 +1,6 @@
 class GnuProlog
   livecheck do
     url :homepage
-    regex(/href=.+gprolog-v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?gprolog[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/icoutils.rb
+++ b/Livecheckables/icoutils.rb
@@ -1,6 +1,6 @@
 class Icoutils
   livecheck do
     url "https://download.savannah.gnu.org/releases/icoutils/"
-    regex(/href=.+icoutils-(\d+\.\d+\.\d+)\.t/)
+    regex(/href=.*?icoutils[._-](\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/miniupnpc.rb
+++ b/Livecheckables/miniupnpc.rb
@@ -3,6 +3,6 @@ class Miniupnpc
   # stable and versions like 2.1.20191224 are unstable/development releases.
   livecheck do
     url "https://miniupnp.tuxfamily.org/files/"
-    regex(/href=.+?miniupnpc-v?(\d+\.\d+)\.t/)
+    regex(/href=.*?miniupnpc[._-]v?(\d+\.\d+)\.t/i)
   end
 end

--- a/Livecheckables/nload.rb
+++ b/Livecheckables/nload.rb
@@ -1,6 +1,6 @@
 class Nload
   livecheck do
     url :homepage
-    regex(/href=.+?nload-v?(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?nload[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/nuttcp.rb
+++ b/Livecheckables/nuttcp.rb
@@ -1,6 +1,6 @@
 class Nuttcp
   livecheck do
     url :homepage
-    regex(/href=.+nuttcp-v?(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?nuttcp[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/onioncat.rb
+++ b/Livecheckables/onioncat.rb
@@ -1,6 +1,6 @@
 class Onioncat
   livecheck do
     url "https://www.cypherpunk.at/ocat/download/Source/stable/"
-    regex(/href=.+?onioncat-v?(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?onioncat[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/scamper.rb
+++ b/Livecheckables/scamper.rb
@@ -1,6 +1,6 @@
 class Scamper
   livecheck do
     url "https://www.caida.org/tools/measurement/scamper/code/?C=M&O=D"
-    regex(/href=.+?scamper(?:-cvs)?-v?(\d+[a-z]?)\.t/)
+    regex(/href=.*?scamper(?:-cvs)?[._-]v?(\d{6,8}[a-z]?)\.t/i)
   end
 end

--- a/Livecheckables/szip.rb
+++ b/Livecheckables/szip.rb
@@ -1,6 +1,6 @@
 class Szip
   livecheck do
     url "https://support.hdfgroup.org/ftp/lib-external/szip/"
-    regex(%r{href=.+?v?(\d+(?:\.\d+)+)/?["']})
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/theora.rb
+++ b/Livecheckables/theora.rb
@@ -1,6 +1,6 @@
 class Theora
   livecheck do
     url "https://www.theora.org/downloads/"
-    regex(/href=.+?libtheora-v?(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?libtheora[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/transmission-cli.rb
+++ b/Livecheckables/transmission-cli.rb
@@ -1,6 +1,6 @@
 class TransmissionCli
   livecheck do
     url "https://github.com/transmission/transmission-releases/"
-    regex(/href=.+?transmission-v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?transmission[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/x264.rb
+++ b/Livecheckables/x264.rb
@@ -4,6 +4,6 @@ class X264
   # the version information at the time of writing.
   livecheck do
     url "https://artifacts.videolan.org/x264/release-macos/"
-    regex(/href=.+?x264-(r\d+)-/i)
+    regex(%r{href=.*?x264[._-](r\d+)[._-][a-z0-9]+/?["' >]}i)
   end
 end

--- a/Livecheckables/zabbix.rb
+++ b/Livecheckables/zabbix.rb
@@ -6,6 +6,6 @@ class Zabbix
   # a proper check sometime in the future and need to be updated.
   livecheck do
     url "https://cdn.zabbix.com/zabbix/sources/stable/5.0/"
-    regex(/href=.+?zabbix-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?zabbix[._-](\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR improves regexes containing `href=.*` in the following ways:
* `href=.+` or `href=.+?` –> `href=.*?`
* Delimiter between software name and version string, `-` –> `[._-]`
* The regexes are now case-insensitive
* Additional fixes in
    * `icoutils`
    * `scamper`
    * `szip`
    * `x264`