### PR TITLE
Add Xorg strategy

### DIFF
--- a/livecheck/livecheck_strategy/xorg.rb
+++ b/livecheck/livecheck_strategy/xorg.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "open-uri"
+
+module LivecheckStrategy
+  class Xorg
+    NAME = name.demodulize
+    NICE_NAME = "X.Org"
+
+    @page_data = {}
+
+    def self.match?(url)
+      %r{[./]x\.org.*?/individual/|freedesktop\.org/(?:archive|dist|software)/}i.match?(url)
+    end
+
+    def self.find_versions(url, regex)
+      file_name = File.basename(url)
+      return { :matches => {}, :regex => regex, :url => url } unless file_name.include?("-")
+
+      package_name = file_name.match(/^(.*)-\d+/)[1]
+
+      page_url = url.sub("x.org/pub/", "x.org/archive/").delete_suffix(file_name)
+      regex ||= /href=.*?#{package_name}[._-]v?(\d+(?:\.\d+)+)\.t/
+
+      match_data = { :matches => {}, :regex => regex, :url => page_url }
+
+      # Cache responses to avoid unnecessary duplicate fetches
+      @page_data[page_url] = URI.open(page_url).read unless @page_data.key?(page_url)
+
+      matches = @page_data[page_url].scan(regex)
+      matches.map(&:first).uniq.each do |match|
+        match_data[:matches][match] = Version.new(match)
+      end
+
+      match_data
+    end
+  end
+end


### PR DESCRIPTION
Some of the X.Org formulae from linuxbrew/xorg are being merged into homebrew-core in Homebrew/homebrew-core#57995. With this in mind, livecheck needs to handle the checks for these formulae. The linuxbrew/xorg tap has an `Xorg` strategy (created by Maxim) that's used on these formulae, so I'm incorporating it into livecheck as a built-in strategy.

The `Xorg` strategy wasn't quite working properly for all of the cases that I encountered, so I made some improvements:

* Modified the `match?` logic to only match URLs the strategy can use (we can expand this as needed)
* Reworked the way that the `package_name`, `page_url`, and `regex` are identified and generated, so it should be a little more reliable than the previous method
* Added support for caching page content, so we don't end up fetching the same index pages over and over (this also significantly speeds up the `Xorg` strategy for runs with more than one formula)

This works with all the applicable formulae in the linuxbrew/xorg tap, though we'll need to remove some broken `livecheck` blocks in those formulae to allow the `Xorg` strategy to properly work. I'll be updating these formulae after this PR is merged, as well as removing the `Xorg` strategy from that tap (so this one is used instead).