### PR TITLE
vault: update regex

### DIFF
--- a/Livecheckables/vault.rb
+++ b/Livecheckables/vault.rb
@@ -1,6 +1,6 @@
 class Vault
   livecheck do
     url "https://releases.hashicorp.com/vault/"
-    regex(%r{href="/vault/(\d+(?:\.\d+)+)/})
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
This PR updates `vault`'s regex to conform to current standards. The leading path wasn't necessary for livecheck to work.