### PR TITLE
Change `href="` followed by name to `href=.*?`

### DIFF
--- a/Livecheckables/adns.rb
+++ b/Livecheckables/adns.rb
@@ -1,6 +1,6 @@
 class Adns
   livecheck do
     url "https://www.chiark.greenend.org.uk/~ian/adns/ftp/"
-    regex(/href="adns-([0-9.]+)\.t/)
+    regex(/href=.*?adns-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/agedu.rb
+++ b/Livecheckables/agedu.rb
@@ -1,6 +1,6 @@
 class Agedu
   livecheck do
     url :homepage
-    regex(/href="agedu-(\d+)(?:\.[\da-z]+)?\.t/)
+    regex(/href=.*?agedu-(\d+)(?:\.[\da-z]+)?\.t/)
   end
 end

--- a/Livecheckables/ansible.rb
+++ b/Livecheckables/ansible.rb
@@ -1,6 +1,6 @@
 class Ansible
   livecheck do
     url "https://releases.ansible.com/ansible/"
-    regex(/href="ansible-([0-9.]+)\.t/)
+    regex(/href=.*?ansible-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ansifilter.rb
+++ b/Livecheckables/ansifilter.rb
@@ -1,6 +1,6 @@
 class Ansifilter
   livecheck do
     url "http://www.andre-simon.de/zip/download.php"
-    regex(/href="ansifilter-([0-9,.]+)\.t/)
+    regex(/href=.*?ansifilter-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/argus.rb
+++ b/Livecheckables/argus.rb
@@ -1,6 +1,6 @@
 class Argus
   livecheck do
     url "https://qosient.com/argus/src/"
-    regex(/href="argus-([0-9,.]+)\.t/)
+    regex(/href=.*?argus-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/atool.rb
+++ b/Livecheckables/atool.rb
@@ -1,6 +1,6 @@
 class Atool
   livecheck do
     url "https://namesdir.com/mirrors/nongnu/atool/?C=M&O=D"
-    regex(/href="atool-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?atool-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/aubio.rb
+++ b/Livecheckables/aubio.rb
@@ -1,6 +1,6 @@
 class Aubio
   livecheck do
     url "https://aubio.org/pub/"
-    regex(/href="aubio-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?aubio-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/augeas.rb
+++ b/Livecheckables/augeas.rb
@@ -1,6 +1,6 @@
 class Augeas
   livecheck do
     url "http://download.augeas.net/"
-    regex(/href="augeas-([0-9,.]+)\.t/)
+    regex(/href=.*?augeas-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/augustus.rb
+++ b/Livecheckables/augustus.rb
@@ -1,6 +1,6 @@
 class Augustus
   livecheck do
     url "http://bioinf.uni-greifswald.de/augustus/binaries/"
-    regex(/href="augustus-([0-9.]+)\.t/)
+    regex(/href=.*?augustus-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/babeld.rb
+++ b/Livecheckables/babeld.rb
@@ -1,6 +1,6 @@
 class Babeld
   livecheck do
     url "https://www.irif.fr/~jch/software/files/"
-    regex(/href="babeld-([0-9.]+)\.t/)
+    regex(/href=.*?babeld-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/baresip.rb
+++ b/Livecheckables/baresip.rb
@@ -1,6 +1,6 @@
 class Baresip
   livecheck do
     url "http://www.creytiv.com/pub/"
-    regex(/href="baresip-([0-9.]+)\.t/)
+    regex(/href=.*?baresip-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/bitlbee.rb
+++ b/Livecheckables/bitlbee.rb
@@ -1,6 +1,6 @@
 class Bitlbee
   livecheck do
     url "https://get.bitlbee.org/src/"
-    regex(/href="bitlbee-([0-9.]+)\.t/)
+    regex(/href=.*?bitlbee-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/bmake.rb
+++ b/Livecheckables/bmake.rb
@@ -1,6 +1,6 @@
 class Bmake
   livecheck do
     url "http://www.crufty.net/ftp/pub/sjg/"
-    regex(/href="bmake-([0-9,.]+)\.t/)
+    regex(/href=.*?bmake-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/cgdb.rb
+++ b/Livecheckables/cgdb.rb
@@ -1,6 +1,6 @@
 class Cgdb
   livecheck do
     url "https://cgdb.me/files/"
-    regex(/href="cgdb-([0-9.]+)\.t/)
+    regex(/href=.*?cgdb-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/chicken.rb
+++ b/Livecheckables/chicken.rb
@@ -1,6 +1,6 @@
 class Chicken
   livecheck do
     url "https://code.call-cc.org/releases/current/"
-    regex(/href="chicken-([0-9.]+)\.t/)
+    regex(/href=.*?chicken-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/chuck.rb
+++ b/Livecheckables/chuck.rb
@@ -1,6 +1,6 @@
 class Chuck
   livecheck do
     url "https://chuck.cs.princeton.edu/release/files/"
-    regex(/href="chuck-([0-9.]+)\.t/)
+    regex(/href=.*?chuck-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/cimg.rb
+++ b/Livecheckables/cimg.rb
@@ -1,6 +1,6 @@
 class Cimg
   livecheck do
     url "https://cimg.eu/files/"
-    regex(/href="CImg_([0-9,.]+)\.zip/)
+    regex(/href=.*?CImg_([0-9,.]+)\.zip/)
   end
 end

--- a/Livecheckables/creduce.rb
+++ b/Livecheckables/creduce.rb
@@ -1,6 +1,6 @@
 class Creduce
   livecheck do
     url :homepage
-    regex(/href="creduce-([0-9,.]+)\.t/)
+    regex(/href=.*?creduce-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/cuba.rb
+++ b/Livecheckables/cuba.rb
@@ -1,6 +1,6 @@
 class Cuba
   livecheck do
     url :homepage
-    regex(/href="Cuba-([0-9.]+)\.t/)
+    regex(/href=.*?Cuba-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/dbus-glib.rb
+++ b/Livecheckables/dbus-glib.rb
@@ -1,6 +1,6 @@
 class DbusGlib
   livecheck do
     url "https://dbus.freedesktop.org/releases/dbus-glib/"
-    regex(/href="dbus-glib-([0-9.]+)\.t/)
+    regex(/href=.*?dbus-glib-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/dcmtk.rb
+++ b/Livecheckables/dcmtk.rb
@@ -1,6 +1,6 @@
 class Dcmtk
   livecheck do
     url "https://dicom.offis.de/download/dcmtk/release/"
-    regex(/href="dcmtk-([0-9._]+)\.t/)
+    regex(/href=.*?dcmtk-([0-9._]+)\.t/)
   end
 end

--- a/Livecheckables/dcraw.rb
+++ b/Livecheckables/dcraw.rb
@@ -1,6 +1,6 @@
 class Dcraw
   livecheck do
     url "https://distfiles.macports.org/dcraw/"
-    regex(/href="dcraw-([0-9.]+)\.t/)
+    regex(/href=.*?dcraw-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/discount.rb
+++ b/Livecheckables/discount.rb
@@ -1,6 +1,6 @@
 class Discount
   livecheck do
     url :homepage
-    regex(/href="discount-([0-9a-z.]+)\.t/)
+    regex(/href=.*?discount-([0-9a-z.]+)\.t/)
   end
 end

--- a/Livecheckables/dmenu.rb
+++ b/Livecheckables/dmenu.rb
@@ -1,6 +1,6 @@
 class Dmenu
   livecheck do
     url "https://dl.suckless.org/tools/"
-    regex(/href="dmenu-([0-9,.]+)\.t/)
+    regex(/href=.*?dmenu-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/dnsmasq.rb
+++ b/Livecheckables/dnsmasq.rb
@@ -1,6 +1,6 @@
 class Dnsmasq
   livecheck do
     url "http://www.thekelleys.org.uk/dnsmasq/"
-    regex(/href="dnsmasq-([0-9,.]+)\.t/)
+    regex(/href=.*?dnsmasq-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/dos2unix.rb
+++ b/Livecheckables/dos2unix.rb
@@ -1,6 +1,6 @@
 class Dos2unix
   livecheck do
     url "https://waterlan.home.xs4all.nl/dos2unix/"
-    regex(/href="dos2unix-([0-9,.]+)\.t/)
+    regex(/href=.*?dos2unix-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/dsh.rb
+++ b/Livecheckables/dsh.rb
@@ -1,6 +1,6 @@
 class Dsh
   livecheck do
     url "https://www.netfort.gr.jp/~dancer/software/downloads/"
-    regex(/href="dsh-([0-9.]+)\.t/)
+    regex(/href=.*?dsh-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/dtc.rb
+++ b/Livecheckables/dtc.rb
@@ -1,6 +1,6 @@
 class Dtc
   livecheck do
     url "https://mirrors.edge.kernel.org/pub/software/utils/dtc/"
-    regex(/href="dtc-([0-9.]+)\.t/)
+    regex(/href=.*?dtc-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/dvdrtools.rb
+++ b/Livecheckables/dvdrtools.rb
@@ -1,6 +1,6 @@
 class Dvdrtools
   livecheck do
     url "https://download.savannah.gnu.org/releases/dvdrtools/"
-    regex(/href="dvdrtools-([0-9.]+)\.t/)
+    regex(/href=.*?dvdrtools-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/dwdiff.rb
+++ b/Livecheckables/dwdiff.rb
@@ -1,6 +1,6 @@
 class Dwdiff
   livecheck do
     url "https://os.ghalkes.nl/dist/"
-    regex(/href="dwdiff-([0-9.]+)\.t/)
+    regex(/href=.*?dwdiff-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/efl.rb
+++ b/Livecheckables/efl.rb
@@ -1,6 +1,6 @@
 class Efl
   livecheck do
     url "https://download.enlightenment.org/rel/libs/efl/"
-    regex(/href="efl-([0-9,.]+)\.t/)
+    regex(/href=.*?efl-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/exact-image.rb
+++ b/Livecheckables/exact-image.rb
@@ -1,6 +1,6 @@
 class ExactImage
   livecheck do
     url "https://dl.exactcode.de/oss/exact-image/"
-    regex(/href="exact-image-([0-9.]+)\.t/)
+    regex(/href=.*?exact-image-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/exempi.rb
+++ b/Livecheckables/exempi.rb
@@ -1,6 +1,6 @@
 class Exempi
   livecheck do
     url "https://libopenraw.freedesktop.org/exempi/"
-    regex(/href="[^"']+exempi-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?exempi-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/exiftran.rb
+++ b/Livecheckables/exiftran.rb
@@ -1,6 +1,6 @@
 class Exiftran
   livecheck do
     url "https://www.kraxel.org/releases/fbida/"
-    regex(/href="fbida-([0-9.]+)\.t/)
+    regex(/href=.*?fbida-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/feh.rb
+++ b/Livecheckables/feh.rb
@@ -1,6 +1,6 @@
 class Feh
   livecheck do
     url :homepage
-    regex(/href="feh-([0-9,.]+)\.t/)
+    regex(/href=.*?feh-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/fetch-crl.rb
+++ b/Livecheckables/fetch-crl.rb
@@ -1,6 +1,6 @@
 class FetchCrl
   livecheck do
     url "https://dist.eugridpma.info/distribution/util/fetch-crl/"
-    regex(/href="fetch-crl-([0-9,.]+)\.t/)
+    regex(/href=.*?fetch-crl-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/flashrom.rb
+++ b/Livecheckables/flashrom.rb
@@ -1,6 +1,6 @@
 class Flashrom
   livecheck do
     url "https://download.flashrom.org/releases/"
-    regex(/href="flashrom-v?(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?flashrom-v?(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/flawfinder.rb
+++ b/Livecheckables/flawfinder.rb
@@ -1,6 +1,6 @@
 class Flawfinder
   livecheck do
     url :homepage
-    regex(/href="flawfinder-([0-9.]+)\.t/)
+    regex(/href=.*?flawfinder-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/gdal.rb
+++ b/Livecheckables/gdal.rb
@@ -1,6 +1,6 @@
 class Gdal
   livecheck do
     url "https://download.osgeo.org/gdal/CURRENT/"
-    regex(/href="gdal-([0-9.]+)\.t/)
+    regex(/href=.*?gdal-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/gdb.rb
+++ b/Livecheckables/gdb.rb
@@ -1,6 +1,6 @@
 class Gdb
   livecheck do
     url "https://ftp.gnu.org/gnu/gdb/?C=M&O=D"
-    regex(/href="gdb-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?gdb-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/gnustep-make.rb
+++ b/Livecheckables/gnustep-make.rb
@@ -1,6 +1,6 @@
 class GnustepMake
   livecheck do
     url "http://ftpmain.gnustep.org/pub/gnustep/core/"
-    regex(/href="gnustep-make-([0-9.]+)\.t/)
+    regex(/href=.*?gnustep-make-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/graph-tool.rb
+++ b/Livecheckables/graph-tool.rb
@@ -1,6 +1,6 @@
 class GraphTool
   livecheck do
     url "https://downloads.skewed.de/graph-tool/"
-    regex(/href="graph-tool-([0-9.]+)\.t/)
+    regex(/href=.*?graph-tool-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/graphviz.rb
+++ b/Livecheckables/graphviz.rb
@@ -1,6 +1,6 @@
 class Graphviz
   livecheck do
     url "https://www2.graphviz.org/Packages/stable/portable_source/"
-    regex(/href="graphviz-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?graphviz-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/gromacs.rb
+++ b/Livecheckables/gromacs.rb
@@ -1,6 +1,6 @@
 class Gromacs
   livecheck do
     url "https://ftp.gromacs.org/pub/gromacs/"
-    regex(/href="gromacs-([0-9.]+)\.t/)
+    regex(/href=.*?gromacs-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/gst-libav.rb
+++ b/Livecheckables/gst-libav.rb
@@ -1,6 +1,6 @@
 class GstLibav
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gst-libav/"
-    regex(/href="gst-libav-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
+    regex(/href=.*?gst-libav-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/gst-plugins-base.rb
+++ b/Livecheckables/gst-plugins-base.rb
@@ -1,6 +1,6 @@
 class GstPluginsBase
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-base/"
-    regex(/href="gst-plugins-base-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
+    regex(/href=.*?gst-plugins-base-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/gst-plugins-good.rb
+++ b/Livecheckables/gst-plugins-good.rb
@@ -1,6 +1,6 @@
 class GstPluginsGood
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-good/"
-    regex(/href="gst-plugins-good-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
+    regex(/href=.*?gst-plugins-good-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/gst-plugins-ugly.rb
+++ b/Livecheckables/gst-plugins-ugly.rb
@@ -1,6 +1,6 @@
 class GstPluginsUgly
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/"
-    regex(/href="gst-plugins-ugly-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
+    regex(/href=.*?gst-plugins-ugly-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/gstreamer.rb
+++ b/Livecheckables/gstreamer.rb
@@ -1,6 +1,6 @@
 class Gstreamer
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gstreamer/"
-    regex(/href="gstreamer-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
+    regex(/href=.*?gstreamer-v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/html-xml-utils.rb
+++ b/Livecheckables/html-xml-utils.rb
@@ -1,6 +1,6 @@
 class HtmlXmlUtils
   livecheck do
     url :homepage
-    regex(/href="html-xml-utils-([0-9.]+)\.t/)
+    regex(/href=.*?html-xml-utils-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/htpdate.rb
+++ b/Livecheckables/htpdate.rb
@@ -1,6 +1,6 @@
 class Htpdate
   livecheck do
     url "http://www.vervest.org/htp/archive/c/?C=M&O=D"
-    regex(/href="htpdate-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?htpdate-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/i2util.rb
+++ b/Livecheckables/i2util.rb
@@ -1,6 +1,6 @@
 class I2util
   livecheck do
     url "http://software.internet2.edu/sources/I2util/"
-    regex(/href="I2util-([0-9.]+)\.t/)
+    regex(/href=.*?I2util-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/i386-elf-gdb.rb
+++ b/Livecheckables/i386-elf-gdb.rb
@@ -1,6 +1,6 @@
 class I386ElfGdb
   livecheck do
     url "https://ftp.gnu.org/gnu/gdb/?C=M&O=D"
-    regex(/href="gdb-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?gdb-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/icarus-verilog.rb
+++ b/Livecheckables/icarus-verilog.rb
@@ -1,6 +1,6 @@
 class IcarusVerilog
   livecheck do
     url "https://ftp.openbsd.org/pub/OpenBSD/distfiles/"
-    regex(/href="verilog-([0-9.]+)\.t/)
+    regex(/href=.*?verilog-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/icbirc.rb
+++ b/Livecheckables/icbirc.rb
@@ -1,6 +1,6 @@
 class Icbirc
   livecheck do
     url :homepage
-    regex(%r{href="/icbirc-([0-9.]+)\.t})
+    regex(/href=.*?icbirc-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/idnits.rb
+++ b/Livecheckables/idnits.rb
@@ -1,6 +1,6 @@
 class Idnits
   livecheck do
     url :homepage
-    regex(/href="idnits-([0-9.]+)\.t/)
+    regex(/href=.*?idnits-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/imagemagick.rb
+++ b/Livecheckables/imagemagick.rb
@@ -1,6 +1,6 @@
 class Imagemagick
   livecheck do
     url "https://www.imagemagick.org/download/"
-    regex(/href="ImageMagick-([0-9.\-]+)\.t/)
+    regex(/href=.*?ImageMagick-([0-9.\-]+)\.t/)
   end
 end

--- a/Livecheckables/imagemagick@6.rb
+++ b/Livecheckables/imagemagick@6.rb
@@ -1,6 +1,6 @@
 class ImagemagickAT6
   livecheck do
     url "https://www.imagemagick.org/download/"
-    regex(/href="ImageMagick-(6[0-9.\-]+)\.t/)
+    regex(/href=.*?ImageMagick-(6[0-9.\-]+)\.t/)
   end
 end

--- a/Livecheckables/isl.rb
+++ b/Livecheckables/isl.rb
@@ -1,6 +1,6 @@
 class Isl
   livecheck do
     url "http://isl.gforge.inria.fr/"
-    regex(/href="isl-([0-9.]+)\.t/)
+    regex(/href=.*?isl-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/kawa.rb
+++ b/Livecheckables/kawa.rb
@@ -1,6 +1,6 @@
 class Kawa
   livecheck do
     url "https://ftp.gnu.org/gnu/kawa"
-    regex(/href="kawa-(\d+\.\d+(\.\d+)?)\.zip/)
+    regex(/href=.*?kawa-(\d+\.\d+(\.\d+)?)\.zip/)
   end
 end

--- a/Livecheckables/knot-resolver.rb
+++ b/Livecheckables/knot-resolver.rb
@@ -1,6 +1,6 @@
 class KnotResolver
   livecheck do
     url "https://secure.nic.cz/files/knot-resolver/"
-    regex(/href="knot-resolver-([0-9.]+)\.t/)
+    regex(/href=.*?knot-resolver-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/knot.rb
+++ b/Livecheckables/knot.rb
@@ -1,6 +1,6 @@
 class Knot
   livecheck do
     url "https://secure.nic.cz/files/knot-dns/"
-    regex(/href="knot-([0-9.]+)\.t/)
+    regex(/href=.*?knot-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/launch.rb
+++ b/Livecheckables/launch.rb
@@ -1,6 +1,6 @@
 class Launch
   livecheck do
     url "https://sabi.net/nriley/software/"
-    regex(/href="launch-([0-9.]+)\.t/)
+    regex(/href=.*?launch-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/lbdb.rb
+++ b/Livecheckables/lbdb.rb
@@ -1,6 +1,6 @@
 class Lbdb
   livecheck do
     url "https://www.spinnaker.de/lbdb/download/"
-    regex(/href="lbdb_([0-9.]+)\.t/)
+    regex(/href=.*?lbdb_([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libbpg.rb
+++ b/Livecheckables/libbpg.rb
@@ -1,6 +1,6 @@
 class Libbpg
   livecheck do
     url :homepage
-    regex(/href="libbpg-([0-9.]+)\.t/)
+    regex(/href=.*?libbpg-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libcdr.rb
+++ b/Livecheckables/libcdr.rb
@@ -1,6 +1,6 @@
 class Libcdr
   livecheck do
     url "https://dev-www.libreoffice.org/src/"
-    regex(/.*href="libcdr-([0-9.\-]+)\.t/)
+    regex(/.*href=.*?libcdr-([0-9.\-]+)\.t/)
   end
 end

--- a/Livecheckables/libdap.rb
+++ b/Livecheckables/libdap.rb
@@ -1,6 +1,6 @@
 class Libdap
   livecheck do
     url "https://www.opendap.org/pub/source/"
-    regex(/href="libdap-([0-9.]+)\.t/)
+    regex(/href=.*?libdap-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libdiscid.rb
+++ b/Livecheckables/libdiscid.rb
@@ -1,6 +1,6 @@
 class Libdiscid
   livecheck do
     url "http://ftp.musicbrainz.org/pub/musicbrainz/libdiscid/"
-    regex(/href="libdiscid-([0-9.]+)\.t/)
+    regex(/href=.*?libdiscid-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libetonyek.rb
+++ b/Livecheckables/libetonyek.rb
@@ -1,6 +1,6 @@
 class Libetonyek
   livecheck do
     url "https://dev-www.libreoffice.org/src/libetonyek/"
-    regex(/href="libetonyek-([0-9,.]+)\.t/)
+    regex(/href=.*?libetonyek-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/libgig.rb
+++ b/Livecheckables/libgig.rb
@@ -1,6 +1,6 @@
 class Libgig
   livecheck do
     url "https://download.linuxsampler.org/packages/"
-    regex(/href="libgig-([0-9.]+)\.t/)
+    regex(/href=.*?libgig-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libidn2.rb
+++ b/Livecheckables/libidn2.rb
@@ -1,6 +1,6 @@
 class Libidn2
   livecheck do
     url "https://ftp.gnu.org/gnu/libidn/"
-    regex(/href="libidn2-([0-9.]+)\.t/)
+    regex(/href=.*?libidn2-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libinfinity.rb
+++ b/Livecheckables/libinfinity.rb
@@ -1,6 +1,6 @@
 class Libinfinity
   livecheck do
     url "http://releases.0x539.de/libinfinity/"
-    regex(/href="libinfinity-([0-9.]+)\.t/)
+    regex(/href=.*?libinfinity-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libmspub.rb
+++ b/Livecheckables/libmspub.rb
@@ -1,6 +1,6 @@
 class Libmspub
   livecheck do
     url "https://dev-www.libreoffice.org/src/libmspub/"
-    regex(/href="libmspub-([0-9,.]+)\.t/)
+    regex(/href=.*?libmspub-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/libosinfo.rb
+++ b/Livecheckables/libosinfo.rb
@@ -1,6 +1,6 @@
 class Libosinfo
   livecheck do
     url "https://releases.pagure.org/libosinfo/?C=M&O=D"
-    regex(/href="libosinfo-([\d.]+)\.t/)
+    regex(/href=.*?libosinfo-([\d.]+)\.t/)
   end
 end

--- a/Livecheckables/libowfat.rb
+++ b/Livecheckables/libowfat.rb
@@ -1,6 +1,6 @@
 class Libowfat
   livecheck do
     url :homepage
-    regex(/href="libowfat-([0-9.]+)\.t/)
+    regex(/href=.*?libowfat-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libpagemaker.rb
+++ b/Livecheckables/libpagemaker.rb
@@ -1,6 +1,6 @@
 class Libpagemaker
   livecheck do
     url "https://dev-www.libreoffice.org/src/libpagemaker/"
-    regex(/href="libpagemaker-([0-9,.]+)\.t/)
+    regex(/href=.*?libpagemaker-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/libre.rb
+++ b/Livecheckables/libre.rb
@@ -1,6 +1,6 @@
 class Libre
   livecheck do
     url "http://www.creytiv.com/pub/"
-    regex(/href="re-([0-9.]+)\.t/)
+    regex(/href=.*?re-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/librem.rb
+++ b/Livecheckables/librem.rb
@@ -1,6 +1,6 @@
 class Librem
   livecheck do
     url "http://www.creytiv.com/pub/"
-    regex(/href="rem-([0-9.]+)\.t/)
+    regex(/href=.*?rem-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libshout.rb
+++ b/Livecheckables/libshout.rb
@@ -1,6 +1,6 @@
 class Libshout
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/libshout/"
-    regex(/href="libshout-([0-9.]+)\.t/)
+    regex(/href=.*?libshout-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libsmi.rb
+++ b/Livecheckables/libsmi.rb
@@ -1,6 +1,6 @@
 class Libsmi
   livecheck do
     url "https://www.ibr.cs.tu-bs.de/projects/libsmi/download/"
-    regex(/href="libsmi-([0-9.]+)\.t/)
+    regex(/href=.*?libsmi-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libtermkey.rb
+++ b/Livecheckables/libtermkey.rb
@@ -1,6 +1,6 @@
 class Libtermkey
   livecheck do
     url :homepage
-    regex(/href="libtermkey-([0-9,.]+)\.t/)
+    regex(/href=.*?libtermkey-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/libtiff.rb
+++ b/Livecheckables/libtiff.rb
@@ -1,6 +1,6 @@
 class Libtiff
   livecheck do
     url "https://download.osgeo.org/libtiff/"
-    regex(/href="tiff-([0-9.\-]+)\.t/)
+    regex(/href=.*?tiff-([0-9.\-]+)\.t/)
   end
 end

--- a/Livecheckables/libu2f-server.rb
+++ b/Livecheckables/libu2f-server.rb
@@ -1,6 +1,6 @@
 class Libu2fServer
   livecheck do
     url "https://developers.yubico.com/libu2f-server/Releases/"
-    regex(/href="libu2f-server-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?libu2f-server-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/libvirt.rb
+++ b/Livecheckables/libvirt.rb
@@ -1,6 +1,6 @@
 class Libvirt
   livecheck do
     url "https://libvirt.org/sources/"
-    regex(/href="libvirt-([\d.]+)\.t/)
+    regex(/href=.*?libvirt-([\d.]+)\.t/)
   end
 end

--- a/Livecheckables/libvisio.rb
+++ b/Livecheckables/libvisio.rb
@@ -1,6 +1,6 @@
 class Libvisio
   livecheck do
     url "https://dev-www.libreoffice.org/src/"
-    regex(/.*href="libvisio-([0-9.\-]+)\.t/)
+    regex(/.*href=.*?libvisio-([0-9.\-]+)\.t/)
   end
 end

--- a/Livecheckables/libwpd.rb
+++ b/Livecheckables/libwpd.rb
@@ -1,6 +1,6 @@
 class Libwpd
   livecheck do
     url "https://dev-www.libreoffice.org/src/"
-    regex(/.*href="libwpd-([0-9.\-]+)\.t/)
+    regex(/.*href=.*?libwpd-([0-9.\-]+)\.t/)
   end
 end

--- a/Livecheckables/libwpg.rb
+++ b/Livecheckables/libwpg.rb
@@ -1,6 +1,6 @@
 class Libwpg
   livecheck do
     url "https://dev-www.libreoffice.org/src/"
-    regex(/.*href="libwpg-([0-9.\-]+)\.t/)
+    regex(/.*href=.*?libwpg-([0-9.\-]+)\.t/)
   end
 end

--- a/Livecheckables/libxmlsec1.rb
+++ b/Livecheckables/libxmlsec1.rb
@@ -1,6 +1,6 @@
 class Libxmlsec1
   livecheck do
     url "https://www.aleksey.com/xmlsec/download/"
-    regex(/href="xmlsec1-([0-9.]+)\.t/)
+    regex(/href=.*?xmlsec1-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libxslt.rb
+++ b/Livecheckables/libxslt.rb
@@ -1,6 +1,6 @@
 class Libxslt
   livecheck do
     url "http://xmlsoft.org/sources/"
-    regex(/href="libxslt-([0-9.]+)\.t/)
+    regex(/href=.*?libxslt-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libzip.rb
+++ b/Livecheckables/libzip.rb
@@ -1,6 +1,6 @@
 class Libzip
   livecheck do
     url "https://libzip.org/download/"
-    regex(/href="libzip-([0-9.]+)\.t/)
+    regex(/href=.*?libzip-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/lighttpd.rb
+++ b/Livecheckables/lighttpd.rb
@@ -1,6 +1,6 @@
 class Lighttpd
   livecheck do
     url "https://download.lighttpd.net/lighttpd/releases-1.4.x/"
-    regex(/href="lighttpd-([0-9,.]+)\.t/)
+    regex(/href=.*?lighttpd-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/log4shib.rb
+++ b/Livecheckables/log4shib.rb
@@ -1,6 +1,6 @@
 class Log4shib
   livecheck do
     url "https://shibboleth.net/downloads/log4shib/latest/"
-    regex(/href="log4shib-([0-9.]+)\.t/)
+    regex(/href=.*?log4shib-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/lzlib.rb
+++ b/Livecheckables/lzlib.rb
@@ -1,6 +1,6 @@
 class Lzlib
   livecheck do
     url "https://download.savannah.gnu.org/releases/lzip/lzlib/"
-    regex(/href="lzlib-([0-9.]+)\.t/)
+    regex(/href=.*?lzlib-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/lzop.rb
+++ b/Livecheckables/lzop.rb
@@ -1,6 +1,6 @@
 class Lzop
   livecheck do
     url "https://www.lzop.org/download/"
-    regex(/href="lzop-([0-9.]+)\.t/)
+    regex(/href=.*?lzop-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/mawk.rb
+++ b/Livecheckables/mawk.rb
@@ -1,6 +1,6 @@
 class Mawk
   livecheck do
     url "https://invisible-mirror.net/archives/mawk/?C=M&O=D"
-    regex(/href="mawk-(\d+(?:\.\d+)+(?:-\d+)?)\.t/)
+    regex(/href=.*?mawk-(\d+(?:\.\d+)+(?:-\d+)?)\.t/)
   end
 end

--- a/Livecheckables/mercurial.rb
+++ b/Livecheckables/mercurial.rb
@@ -1,6 +1,6 @@
 class Mercurial
   livecheck do
     url "https://www.mercurial-scm.org/release/"
-    regex(/href="mercurial-([0-9.]+)\.t/)
+    regex(/href=.*?mercurial-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/mkvtoolnix.rb
+++ b/Livecheckables/mkvtoolnix.rb
@@ -1,6 +1,6 @@
 class Mkvtoolnix
   livecheck do
     url "https://mkvtoolnix.download/sources/"
-    regex(/href="[^"]*?mkvtoolnix-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?mkvtoolnix-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/monit.rb
+++ b/Livecheckables/monit.rb
@@ -1,6 +1,6 @@
 class Monit
   livecheck do
     url "https://mmonit.com/monit/dist/"
-    regex(/href="monit-([0-9,.]+)\.t/)
+    regex(/href=.*?monit-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/mpc.rb
+++ b/Livecheckables/mpc.rb
@@ -1,6 +1,6 @@
 class Mpc
   livecheck do
     url "https://www.musicpd.org/download/mpc/0/"
-    regex(/href="mpc-([0-9.]+)\.t/)
+    regex(/href=.*?mpc-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/nagios-plugins.rb
+++ b/Livecheckables/nagios-plugins.rb
@@ -1,6 +1,6 @@
 class NagiosPlugins
   livecheck do
     url "https://nagios-plugins.org/download/"
-    regex(/href="nagios-plugins-([\d.]+)\.t/)
+    regex(/href=.*?nagios-plugins-([\d.]+)\.t/)
   end
 end

--- a/Livecheckables/nanopb-generator.rb
+++ b/Livecheckables/nanopb-generator.rb
@@ -1,6 +1,6 @@
 class NanopbGenerator
   livecheck do
     url "https://jpa.kapsi.fi/nanopb/download/"
-    regex(/href="nanopb-([0-9.]+)\.t/)
+    regex(/href=.*?nanopb-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ncmpc.rb
+++ b/Livecheckables/ncmpc.rb
@@ -1,6 +1,6 @@
 class Ncmpc
   livecheck do
     url "https://www.musicpd.org/download/ncmpc/0/"
-    regex(/href="ncmpc-([0-9,.]+)\.t/)
+    regex(/href=.*?ncmpc-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/nickle.rb
+++ b/Livecheckables/nickle.rb
@@ -1,6 +1,6 @@
 class Nickle
   livecheck do
     url "https://www.nickle.org/release/"
-    regex(/href="nickle-([0-9.]+)\.t/)
+    regex(/href=.*?nickle-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/nmap.rb
+++ b/Livecheckables/nmap.rb
@@ -1,6 +1,6 @@
 class Nmap
   livecheck do
     url "https://nmap.org/dist/"
-    regex(/href="nmap-([0-9,.]+)\.t/)
+    regex(/href=.*?nmap-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/ntl.rb
+++ b/Livecheckables/ntl.rb
@@ -1,6 +1,6 @@
 class Ntl
   livecheck do
     url "https://www.shoup.net/ntl/download.html"
-    regex(/href="ntl-([0-9.]+)\.t/)
+    regex(/href=.*?ntl-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/opensaml.rb
+++ b/Livecheckables/opensaml.rb
@@ -1,6 +1,6 @@
 class Opensaml
   livecheck do
     url "https://shibboleth.net/downloads/c++-opensaml/latest/"
-    regex(/href="opensaml-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?opensaml-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/openssl@1.1.rb
+++ b/Livecheckables/openssl@1.1.rb
@@ -1,6 +1,6 @@
 class OpensslAT11
   livecheck do
     url "https://www.openssl.org/source/"
-    regex(/href="openssl-(1\.1[0-9a-z.]+)\.t/)
+    regex(/href=.*?openssl-(1\.1[0-9a-z.]+)\.t/)
   end
 end

--- a/Livecheckables/orc.rb
+++ b/Livecheckables/orc.rb
@@ -1,6 +1,6 @@
 class Orc
   livecheck do
     url "https://gstreamer.freedesktop.org/src/orc/"
-    regex(/href="orc-([\d.]+\.[\d.]+\.[\d.]+)\.t/)
+    regex(/href=.*?orc-([\d.]+\.[\d.]+\.[\d.]+)\.t/)
   end
 end

--- a/Livecheckables/owamp.rb
+++ b/Livecheckables/owamp.rb
@@ -1,6 +1,6 @@
 class Owamp
   livecheck do
     url "http://software.internet2.edu/sources/owamp/"
-    regex(/href="owamp-([0-9.\-]+)\.t/)
+    regex(/href=.*?owamp-([0-9.\-]+)\.t/)
   end
 end

--- a/Livecheckables/pam-u2f.rb
+++ b/Livecheckables/pam-u2f.rb
@@ -1,6 +1,6 @@
 class PamU2f
   livecheck do
     url "https://developers.yubico.com/pam-u2f/Releases/"
-    regex(/href="pam_u2f-([0-9.]+)\.t/)
+    regex(/href=.*?pam_u2f-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/pam_yubico.rb
+++ b/Livecheckables/pam_yubico.rb
@@ -1,6 +1,6 @@
 class PamYubico
   livecheck do
     url "https://developers.yubico.com/yubico-pam/Releases/"
-    regex(/href="pam_yubico-([0-9.]+)\.t/)
+    regex(/href=.*?pam_yubico-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/pazpar2.rb
+++ b/Livecheckables/pazpar2.rb
@@ -1,6 +1,6 @@
 class Pazpar2
   livecheck do
     url "http://ftp.indexdata.dk/pub/pazpar2/"
-    regex(/href="pazpar2-([0-9.]+)\.t/)
+    regex(/href=.*?pazpar2-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/pcre.rb
+++ b/Livecheckables/pcre.rb
@@ -1,6 +1,6 @@
 class Pcre
   livecheck do
     url "https://ftp.pcre.org/pub/pcre/"
-    regex(/href="pcre-([0-9,.]+)\.t/)
+    regex(/href=.*?pcre-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/pcre2.rb
+++ b/Livecheckables/pcre2.rb
@@ -1,6 +1,6 @@
 class Pcre2
   livecheck do
     url "https://ftp.pcre.org/pub/pcre/"
-    regex(/href="pcre2-([0-9.]+)\.t/)
+    regex(/href=.*?pcre2-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/perl@5.18.rb
+++ b/Livecheckables/perl@5.18.rb
@@ -1,6 +1,6 @@
 class PerlAT518
   livecheck do
     url "https://www.cpan.org/src/5.0/"
-    regex(/href="perl-(5\.18\.[0-9.]+)\.t/)
+    regex(/href=.*?perl-(5\.18\.[0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/pgroonga.rb
+++ b/Livecheckables/pgroonga.rb
@@ -1,6 +1,6 @@
 class Pgroonga
   livecheck do
     url "https://packages.groonga.org/source/pgroonga/"
-    regex(/href="pgroonga-([0-9.]+)\.t/)
+    regex(/href=.*?pgroonga-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/physfs.rb
+++ b/Livecheckables/physfs.rb
@@ -1,6 +1,6 @@
 class Physfs
   livecheck do
     url "https://icculus.org/physfs/downloads/"
-    regex(/href="physfs-([0-9.]+)\.t/)
+    regex(/href=.*?physfs-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/pigz.rb
+++ b/Livecheckables/pigz.rb
@@ -1,6 +1,6 @@
 class Pigz
   livecheck do
     url :homepage
-    regex(/href="pigz-([0-9.]+)\.t/)
+    regex(/href=.*?pigz-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/redis.rb
+++ b/Livecheckables/redis.rb
@@ -1,6 +1,6 @@
 class Redis
   livecheck do
     url "http://download.redis.io/releases/"
-    regex(/href="redis-([0-9,.]+)\.t/)
+    regex(/href=.*?redis-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/reminiscence.rb
+++ b/Livecheckables/reminiscence.rb
@@ -1,6 +1,6 @@
 class Reminiscence
   livecheck do
     url :homepage
-    regex(/href="REminiscence-([0-9.]+)\.t/)
+    regex(/href=.*?REminiscence-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/restund.rb
+++ b/Livecheckables/restund.rb
@@ -1,6 +1,6 @@
 class Restund
   livecheck do
     url "http://www.creytiv.com/pub/"
-    regex(/href="restund-([0-9.]+)\.t/)
+    regex(/href=.*?restund-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/shapelib.rb
+++ b/Livecheckables/shapelib.rb
@@ -1,6 +1,6 @@
 class Shapelib
   livecheck do
     url "https://download.osgeo.org/shapelib/"
-    regex(/href="shapelib-([0-9.]+)\.t/)
+    regex(/href=.*?shapelib-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/shibboleth-sp.rb
+++ b/Livecheckables/shibboleth-sp.rb
@@ -1,6 +1,6 @@
 class ShibbolethSp
   livecheck do
     url "https://shibboleth.net/downloads/service-provider/latest/"
-    regex(/href="shibboleth-sp-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?shibboleth-sp-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/sord.rb
+++ b/Livecheckables/sord.rb
@@ -1,6 +1,6 @@
 class Sord
   livecheck do
     url "https://download.drobilla.net"
-    regex(/href="sord-(\d+.\d+.\d+)\.t/)
+    regex(/href=.*?sord-(\d+.\d+.\d+)\.t/)
   end
 end

--- a/Livecheckables/spigot.rb
+++ b/Livecheckables/spigot.rb
@@ -1,6 +1,6 @@
 class Spigot
   livecheck do
     url :homepage
-    regex(/href="spigot-(\d+)(?:\.[\da-z]+)?\.t/)
+    regex(/href=.*?spigot-(\d+)(?:\.[\da-z]+)?\.t/)
   end
 end

--- a/Livecheckables/stress-ng.rb
+++ b/Livecheckables/stress-ng.rb
@@ -1,6 +1,6 @@
 class StressNg
   livecheck do
     url "https://kernel.ubuntu.com/~cking/tarballs/stress-ng/"
-    regex(/href="stress-ng-([0-9.]+)\.t/)
+    regex(/href=.*?stress-ng-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/swftools.rb
+++ b/Livecheckables/swftools.rb
@@ -1,6 +1,6 @@
 class Swftools
   livecheck do
     url "http://www.swftools.org/download.html"
-    regex(/href="swftools-([0-9.]+)\.t/)
+    regex(/href=.*?swftools-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/talloc.rb
+++ b/Livecheckables/talloc.rb
@@ -1,6 +1,6 @@
 class Talloc
   livecheck do
     url "https://www.samba.org/ftp/talloc/"
-    regex(/href="talloc-([0-9.]+)\.t/)
+    regex(/href=.*?talloc-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/tcpdump.rb
+++ b/Livecheckables/tcpdump.rb
@@ -1,6 +1,6 @@
 class Tcpdump
   livecheck do
     url "https://www.tcpdump.org/release/"
-    regex(/href="tcpdump-([0-9.]+)\.t/)
+    regex(/href=.*?tcpdump-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/tcpflow.rb
+++ b/Livecheckables/tcpflow.rb
@@ -1,6 +1,6 @@
 class Tcpflow
   livecheck do
     url "http://downloads.digitalcorpora.org/downloads/tcpflow/"
-    regex(/href="tcpflow-v?(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?tcpflow-v?(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/u-boot-tools.rb
+++ b/Livecheckables/u-boot-tools.rb
@@ -1,6 +1,6 @@
 class UBootTools
   livecheck do
     url "https://ftp.denx.de/pub/u-boot/"
-    regex(/href="u-boot-([0-9.]+)\.t/)
+    regex(/href=.*?u-boot-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/udpxy.rb
+++ b/Livecheckables/udpxy.rb
@@ -1,6 +1,6 @@
 class Udpxy
   livecheck do
     url "http://www.udpxy.com/download/1_23/"
-    regex(/href="udpxy.([0-9.\-]+)-prod\.t/)
+    regex(/href=.*?udpxy.([0-9.\-]+)-prod\.t/)
   end
 end

--- a/Livecheckables/upscaledb.rb
+++ b/Livecheckables/upscaledb.rb
@@ -1,6 +1,6 @@
 class Upscaledb
   livecheck do
     url "http://files.upscaledb.com/dl/"
-    regex(/href="upscaledb-(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?upscaledb-(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/userspace-rcu.rb
+++ b/Livecheckables/userspace-rcu.rb
@@ -1,6 +1,6 @@
 class UserspaceRcu
   livecheck do
     url "https://www.lttng.org/files/urcu/"
-    regex(/href="userspace-rcu-([0-9.]+)\.t/)
+    regex(/href=.*?userspace-rcu-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/wimlib.rb
+++ b/Livecheckables/wimlib.rb
@@ -1,6 +1,6 @@
 class Wimlib
   livecheck do
     url "https://wimlib.net/downloads/"
-    regex(/href="wimlib-([0-9.]+)\.t/)
+    regex(/href=.*?wimlib-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/xboard.rb
+++ b/Livecheckables/xboard.rb
@@ -1,6 +1,6 @@
 class Xboard
   livecheck do
     url "https://ftp.gnu.org/gnu/xboard/"
-    regex(/href="xboard-v?(\d+(?:\.\d+)+)\.t/)
+    regex(/href=.*?xboard-v?(\d+(?:\.\d+)+)\.t/)
   end
 end

--- a/Livecheckables/xml-tooling-c.rb
+++ b/Livecheckables/xml-tooling-c.rb
@@ -1,6 +1,6 @@
 class XmlToolingC
   livecheck do
     url "https://shibboleth.net/downloads/c++-opensaml/latest/"
-    regex(/href="xmltooling-([0-9.]+)\.t/)
+    regex(/href=.*?xmltooling-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ykman.rb
+++ b/Livecheckables/ykman.rb
@@ -1,6 +1,6 @@
 class Ykman
   livecheck do
     url "https://developers.yubico.com/yubikey-manager/Releases/"
-    regex(/href="yubikey-manager-([0-9.]+)\.t/)
+    regex(/href=.*?yubikey-manager-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ykpers.rb
+++ b/Livecheckables/ykpers.rb
@@ -1,6 +1,6 @@
 class Ykpers
   livecheck do
     url "https://developers.yubico.com/yubikey-personalization/Releases/"
-    regex(/href="ykpers-([0-9.]+)\.t/)
+    regex(/href=.*?ykpers-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/yubico-piv-tool.rb
+++ b/Livecheckables/yubico-piv-tool.rb
@@ -1,6 +1,6 @@
 class YubicoPivTool
   livecheck do
     url "https://developers.yubico.com/yubico-piv-tool/Releases/"
-    regex(/href="yubico-piv-tool-([0-9.]+)\.t/)
+    regex(/href=.*?yubico-piv-tool-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/zita-convolver.rb
+++ b/Livecheckables/zita-convolver.rb
@@ -1,6 +1,6 @@
 class ZitaConvolver
   livecheck do
     url "https://kokkinizita.linuxaudio.org/linuxaudio/downloads/index.html"
-    regex(/href="zita-convolver-([0-9.]+)\.t/)
+    regex(/href=.*?zita-convolver-([0-9.]+)\.t/)
   end
 end


### PR DESCRIPTION
This PR changes `href="` when followed by the file/formula name to `href=.*?`.

The changes made are, for the most part, just simple replacements as stated above, except:
* `exempi`: also removed `[^"']`
* `icbirc`: also removed leading `/` and hence changing `%r{...}` to `/.../`
* `mkvtoolnix`: also removed `[^"]`

I've run `brew style homebrew/livecheck` and ensured that these changes haven't broken any Livecheckables.