### PR TITLE
Change `href="` followed by version directory to `href=.*?`

### DIFF
--- a/Livecheckables/alluxio.rb
+++ b/Livecheckables/alluxio.rb
@@ -1,6 +1,6 @@
 class Alluxio
   livecheck do
     url "https://downloads.alluxio.io/downloads/files/"
-    regex(%r{href="(\d+(?:\.\d+)+)/?"})
+    regex(%r{href=.*?(\d+(?:\.\d+)+)/?["' >]})
   end
 end

--- a/Livecheckables/autogen.rb
+++ b/Livecheckables/autogen.rb
@@ -1,6 +1,6 @@
 class Autogen
   livecheck do
     url "https://ftp.gnu.org/gnu/autogen/"
-    regex(%r{href="rel([0-9.]+)/})
+    regex(%r{href=.*?rel([0-9.]+)/?["' >]})
   end
 end

--- a/Livecheckables/coturn.rb
+++ b/Livecheckables/coturn.rb
@@ -1,6 +1,6 @@
 class Coturn
   livecheck do
     url "http://turnserver.open-sys.org/downloads/"
-    regex(%r{href="v?(\d+(?:\.\d+)+)/"})
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]})
   end
 end

--- a/Livecheckables/docbook.rb
+++ b/Livecheckables/docbook.rb
@@ -1,6 +1,6 @@
 class Docbook
   livecheck do
     url "https://docbook.org/xml/"
-    regex(%r{href="(\d+(?:\.\d+)+)/?"})
+    regex(%r{href=.*?(\d+(?:\.\d+)+)/?["' >]})
   end
 end

--- a/Livecheckables/gcc@4.9.rb
+++ b/Livecheckables/gcc@4.9.rb
@@ -1,6 +1,6 @@
 class GccAT49
   livecheck do
     url "https://ftp.gnu.org/gnu/gcc/"
-    regex(%r{href="gcc-(4\.9\.[0-9.]+)/"})
+    regex(%r{href=.*?gcc-(4\.9\.[0-9.]+)/?["' >]})
   end
 end

--- a/Livecheckables/gcc@5.rb
+++ b/Livecheckables/gcc@5.rb
@@ -1,6 +1,6 @@
 class GccAT5
   livecheck do
     url "https://ftp.gnu.org/gnu/gcc/"
-    regex(%r{href="gcc-(5\.[0-9.]+)/"})
+    regex(%r{href=.*?gcc-(5\.[0-9.]+)/?["' >]})
   end
 end

--- a/Livecheckables/gcc@6.rb
+++ b/Livecheckables/gcc@6.rb
@@ -1,6 +1,6 @@
 class GccAT6
   livecheck do
     url "https://ftp.gnu.org/gnu/gcc/"
-    regex(%r{href="gcc-(6\.[0-9.]+)/"})
+    regex(%r{href=.*?gcc-(6\.[0-9.]+)/?["' >]})
   end
 end

--- a/Livecheckables/gcc@7.rb
+++ b/Livecheckables/gcc@7.rb
@@ -1,6 +1,6 @@
 class GccAT7
   livecheck do
     url "https://ftp.gnu.org/gnu/gcc/"
-    regex(%r{href="gcc-(7\.[0-9.]+)/"})
+    regex(%r{href=.*?gcc-(7\.[0-9.]+)/?["' >]})
   end
 end

--- a/Livecheckables/libpq.rb
+++ b/Livecheckables/libpq.rb
@@ -1,6 +1,6 @@
 class Libpq
   livecheck do
     url "https://ftp.postgresql.org/pub/source/?C=M&O=A"
-    regex(%r{href="v?(\d+(?:\.\d+)+)/?"})
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]})
   end
 end

--- a/Livecheckables/poco.rb
+++ b/Livecheckables/poco.rb
@@ -1,6 +1,6 @@
 class Poco
   livecheck do
     url "https://pocoproject.org/releases"
-    regex(%r{href="poco-([0-9.]+)/"})
+    regex(%r{href=.*?poco-([0-9.]+)/?["' >]})
   end
 end

--- a/Livecheckables/qcachegrind.rb
+++ b/Livecheckables/qcachegrind.rb
@@ -1,6 +1,6 @@
 class Qcachegrind
   livecheck do
     url "https://download.kde.org/stable/applications"
-    regex(%r{href="([0-9.]+)/"})
+    regex(%r{href=.*?([0-9.]+)/?["' >]})
   end
 end

--- a/Livecheckables/spades.rb
+++ b/Livecheckables/spades.rb
@@ -1,6 +1,6 @@
 class Spades
   livecheck do
     url "http://cab.spbu.ru/files/?C=M&O=D"
-    regex(%r{href="release(\d+(?:\.\d+)+)/?"})
+    regex(%r{href=.*?release(\d+(?:\.\d+)+)/?["' >]})
   end
 end

--- a/Livecheckables/speech-tools.rb
+++ b/Livecheckables/speech-tools.rb
@@ -1,6 +1,6 @@
 class SpeechTools
   livecheck do
     url "http://festvox.org/packed/festival/?C=M&O=D"
-    regex(%r{href="(\d+(?:\.\d+)+)/?"})
+    regex(%r{href=.*?(\d+(?:\.\d+)+)/?["' >]})
   end
 end

--- a/Livecheckables/sword.rb
+++ b/Livecheckables/sword.rb
@@ -1,6 +1,6 @@
 class Sword
   livecheck do
     url "https://www.crosswire.org/ftpmirror/pub/sword/source/"
-    regex(%r{href="sword-([0-9.]+)/})
+    regex(%r{href=.*?sword-([0-9.]+)/?["' >]})
   end
 end

--- a/Livecheckables/tomcat-native.rb
+++ b/Livecheckables/tomcat-native.rb
@@ -1,6 +1,6 @@
 class TomcatNative
   livecheck do
     url "https://archive.apache.org/dist/tomcat/tomcat-connectors/native/"
-    regex(%r{href="v?(\d+(?:\.\d+)+)/"})
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]})
   end
 end

--- a/Livecheckables/tomcat@7.rb
+++ b/Livecheckables/tomcat@7.rb
@@ -1,6 +1,6 @@
 class TomcatAT7
   livecheck do
     url "https://archive.apache.org/dist/tomcat/tomcat-7/"
-    regex(%r{href="v?(\d+(?:\.\d+)+)/"})
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]})
   end
 end

--- a/Livecheckables/tomcat@8.rb
+++ b/Livecheckables/tomcat@8.rb
@@ -1,6 +1,6 @@
 class TomcatAT8
   livecheck do
     url "https://archive.apache.org/dist/tomcat/tomcat-8/"
-    regex(%r{href="v?(\d+(?:\.\d+)+)/"})
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]})
   end
 end


### PR DESCRIPTION
This PR changes `href="` when followed by a version directory to `href=.*?`, and also updates the portion of the regex checking for `/` to `/?["' >]`.

Note: `jenkins-lts` will be handled separately.