### PR TITLE
burp: update url and regex

### DIFF
--- a/Livecheckables/burp.rb
+++ b/Livecheckables/burp.rb
@@ -1,6 +1,6 @@
 class Burp
   livecheck do
-    url "https://burp.grke.org/download.html"
-    regex(/<li>([0-9.]+): Stable/)
+    url :stable
+    regex(%r{url=.*?/burp[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `burp` wasn't able to find versions. This updates it to use the `stable` URL (a SourceForge archive) and updates the regex accordingly (while also following current standards).