### PR TITLE
jenkins-lts: update regex

### DIFF
--- a/Livecheckables/jenkins-lts.rb
+++ b/Livecheckables/jenkins-lts.rb
@@ -1,6 +1,6 @@
 class JenkinsLts
   livecheck do
     url "http://mirrors.jenkins-ci.org/war-stable/"
-    regex(%r{href="(\d+.\d+.\d+)/"})
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
This PR updates the regex for `jenkins-lts`, bringing it up to current standards.

When changing `href="` to `href=.*?`, the older regex matched `2020-06-17` due to the capture group being `(\d+.\d+.\d+)`. A separate PR was necessary due to the additional changes involved.

The changes made are:
* `href="` –> `href=.*?`
* Matching `/` now done using `/?["' >]`
* Version capturing group is now `(\d+(?:\.\d+)+)`
* `v?` in case directory is prefixed with `v`
* Case-insensitivity