### PR TITLE
x3270: add url and update regex

### DIFF
--- a/Livecheckables/x3270.rb
+++ b/Livecheckables/x3270.rb
@@ -1,5 +1,6 @@
 class X3270
   livecheck do
-    regex(%r{url=.+?/suite3270-v?(\d+(?:\.\d+)+(?:ga\d+)?)(?:-src)?\.t})
+    url "http://x3270.bgp.nu/download.html"
+    regex(/href=.*?suite3270[._-]v?(\d+(?:\.\d+)+(?:ga\d+)?)(?:-src)?\.t/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `x3270` was not able to find versions. This updates it to check [the first-party downloads page](http://x3270.bgp.nu/download.html) and updates the regex to bring it up to current standards.

This also adds an explicit `url` in the process, as this was one of the few remaining livecheckables without one.