### PR TITLE
bashdb: update regex

### DIFF
--- a/Livecheckables/bashdb.rb
+++ b/Livecheckables/bashdb.rb
@@ -1,6 +1,6 @@
 class Bashdb
   livecheck do
     url "https://sourceforge.net/projects/bashdb/files/bashdb/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+[._-](?:\d+(?:\.\d+)+))/?["' >]}i)
+    regex(%r{href=(?:["']|.*?bashdb/)?v?(\d+(?:[.-]\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/bashdb.rb
+++ b/Livecheckables/bashdb.rb
@@ -1,6 +1,6 @@
 class Bashdb
   livecheck do
     url "https://sourceforge.net/projects/bashdb/files/bashdb/"
-    regex(%r{href="/projects/bashdb/files/bashdb/([0-9.\-]+)/"})
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+[._-](?:\d+(?:\.\d+)+))/?["' >]}i)
   end
 end


### PR DESCRIPTION
This PR updates the regex for `bashdb`.

The changes are:
* `href="` to `href=.*?` and removed the path from the regex
* They've been using `x.x-x.x(.x)?` since 2004, the version capturing group has been updated accordingly (needs to be checked, of course).
* `v?` prior to version capturing group
* `/` matching changed to `/?["' >]`
* Case-insensitivity
