### PR TITLE
libwps: update regex

### DIFF
--- a/Livecheckables/libwps.rb
+++ b/Livecheckables/libwps.rb
@@ -1,6 +1,6 @@
 class Libwps
   livecheck do
     url "https://sourceforge.net/projects/libwps/files/libwps/"
-    regex(%r{href=.*?libwps[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
+    regex(%r{href=.*?libwps(?:/|[._-])v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/libwps.rb
+++ b/Livecheckables/libwps.rb
@@ -1,6 +1,6 @@
 class Libwps
   livecheck do
     url "https://sourceforge.net/projects/libwps/files/libwps/"
-    regex(%r{href="/projects/libwps/files/libwps/libwps-([0-9.]+)/"})
+    regex(%r{href=.*?libwps[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
This PR updates `libwps`'s regex.

Changes:
* `href="` –> `href=.*?` and removal of leading path
* `/` matching –> `/?["' >]`
* `-` –> `[._-]` (delimiter between formula name and version)
* `v?` before version capturing group
* Version capturing group updated to current standard
* Case-insensitivity