### PR TITLE
midnight-commander: update url and regex

### DIFF
--- a/Livecheckables/midnight-commander.rb
+++ b/Livecheckables/midnight-commander.rb
@@ -1,6 +1,6 @@
 class MidnightCommander
   livecheck do
-    url "https://midnight-commander.org/"
-    regex(/Current version is: ([0-9.]+)/)
+    url "http://ftp.midnight-commander.org"
+    regex(/href=.*?mc[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
The existing check is giving an SSL error:

```
SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (certificate has expired)
```

The Midnight commander homepage says "A list of the latest releases is available [here](http://www.midnight-commander.org/downloads)", pointing to http://www.midnight-commander.org/downloads. The downloads URL redirects to http://ftp.midnight-commander.org, which is a directory listing page.

This modifies the livecheckable to use the aforementioned page and updates the regex accordingly.