### PR TITLE
Use array instead of enumerator for watchlist

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -96,13 +96,9 @@ module Homebrew
       elsif !Homebrew.args.formulae.empty?
         Homebrew.args.formulae
       elsif File.exist?(WATCHLIST_PATH)
-        Enumerator.new do |enum|
-          File.open(WATCHLIST_PATH).each do |line|
-            next if line.start_with?("#")
-
-            line.split.each do |word|
-              enum.yield Formulary.factory(word)
-            end
+        begin
+          File.readlines(WATCHLIST_PATH).each_with_object([]) do |word, memo|
+            memo << Formulary.factory(word.chomp) unless word.start_with?("#")
           end
         rescue Errno::ENOENT => e
           onoe e


### PR DESCRIPTION
The `formulae_to_check` variable in `#livecheck` is usually an array of `Formula` objects or `nil`. However, when formulae are collected from the watchlist file, `formulae_to_check` is an `Enumerator` instead of an array.

This PR reworks the watchlist code to produce an array of formulae, like the other conditional blocks. Though this consistency is good in its own right, I specifically worked on this so that we'll be able to produce an error when `formulae_to_check` is empty (which we can't do with an `Enumerator`).