### PR TITLE
stk: update regex

### DIFF
--- a/Livecheckables/stk.rb
+++ b/Livecheckables/stk.rb
@@ -1,6 +1,6 @@
 class Stk
   livecheck do
     url "https://ccrma.stanford.edu/software/stk/download.html"
-    regex(%r{href=".*?/stk-([0-9.]+)\.t})
+    regex(%r{href=.*?stk[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `stk` is currently failing due to an upstream SSL certificate issue. Unfortunately, we can't work around this, as HTTP URLs simply redirect to HTTPS. As a result, CI will predictably fail for this PR until the upstream situation is resolved.

However, this regex needs to be brought up to our current standards. I'm handling this individually, so this one PR can fail instead of tanking a batch PR.