### PR TITLE
biosig: add url and update regex

### DIFF
--- a/Livecheckables/biosig.rb
+++ b/Livecheckables/biosig.rb
@@ -1,5 +1,6 @@
 class Biosig
   livecheck do
-    regex(%r{url=.+?/biosig4c[^-]*?-v?(\d+(?:\.\d+)+)\.src\.t}i)
+    url :stable
+    regex(%r{url=.*?/(?:biosig|biosig4c[^-]*?)[._-]v?(\d+(?:\.\d+)+)\.src\.t}i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `biosig` wasn't finding the latest versions in the SourceForge RSS feed, since the filename format changed. This updates the regex to match both the older and newer file name format.

This also adds an explicit `url`, as it's one of the few remaining livecheckables without one.