### PR TITLE
Change `href=".*?/` to `href=.*?`

### DIFF
--- a/Livecheckables/aircrack-ng.rb
+++ b/Livecheckables/aircrack-ng.rb
@@ -1,6 +1,6 @@
 class AircrackNg
   livecheck do
     url :homepage
-    regex(%r{href=".*?/aircrack-ng-([0-9.]+)\.t})
+    regex(/href=.*?aircrack-ng-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ansible-lint.rb
+++ b/Livecheckables/ansible-lint.rb
@@ -1,6 +1,6 @@
 class AnsibleLint
   livecheck do
     url "https://pypi.org/simple/ansible-lint/"
-    regex(%r{href=".*?/ansible-lint-([0-9.]+)\.t})
+    regex(/href=.*?ansible-lint-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ansible-lint.rb
+++ b/Livecheckables/ansible-lint.rb
@@ -1,6 +1,6 @@
 class AnsibleLint
   livecheck do
-    url "https://pypi.org/simple/ansible-lint/"
+    url :stable
     regex(/href=.*?ansible-lint-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/archivemount.rb
+++ b/Livecheckables/archivemount.rb
@@ -1,6 +1,6 @@
 class Archivemount
   livecheck do
     url :homepage
-    regex(%r{href=".*?/archivemount-([0-9.]+)\.t})
+    regex(/href=.*?archivemount-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/aws-elasticbeanstalk.rb
+++ b/Livecheckables/aws-elasticbeanstalk.rb
@@ -1,6 +1,6 @@
 class AwsElasticbeanstalk
   livecheck do
-    url "https://pypi.org/simple/awsebcli/"
+    url :stable
     regex(/href=.*?awsebcli-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/aws-elasticbeanstalk.rb
+++ b/Livecheckables/aws-elasticbeanstalk.rb
@@ -1,6 +1,6 @@
 class AwsElasticbeanstalk
   livecheck do
     url "https://pypi.org/simple/awsebcli/"
-    regex(%r{href=".*?/awsebcli-([0-9.]+)\.t})
+    regex(/href=.*?awsebcli-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/batik.rb
+++ b/Livecheckables/batik.rb
@@ -1,6 +1,6 @@
 class Batik
   livecheck do
     url "https://xmlgraphics.apache.org/batik/download.html"
-    regex(%r{href=".*?/batik-bin-([0-9.]+)\.t})
+    regex(/href=.*?batik-bin-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/bzt.rb
+++ b/Livecheckables/bzt.rb
@@ -1,6 +1,6 @@
 class Bzt
   livecheck do
-    url "https://pypi.org/simple/bzt/"
+    url :stable
     regex(/href=.*?bzt-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/bzt.rb
+++ b/Livecheckables/bzt.rb
@@ -1,6 +1,6 @@
 class Bzt
   livecheck do
     url "https://pypi.org/simple/bzt/"
-    regex(%r{href=".*?/bzt-([0-9.]+)\.t})
+    regex(/href=.*?bzt-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/charm-tools.rb
+++ b/Livecheckables/charm-tools.rb
@@ -1,6 +1,6 @@
 class CharmTools
   livecheck do
-    url "https://pypi.org/simple/charm-tools/"
+    url :stable
     regex(/href=.*?charm-tools-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/charm-tools.rb
+++ b/Livecheckables/charm-tools.rb
@@ -1,6 +1,6 @@
 class CharmTools
   livecheck do
     url "https://pypi.org/simple/charm-tools/"
-    regex(%r{href=".*?/charm-tools-([0-9.]+)\.t})
+    regex(/href=.*?charm-tools-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/clamav.rb
+++ b/Livecheckables/clamav.rb
@@ -1,6 +1,6 @@
 class Clamav
   livecheck do
     url "https://www.clamav.net/downloads"
-    regex(%r{href=".*?/clamav-([0-9.]+)\.t})
+    regex(/href=.*?clamav-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/codemod.rb
+++ b/Livecheckables/codemod.rb
@@ -1,6 +1,6 @@
 class Codemod
   livecheck do
     url "https://pypi.org/simple/codemod/"
-    regex(%r{href=".*?/codemod-([0-9.]+)\.t})
+    regex(/href=.*?codemod-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/codemod.rb
+++ b/Livecheckables/codemod.rb
@@ -1,6 +1,6 @@
 class Codemod
   livecheck do
-    url "https://pypi.org/simple/codemod/"
+    url :stable
     regex(/href=.*?codemod-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/csvkit.rb
+++ b/Livecheckables/csvkit.rb
@@ -1,6 +1,6 @@
 class Csvkit
   livecheck do
-    url "https://pypi.org/simple/csvkit/"
+    url :stable
     regex(/href=.*?csvkit-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/csvkit.rb
+++ b/Livecheckables/csvkit.rb
@@ -1,6 +1,6 @@
 class Csvkit
   livecheck do
     url "https://pypi.org/simple/csvkit/"
-    regex(%r{href=".*?/csvkit-([0-9.]+)\.t})
+    regex(/href=.*?csvkit-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/cython.rb
+++ b/Livecheckables/cython.rb
@@ -1,6 +1,6 @@
 class Cython
   livecheck do
     url "https://pypi.org/simple/cython/"
-    regex(%r{href=".*?/Cython-([0-9.]+)\.t})
+    regex(/href=.*?Cython-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/cython.rb
+++ b/Livecheckables/cython.rb
@@ -1,6 +1,6 @@
 class Cython
   livecheck do
-    url "https://pypi.org/simple/cython/"
+    url :stable
     regex(/href=.*?Cython-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/deark.rb
+++ b/Livecheckables/deark.rb
@@ -1,6 +1,6 @@
 class Deark
   livecheck do
     url :homepage
-    regex(%r{href=".*?/deark-([0-9.]+)\.t})
+    regex(/href=.*?deark-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/deark.rb
+++ b/Livecheckables/deark.rb
@@ -1,6 +1,6 @@
 class Deark
   livecheck do
-    url :homepage
+    url "https://entropymine.com/deark/releases/"
     regex(/href=.*?deark-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/doitlive.rb
+++ b/Livecheckables/doitlive.rb
@@ -1,6 +1,6 @@
 class Doitlive
   livecheck do
     url "https://pypi.org/simple/doitlive/"
-    regex(%r{href=".*?/doitlive-([0-9.]+)\.t})
+    regex(/href=.*?doitlive-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/doitlive.rb
+++ b/Livecheckables/doitlive.rb
@@ -1,6 +1,6 @@
 class Doitlive
   livecheck do
-    url "https://pypi.org/simple/doitlive/"
+    url :stable
     regex(/href=.*?doitlive-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/dxpy.rb
+++ b/Livecheckables/dxpy.rb
@@ -1,6 +1,6 @@
 class Dxpy
   livecheck do
-    url "https://pypi.org/simple/dxpy/"
+    url :stable
     regex(/href=.*?dxpy-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/dxpy.rb
+++ b/Livecheckables/dxpy.rb
@@ -1,6 +1,6 @@
 class Dxpy
   livecheck do
     url "https://pypi.org/simple/dxpy/"
-    regex(%r{href=".*?/dxpy-([0-9.]+)\.t})
+    regex(/href=.*?dxpy-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/eccodes.rb
+++ b/Livecheckables/eccodes.rb
@@ -1,6 +1,6 @@
 class Eccodes
   livecheck do
     url "https://software.ecmwf.int/wiki/display/ECC/Releases"
-    regex(%r{href=".*?/eccodes-([0-9.]+)-Source\.t})
+    regex(/href=.*?eccodes-([0-9.]+)-Source\.t/)
   end
 end

--- a/Livecheckables/exomizer.rb
+++ b/Livecheckables/exomizer.rb
@@ -1,6 +1,6 @@
 class Exomizer
   livecheck do
     url "https://bitbucket.org/magli143/exomizer/wiki/browse/downloads/"
-    regex(%r{href=".*?/exomizer-([0-9.]+)\.zip})
+    regex(/href=.*?exomizer-([0-9.]+)\.zip/)
   end
 end

--- a/Livecheckables/geeqie.rb
+++ b/Livecheckables/geeqie.rb
@@ -1,6 +1,6 @@
 class Geeqie
   livecheck do
     url :homepage
-    regex(%r{href=".*?/geeqie-([0-9.]+)\.t})
+    regex(/href=.*?geeqie-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/haxe.rb
+++ b/Livecheckables/haxe.rb
@@ -1,6 +1,6 @@
 class Haxe
   livecheck do
-    url "https://haxe.org/download/"
-    regex(/href=.*?haxe-([0-9.]+)-/)
+    url "https://github.com/HaxeFoundation/haxe/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/haxe.rb
+++ b/Livecheckables/haxe.rb
@@ -1,6 +1,6 @@
 class Haxe
   livecheck do
     url "https://haxe.org/download/"
-    regex(%r{href=".*?/haxe-([0-9.]+)-})
+    regex(/href=.*?haxe-([0-9.]+)-/)
   end
 end

--- a/Livecheckables/hercules.rb
+++ b/Livecheckables/hercules.rb
@@ -1,6 +1,6 @@
 class Hercules
   livecheck do
     url :homepage
-    regex(%r{href=".*?/hercules-([0-9.]+)\.t})
+    regex(/href=.*?hercules-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ii.rb
+++ b/Livecheckables/ii.rb
@@ -1,6 +1,6 @@
 class Ii
   livecheck do
-    url :homepage
+    url "https://dl.suckless.org/tools/"
     regex(/href=.*?ii-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ii.rb
+++ b/Livecheckables/ii.rb
@@ -1,6 +1,6 @@
 class Ii
   livecheck do
     url :homepage
-    regex(%r{href=".*?/ii-([0-9.]+)\.t})
+    regex(/href=.*?ii-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/jansson.rb
+++ b/Livecheckables/jansson.rb
@@ -1,6 +1,6 @@
 class Jansson
   livecheck do
-    url "http://www.digip.org/jansson/"
+    url "https://digip.org/jansson/releases/"
     regex(/href=.*?jansson-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/jansson.rb
+++ b/Livecheckables/jansson.rb
@@ -1,6 +1,6 @@
 class Jansson
   livecheck do
     url "http://www.digip.org/jansson/"
-    regex(%r{href=".*?/jansson-([0-9.]+)\.t})
+    regex(/href=.*?jansson-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/jenkins-job-builder.rb
+++ b/Livecheckables/jenkins-job-builder.rb
@@ -1,6 +1,6 @@
 class JenkinsJobBuilder
   livecheck do
     url "https://pypi.org/simple/jenkins-job-builder/"
-    regex(%r{href=".*?/jenkins-job-builder-([0-9.]+)\.t})
+    regex(/href=.*?jenkins-job-builder-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/jenkins-job-builder.rb
+++ b/Livecheckables/jenkins-job-builder.rb
@@ -1,6 +1,6 @@
 class JenkinsJobBuilder
   livecheck do
-    url "https://pypi.org/simple/jenkins-job-builder/"
+    url :stable
     regex(/href=.*?jenkins-job-builder-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/jetty-runner.rb
+++ b/Livecheckables/jetty-runner.rb
@@ -1,6 +1,6 @@
 class JettyRunner
   livecheck do
     url "https://www.eclipse.org/jetty/download.html"
-    regex(/href=.*?jetty-distribution-([0-9.v]+)\.t/)
+    regex(/href=.*?jetty-distribution[._-]v?(\d+(?:\.\d+)+(?:\.v\d+)?)\.t/i)
   end
 end

--- a/Livecheckables/jetty-runner.rb
+++ b/Livecheckables/jetty-runner.rb
@@ -1,6 +1,6 @@
 class JettyRunner
   livecheck do
     url "https://www.eclipse.org/jetty/download.html"
-    regex(%r{href=".*?/jetty-distribution-([0-9.v]+)\.t})
+    regex(/href=.*?jetty-distribution-([0-9.v]+)\.t/)
   end
 end

--- a/Livecheckables/jetty.rb
+++ b/Livecheckables/jetty.rb
@@ -1,6 +1,6 @@
 class Jetty
   livecheck do
     url "https://www.eclipse.org/jetty/download.html"
-    regex(/href=.*?jetty-distribution-([0-9.v]+)\.t/)
+    regex(/href=.*?jetty-distribution[._-]v?(\d+(?:\.\d+)+(?:\.v\d+)?)\.t/i)
   end
 end

--- a/Livecheckables/jetty.rb
+++ b/Livecheckables/jetty.rb
@@ -1,6 +1,6 @@
 class Jetty
   livecheck do
     url "https://www.eclipse.org/jetty/download.html"
-    regex(%r{href=".*?/jetty-distribution-([0-9.v]+)\.t})
+    regex(/href=.*?jetty-distribution-([0-9.v]+)\.t/)
   end
 end

--- a/Livecheckables/keepassc.rb
+++ b/Livecheckables/keepassc.rb
@@ -1,6 +1,6 @@
 class Keepassc
   livecheck do
     url "https://pypi.org/simple/keepassc/"
-    regex(%r{href=".*?/keepassc-([0-9.]+)\.t})
+    regex(/href=.*?keepassc-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/keepassc.rb
+++ b/Livecheckables/keepassc.rb
@@ -1,6 +1,6 @@
 class Keepassc
   livecheck do
-    url "https://pypi.org/simple/keepassc/"
+    url :stable
     regex(/href=.*?keepassc-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/keepkey-agent.rb
+++ b/Livecheckables/keepkey-agent.rb
@@ -1,6 +1,6 @@
 class KeepkeyAgent
   livecheck do
-    url "https://pypi.org/simple/keepkey_agent/"
+    url :stable
     regex(/href=.*?keepkey_agent-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/keepkey-agent.rb
+++ b/Livecheckables/keepkey-agent.rb
@@ -1,6 +1,6 @@
 class KeepkeyAgent
   livecheck do
     url "https://pypi.org/simple/keepkey_agent/"
-    regex(%r{href=".*?/keepkey_agent-([0-9.]+)\.t})
+    regex(/href=.*?keepkey_agent-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libgsm.rb
+++ b/Livecheckables/libgsm.rb
@@ -1,6 +1,6 @@
 class Libgsm
   livecheck do
     url :homepage
-    regex(%r{href=".*?/gsm-([0-9.]+)\.t})
+    regex(/href=.*?gsm-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/libhdhomerun.rb
+++ b/Livecheckables/libhdhomerun.rb
@@ -1,6 +1,6 @@
 class Libhdhomerun
   livecheck do
     url :homepage
-    regex(%r{href=".*?/libhdhomerun_([0-9]+)\.t})
+    regex(/href=.*?libhdhomerun_([0-9]+)\.t/)
   end
 end

--- a/Livecheckables/liblwgeom.rb
+++ b/Livecheckables/liblwgeom.rb
@@ -1,6 +1,6 @@
 class Liblwgeom
   livecheck do
-    url "https://postgis.net/source/"
+    url "https://download.osgeo.org/postgis/source/"
     regex(/href=.*?postgis-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/liblwgeom.rb
+++ b/Livecheckables/liblwgeom.rb
@@ -1,6 +1,6 @@
 class Liblwgeom
   livecheck do
     url "https://postgis.net/source/"
-    regex(%r{href=".*?/postgis-([0-9.]+)\.t})
+    regex(/href=.*?postgis-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/link-grammar.rb
+++ b/Livecheckables/link-grammar.rb
@@ -1,6 +1,6 @@
 class LinkGrammar
   livecheck do
     url :homepage
-    regex(%r{href=".*?/link-grammar-([0-9.]+)\.t})
+    regex(/href=.*?link-grammar-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/lwtools.rb
+++ b/Livecheckables/lwtools.rb
@@ -1,6 +1,6 @@
 class Lwtools
   livecheck do
-    url :homepage
+    url "http://www.lwtools.ca/releases/lwtools/"
     regex(/href=.*?lwtools-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/lwtools.rb
+++ b/Livecheckables/lwtools.rb
@@ -1,6 +1,6 @@
 class Lwtools
   livecheck do
     url :homepage
-    regex(%r{href=".*?/lwtools-([0-9.]+)\.t})
+    regex(/href=.*?lwtools-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ocaml-findlib.rb
+++ b/Livecheckables/ocaml-findlib.rb
@@ -1,6 +1,6 @@
 class OcamlFindlib
   livecheck do
     url :homepage
-    regex(%r{href=".*?/findlib-([0-9.]+)\.t})
+    regex(/href=.*?findlib-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ocaml-findlib.rb
+++ b/Livecheckables/ocaml-findlib.rb
@@ -1,6 +1,6 @@
 class OcamlFindlib
   livecheck do
-    url :homepage
+    url "http://download.camlcity.org/download/"
     regex(/href=.*?findlib-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ocrmypdf.rb
+++ b/Livecheckables/ocrmypdf.rb
@@ -1,6 +1,6 @@
 class Ocrmypdf
   livecheck do
     url "https://pypi.org/simple/ocrmypdf/"
-    regex(%r{href=".*?/ocrmypdf-([0-9.]+)\.t})
+    regex(/href=.*?ocrmypdf-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ocrmypdf.rb
+++ b/Livecheckables/ocrmypdf.rb
@@ -1,6 +1,6 @@
 class Ocrmypdf
   livecheck do
-    url "https://pypi.org/simple/ocrmypdf/"
+    url :stable
     regex(/href=.*?ocrmypdf-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/openvpn.rb
+++ b/Livecheckables/openvpn.rb
@@ -1,6 +1,6 @@
 class Openvpn
   livecheck do
     url :homepage
-    regex(%r{href=".*?/openvpn-([0-9.]+)\.t})
+    regex(/href=.*?openvpn-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/petsc.rb
+++ b/Livecheckables/petsc.rb
@@ -1,6 +1,6 @@
 class Petsc
   livecheck do
     url "https://www.mcs.anl.gov/petsc/download/index.html"
-    regex(%r{href=".*?/petsc-lite-([0-9.]+)\.t})
+    regex(/href=.*?petsc-lite-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/phpunit.rb
+++ b/Livecheckables/phpunit.rb
@@ -1,6 +1,6 @@
 class Phpunit
   livecheck do
     url "https://phar.phpunit.de/"
-    regex(%r{href=".*?/phpunit-([0-9.]+)\.phar})
+    regex(/href=.*?phpunit-([0-9.]+)\.phar/)
   end
 end

--- a/Livecheckables/pike.rb
+++ b/Livecheckables/pike.rb
@@ -1,6 +1,6 @@
 class Pike
   livecheck do
-    url :homepage
+    url "https://pike.lysator.liu.se/download/pub/pike/latest-stable/"
     regex(/href=.*?Pike-v([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/pike.rb
+++ b/Livecheckables/pike.rb
@@ -1,6 +1,6 @@
 class Pike
   livecheck do
     url :homepage
-    regex(%r{href=".*?/latest-stable/Pike-v([0-9.]+)\.t})
+    regex(/href=.*?Pike-v([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/pod2man.rb
+++ b/Livecheckables/pod2man.rb
@@ -1,6 +1,6 @@
 class Pod2man
   livecheck do
-    url :homepage
+    url "https://archives.eyrie.org/software/perl/"
     regex(/href=.*?podlators-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/pod2man.rb
+++ b/Livecheckables/pod2man.rb
@@ -1,6 +1,6 @@
 class Pod2man
   livecheck do
     url :homepage
-    regex(%r{href=".*?/podlators-([0-9.]+)\.t})
+    regex(/href=.*?podlators-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/postgis.rb
+++ b/Livecheckables/postgis.rb
@@ -1,6 +1,6 @@
 class Postgis
   livecheck do
     url "https://postgis.net/source/"
-    regex(%r{href=".*?/postgis-([0-9.]+)\.t})
+    regex(/href=.*?postgis-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/postgis.rb
+++ b/Livecheckables/postgis.rb
@@ -1,6 +1,6 @@
 class Postgis
   livecheck do
-    url "https://postgis.net/source/"
+    url "https://download.osgeo.org/postgis/source/"
     regex(/href=.*?postgis-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/psqlodbc.rb
+++ b/Livecheckables/psqlodbc.rb
@@ -1,6 +1,6 @@
 class Psqlodbc
   livecheck do
-    url "https://www.postgresql.org/ftp/odbc/versions/src/"
+    url "https://ftp.postgresql.org/pub/odbc/versions/src/"
     regex(/href=.*?psqlodbc-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/psqlodbc.rb
+++ b/Livecheckables/psqlodbc.rb
@@ -1,6 +1,6 @@
 class Psqlodbc
   livecheck do
     url "https://www.postgresql.org/ftp/odbc/versions/src/"
-    regex(%r{href=".*?/psqlodbc-([0-9.]+)\.t})
+    regex(/href=.*?psqlodbc-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/ptex.rb
+++ b/Livecheckables/ptex.rb
@@ -1,6 +1,6 @@
 class Ptex
   livecheck do
-    url "http://ptex.us/download.html"
-    regex(/href=.*?v([0-9.]+)\.zip/)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/ptex.rb
+++ b/Livecheckables/ptex.rb
@@ -1,6 +1,6 @@
 class Ptex
   livecheck do
     url "http://ptex.us/download.html"
-    regex(%r{href=".*?/v([0-9.]+)\.zip})
+    regex(/href=.*?v([0-9.]+)\.zip/)
   end
 end

--- a/Livecheckables/qd.rb
+++ b/Livecheckables/qd.rb
@@ -1,6 +1,6 @@
 class Qd
   livecheck do
     url "https://www.davidhbailey.com/dhbsoftware/"
-    regex(%r{href=".*?/qd-([0-9.]+)\.t})
+    regex(/href=.*?qd-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/qd.rb
+++ b/Livecheckables/qd.rb
@@ -1,6 +1,6 @@
 class Qd
   livecheck do
-    url "https://www.davidhbailey.com/dhbsoftware/"
+    url :homepage
     regex(/href=.*?qd-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/qsoas.rb
+++ b/Livecheckables/qsoas.rb
@@ -1,6 +1,6 @@
 class Qsoas
   livecheck do
     url "http://bip.cnrs-mrs.fr/bip06/qsoas/downloads.html"
-    regex(%r{href=".*?/qsoas-([0-9.]+)\.t})
+    regex(/href=.*?qsoas-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/recoverjpeg.rb
+++ b/Livecheckables/recoverjpeg.rb
@@ -1,6 +1,6 @@
 class Recoverjpeg
   livecheck do
     url "https://rfc1149.net/devel/recoverjpeg.html"
-    regex(%r{href=".*?/recoverjpeg-([0-9.]+)\.t})
+    regex(/href=.*?recoverjpeg-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/recoverjpeg.rb
+++ b/Livecheckables/recoverjpeg.rb
@@ -1,6 +1,6 @@
 class Recoverjpeg
   livecheck do
-    url "https://rfc1149.net/devel/recoverjpeg.html"
+    url "https://rfc1149.net/download/recoverjpeg/"
     regex(/href=.*?recoverjpeg-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/remctl.rb
+++ b/Livecheckables/remctl.rb
@@ -1,6 +1,6 @@
 class Remctl
   livecheck do
-    url :homepage
+    url "https://archives.eyrie.org/software/kerberos/"
     regex(/href=.*?remctl-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/remctl.rb
+++ b/Livecheckables/remctl.rb
@@ -1,6 +1,6 @@
 class Remctl
   livecheck do
     url :homepage
-    regex(%r{href=".*?/remctl-([0-9.]+)\.t})
+    regex(/href=.*?remctl-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/scummvm-tools.rb
+++ b/Livecheckables/scummvm-tools.rb
@@ -1,6 +1,6 @@
 class ScummvmTools
   livecheck do
     url "https://www.scummvm.org/downloads/"
-    regex(%r{href=".*?/scummvm-tools-([0-9.]+)\.t})
+    regex(/href=.*?scummvm-tools-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/snort.rb
+++ b/Livecheckables/snort.rb
@@ -1,6 +1,6 @@
 class Snort
   livecheck do
     url "https://www.snort.org/downloads"
-    regex(%r{href=".*?/snort-([0-9.]+)\.t})
+    regex(/href=.*?snort-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/spring-roo.rb
+++ b/Livecheckables/spring-roo.rb
@@ -1,6 +1,6 @@
 class SpringRoo
   livecheck do
     url :homepage
-    regex(%r{href=".*?/spring-roo-([0-9.]+)\.RELEASE\.zip})
+    regex(/href=.*?spring-roo-([0-9.]+)\.RELEASE\.zip/)
   end
 end

--- a/Livecheckables/stunnel.rb
+++ b/Livecheckables/stunnel.rb
@@ -1,6 +1,6 @@
 class Stunnel
   livecheck do
     url "https://www.stunnel.org/downloads.html"
-    regex(%r{href=".*?/stunnel-([0-9.]+)\.t})
+    regex(/href=.*?stunnel-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/sundials.rb
+++ b/Livecheckables/sundials.rb
@@ -1,6 +1,6 @@
 class Sundials
   livecheck do
     url "https://computation.llnl.gov/projects/sundials/sundials-software"
-    regex(%r{href=".*?/sundials-([0-9.]+)\.t})
+    regex(/href=.*?sundials-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/systemc.rb
+++ b/Livecheckables/systemc.rb
@@ -1,6 +1,6 @@
 class Systemc
   livecheck do
     url "https://www.accellera.org/downloads/standards/systemc"
-    regex(%r{href=".*?/systemc-([0-9.]+)\.t})
+    regex(/href=.*?systemc-([0-9.]+)\.t/)
   end
 end

--- a/Livecheckables/vsts-cli.rb
+++ b/Livecheckables/vsts-cli.rb
@@ -1,6 +1,6 @@
 class VstsCli
   livecheck do
     url "https://pypi.org/simple/vsts-cli/"
-    regex(%r{href=".*?/vsts-cli-([0-9a-z.]+)\.t})
+    regex(/href=.*?vsts-cli-([0-9a-z.]+)\.t/)
   end
 end

--- a/Livecheckables/vsts-cli.rb
+++ b/Livecheckables/vsts-cli.rb
@@ -1,6 +1,6 @@
 class VstsCli
   livecheck do
-    url "https://pypi.org/simple/vsts-cli/"
+    url :stable
     regex(/href=.*?vsts-cli-([0-9a-z.]+)\.t/)
   end
 end

--- a/Livecheckables/wandio.rb
+++ b/Livecheckables/wandio.rb
@@ -1,6 +1,6 @@
 class Wandio
   livecheck do
     url :homepage
-    regex(%r{href=".*?/wandio-([0-9.]+)\.t})
+    regex(/href=.*?wandio-([0-9.]+)\.t/)
   end
 end


### PR DESCRIPTION
This PR changes `href=".*?/` to `href=.*?`. It turns out the `/` (leading) wasn't required in any of the regexes, which I verified by comparing pre- and post-change debug outputs.