### PR TITLE
fortune: update url and regex

### DIFF
--- a/Livecheckables/fortune.rb
+++ b/Livecheckables/fortune.rb
@@ -1,6 +1,8 @@
 class Fortune
+  # The URL below should be modified to use HTTPS again after the upstream
+  # server fixes their SSL certificate issue.
   livecheck do
-    url "https://www.ibiblio.org/pub/linux/games/amusements/fortune/"
-    regex(/href=.*?fortune-mod-v?(\d+(?:\.\d+)*)\.t/)
+    url "http://www.ibiblio.org/pub/linux/games/amusements/fortune/"
+    regex(/href=.*?fortune-mod[._-]v?(\d+(?:\.\d+)*)\.t/)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `fortune` is giving an SSL error:

```
Error: fortune: SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (certificate has expired)
```

This temporarily modifies the URL to use HTTP instead of HTTPS (leaving a comment to return to HTTPS when possible).

Besides that, I also made a small change to the regex to bring it up to current standards.