### PR TITLE
Change `href="` followed by path to `href=.*?`

### DIFF
--- a/Livecheckables/aescrypt-packetizer.rb
+++ b/Livecheckables/aescrypt-packetizer.rb
@@ -1,6 +1,6 @@
 class AescryptPacketizer
   livecheck do
     url "https://www.aescrypt.com/download/"
-    regex(%r{href="/download/v3/linux/aescrypt-([0-9,.]+)\.t})
+    regex(/href=.*?aescrypt-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/aescrypt-packetizer.rb
+++ b/Livecheckables/aescrypt-packetizer.rb
@@ -1,6 +1,6 @@
 class AescryptPacketizer
   livecheck do
     url "https://www.aescrypt.com/download/"
-    regex(/href=.*?aescrypt-([0-9,.]+)\.t/)
+    regex(%r{href=.*?/linux/aescrypt-([0-9,.]+)\.t})
   end
 end

--- a/Livecheckables/duck.rb
+++ b/Livecheckables/duck.rb
@@ -1,6 +1,6 @@
 class Duck
   livecheck do
     url "https://cyberduck.io/changelog/"
-    regex(%r{href=https://update.cyberduck.io/Cyberduck-([0-9,.]+)\.zip})
+    regex(/href=.*?Cyberduck-([0-9,.]+)\.zip/)
   end
 end

--- a/Livecheckables/dxflib.rb
+++ b/Livecheckables/dxflib.rb
@@ -1,6 +1,6 @@
 class Dxflib
   livecheck do
     url "https://www.ribbonsoft.com/en/dxflib-downloads"
-    regex(%r{href="/archives/dxflib/dxflib-([0-9.]+)-src\.t})
+    regex(/href=.*?dxflib-([0-9.]+)-src\.t/)
   end
 end

--- a/Livecheckables/gkrellm.rb
+++ b/Livecheckables/gkrellm.rb
@@ -1,6 +1,6 @@
 class Gkrellm
   livecheck do
-    url "http://gkrellm.srcbox.net/"
+    url "http://gkrellm.srcbox.net/releases/"
     regex(/href=.*?gkrellm-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/gkrellm.rb
+++ b/Livecheckables/gkrellm.rb
@@ -1,6 +1,6 @@
 class Gkrellm
   livecheck do
     url "http://gkrellm.srcbox.net/"
-    regex(%r{href="releases/gkrellm-([0-9,.]+)\.t})
+    regex(/href=.*?gkrellm-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/libav.rb
+++ b/Livecheckables/libav.rb
@@ -1,6 +1,6 @@
 class Libav
   livecheck do
     url :homepage
-    regex(%r{href="//libav.org/releases/libav-([0-9.]+)\.t})
+    regex(/href=.*?libav-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libav.rb
+++ b/Livecheckables/libav.rb
@@ -1,6 +1,6 @@
 class Libav
   livecheck do
-    url :homepage
+    url "https://libav.org/releases/"
     regex(/href=.*?libav-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/mednafen.rb
+++ b/Livecheckables/mednafen.rb
@@ -1,6 +1,6 @@
 class Mednafen
   livecheck do
     url "https://mednafen.github.io/releases/"
-    regex(%r{href="/releases/files/mednafen-([0-9.]+)\.t})
+    regex(/href=.*?mednafen-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/mupdf.rb
+++ b/Livecheckables/mupdf.rb
@@ -1,6 +1,6 @@
 class Mupdf
   livecheck do
     url "https://mupdf.com/downloads/"
-    regex(%r{href="archive/mupdf-([0-9.]+)-source})
+    regex(/href=.*?mupdf-([0-9.]+)-source\.t/)
   end
 end

--- a/Livecheckables/mupdf.rb
+++ b/Livecheckables/mupdf.rb
@@ -1,6 +1,6 @@
 class Mupdf
   livecheck do
-    url "https://mupdf.com/downloads/"
+    url "https://mupdf.com/downloads/archive/"
     regex(/href=.*?mupdf-([0-9.]+)-source\.t/)
   end
 end

--- a/Livecheckables/mysql-connector-c++.rb
+++ b/Livecheckables/mysql-connector-c++.rb
@@ -1,6 +1,6 @@
 class MysqlConnectorCxx
   livecheck do
     url :homepage
-    regex(%r{href="/downloads/gpg/\?file=mysql-connector-c%2B%2B-(\d+.\d+.\d+)-})
+    regex(/href=.*?mysql-connector-c%2B%2B-(\d+.\d+.\d+)-/)
   end
 end

--- a/Livecheckables/mysql.rb
+++ b/Livecheckables/mysql.rb
@@ -1,6 +1,6 @@
 class Mysql
   livecheck do
     url "https://dev.mysql.com/downloads/mysql/"
-    regex(%r{href="/downloads/gpg/\?file=mysql-(\d+.\d+.\d+)-})
+    regex(/href=.*?mysql-(\d+.\d+.\d+)-/)
   end
 end

--- a/Livecheckables/mysql@5.6.rb
+++ b/Livecheckables/mysql@5.6.rb
@@ -1,6 +1,6 @@
 class MysqlAT56
   livecheck do
     url "https://dev.mysql.com/downloads/mysql/5.6.html"
-    regex(%r{href="/downloads/gpg/\?file=mysql-(\d+.\d+.\d+)-})
+    regex(/href=.*?mysql-(\d+.\d+.\d+)-/)
   end
 end

--- a/Livecheckables/mysql@5.7.rb
+++ b/Livecheckables/mysql@5.7.rb
@@ -1,6 +1,6 @@
 class MysqlAT57
   livecheck do
     url "https://dev.mysql.com/downloads/mysql/5.7.html"
-    regex(%r{href="/downloads/gpg/\?file=mysql-(\d+.\d+.\d+)-})
+    regex(/href=.*?mysql-(\d+.\d+.\d+)-/)
   end
 end

--- a/Livecheckables/packetq.rb
+++ b/Livecheckables/packetq.rb
@@ -1,6 +1,6 @@
 class Packetq
   livecheck do
     url :homepage
-    regex(%r{href="/files/packetq/packetq-([0-9,.]+)\.t})
+    regex(/href=.*?packetq-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/unp64.rb
+++ b/Livecheckables/unp64.rb
@@ -1,6 +1,6 @@
 class Unp64
   livecheck do
     url :homepage
-    regex(%r{href="C/unp64.*?UNP64 ([0-9.]+) -})
+    regex(/href=.*?unp64.*?UNP64 ([0-9.]+) -/)
   end
 end

--- a/Livecheckables/unrar.rb
+++ b/Livecheckables/unrar.rb
@@ -1,6 +1,6 @@
 class Unrar
   livecheck do
     url "https://www.rarlab.com/rar_add.htm"
-    regex(%r{href="rar/unrarsrc-([0-9,.]+)\.t})
+    regex(/href=.*?unrarsrc-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/varnish.rb
+++ b/Livecheckables/varnish.rb
@@ -1,6 +1,6 @@
 class Varnish
   livecheck do
     url "https://varnish-cache.org/releases/"
-    regex(%r{href="\.\./_downloads/varnish-([0-9,.]+)\.t})
+    regex(/href=.*?varnish-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/xrootd.rb
+++ b/Livecheckables/xrootd.rb
@@ -1,6 +1,6 @@
 class Xrootd
   livecheck do
     url "http://xrootd.org/dload.html"
-    regex(%r{href="/download/.*/xrootd-([0-9,.]+)\.t})
+    regex(/href=".*?xrootd-([0-9,.]+)\.t/)
   end
 end


### PR DESCRIPTION
This PR changes `href="` when followed by a path to `href=.*?`.

Extra attention is to be paid to the `mysql` family of Livecheckables, and `unp64` – due to the lack of alternative solutions which I felt would be apt (w.r.t matching a `.t` or something at the end).