### PR TITLE
remake: update regex

### DIFF
--- a/Livecheckables/remake.rb
+++ b/Livecheckables/remake.rb
@@ -1,6 +1,6 @@
 class Remake
   livecheck do
     url "https://sourceforge.net/projects/bashdb/files/remake/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+%2Bdbg[._-](?:\d+(?:\.\d+)+))/?["' >]}i)
+    regex(%r{href=.*?remake/v?(\d+(?:\.\d+)+(?:(?:%2Bdbg)?[._-]\d+(?:\.\d+)+)?)/?["' >]}i)
   end
 end

--- a/Livecheckables/remake.rb
+++ b/Livecheckables/remake.rb
@@ -1,6 +1,6 @@
 class Remake
   livecheck do
     url "https://sourceforge.net/projects/bashdb/files/remake/"
-    regex(%r{href="/projects/bashdb/files/remake/([0-9.+\-a-z%B]+)/"})
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+%2Bdbg[._-](?:\d+(?:\.\d+)+))/?["' >]}i)
   end
 end


### PR DESCRIPTION
This PR updates `remake`'s regex to conform to current standards. The regex probably needs changing: it's stricter than the previous one but matches the versioning format they've followed since 2009.

Until the `alterations` feature is out, the Livecheckable won't work as intended (and this is, most probably, a known issue).