### PR TITLE
alpine: add livecheckable

### DIFF
--- a/Livecheckables/alpine.rb
+++ b/Livecheckables/alpine.rb
@@ -1,0 +1,6 @@
+class Alpine
+  livecheck do
+    url :homepage
+    regex(/href=.*?alpine[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
The default check for `alpine` checks the HEAD repo (https://repo.or.cz/alpine.git) but it's currently experiencing SSL issues:

```
fatal: unable to access 'https://repo.or.cz/alpine.git/': LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to repo.or.cz:443
```

This addresses the issue by adding a livecheckable that uses the homepage, as that's the closest we can get to the stable source (i.e., the `src` subdirectory doesn't allow directory listing).