### PR TITLE
Fix "Sort files before requiring them" warning

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -120,7 +120,7 @@ module Homebrew
     # Load additional LivecheckStrategy files from taps
     non_core_taps.each do |tap_name|
       tap_strategy_path = File.join(Tap.fetch(tap_name).path, "livecheck_strategy")
-      Dir.glob(File.join(tap_strategy_path, "*.rb"), &method(:require)) if Dir.exist?(tap_strategy_path)
+      Dir[File.join(tap_strategy_path, "*.rb")].sort.each(&method(:require)) if Dir.exist?(tap_strategy_path)
     end
 
     formulae_checked = formulae_to_check.sort.map.with_index do |formula, i|

--- a/livecheck_strategy.rb
+++ b/livecheck_strategy.rb
@@ -33,4 +33,4 @@ module LivecheckStrategy
   end
 end
 
-Dir.glob(File.join(__dir__, "livecheck_strategy", "*.rb"), &method(:require))
+Dir[File.join(__dir__, "livecheck_strategy", "*.rb")].sort.each(&method(:require))


### PR DESCRIPTION
We now have a "Sort files before requiring them" style warning, so this modifies the strategy-requiring code  in `cmd/livecheck.rb` and `livecheck_strategy.rb` to involve a sort.