### PR TITLE
fossil: update regex

### DIFF
--- a/Livecheckables/fossil.rb
+++ b/Livecheckables/fossil.rb
@@ -1,6 +1,6 @@
 class Fossil
   livecheck do
     url "https://www.fossil-scm.org/home/uv/download.js"
-    regex(/"title": *?"Version (\d+(?:\.\d+)+)"/)
+    regex(/"title": *?"Version (\d+(?:\.\d+)+) circa/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `fossil` broke since the format of the release `title` strings in `download.js` changed a little (so the regex failed to match).

The format now seems to be:

* Preview/unstable: "Version 2.12 preview 2020-07-12"
* Stable: "Version 2.11.1 circa 2020-05-25 + patches"

This check is more fragile than I would like but I don't think we have any other choice but to keep updating the regex when upstream makes breaking changes like this.