### PR TITLE
darkice: add url and update regex

### DIFF
--- a/Livecheckables/darkice.rb
+++ b/Livecheckables/darkice.rb
@@ -1,5 +1,6 @@
 class Darkice
   livecheck do
-    regex(%r{url=.+?/darkice-v?(\d+(?:\.\d+)+)\.t})
+    url "https://github.com/rafael2k/darkice/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `darkice` wasn't able to identify any versions. This updates it to check the "latest" release on GitHub (as the formula uses archives from the GitHub repository).

This also adds an explicit `url` in the process, as it was one of the few remaining livecheckables without one.