### PR TITLE
Change `url=.+?` to `url=.*?`

### DIFF
--- a/Livecheckables/ant-contrib.rb
+++ b/Livecheckables/ant-contrib.rb
@@ -1,6 +1,6 @@
 class AntContrib
   livecheck do
     url :stable
-    regex(%r{url=.+?/ant-contrib-v?(\d+(?:\.\d+)+(?:[a-z]\d+)?)-bin\.t}i)
+    regex(%r{url=.*?/ant-contrib-v?(\d+(?:\.\d+)+(?:[a-z]\d+)?)-bin\.t}i)
   end
 end

--- a/Livecheckables/apcupsd.rb
+++ b/Livecheckables/apcupsd.rb
@@ -1,6 +1,6 @@
 class Apcupsd
   livecheck do
     url :stable
-    regex(%r{url=.+?/apcupsd%20-%20Stable/[^/]+/apcupsd-v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/apcupsd%20-%20Stable/[^/]+/apcupsd-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/armadillo.rb
+++ b/Livecheckables/armadillo.rb
@@ -1,6 +1,6 @@
 class Armadillo
   livecheck do
     url :stable
-    regex(%r{url=.+?/armadillo-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/armadillo-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/asymptote.rb
+++ b/Livecheckables/asymptote.rb
@@ -1,6 +1,6 @@
 class Asymptote
   livecheck do
     url :stable
-    regex(%r{url=.+?/asymptote-v?(\d+(?:\.\d+)+)\.src\.t})
+    regex(%r{url=.*?/asymptote-v?(\d+(?:\.\d+)+)\.src\.t})
   end
 end

--- a/Livecheckables/automysqlbackup.rb
+++ b/Livecheckables/automysqlbackup.rb
@@ -1,6 +1,6 @@
 class Automysqlbackup
   livecheck do
     url :stable
-    regex(%r{url=.+?/automysqlbackup-v?(\d+(?:\.\d+)+(?:.rc\d+)?)\.t}i)
+    regex(%r{url=.*?/automysqlbackup-v?(\d+(?:\.\d+)+(?:.rc\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/avfs.rb
+++ b/Livecheckables/avfs.rb
@@ -1,6 +1,6 @@
 class Avfs
   livecheck do
     url "https://sourceforge.net/projects/avf/rss"
-    regex(%r{url=.+?/avfs-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/avfs-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/aview.rb
+++ b/Livecheckables/aview.rb
@@ -1,6 +1,6 @@
 class Aview
   livecheck do
     url "https://sourceforge.net/projects/aa-project/rss"
-    regex(%r{url=.+?/aview-v?(\d+(?:\.\d+)+(?:[a-z]+\d*)?)\.t})
+    regex(%r{url=.*?/aview-v?(\d+(?:\.\d+)+(?:[a-z]+\d*)?)\.t})
   end
 end

--- a/Livecheckables/camellia.rb
+++ b/Livecheckables/camellia.rb
@@ -1,6 +1,6 @@
 class Camellia
   livecheck do
     url :stable
-    regex(%r{url=.+?/CamelliaLib-v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/CamelliaLib-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/cdrtools.rb
+++ b/Livecheckables/cdrtools.rb
@@ -1,6 +1,6 @@
 class Cdrtools
   livecheck do
     url :stable
-    regex(%r{url=.+?/cdrtools-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/cdrtools-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/chadwick.rb
+++ b/Livecheckables/chadwick.rb
@@ -1,6 +1,6 @@
 class Chadwick
   livecheck do
     url :stable
-    regex(%r{url=.+?/chadwick-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/chadwick-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/chordii.rb
+++ b/Livecheckables/chordii.rb
@@ -1,6 +1,6 @@
 class Chordii
   livecheck do
     url :stable
-    regex(%r{url=.+?/chordii-v?(\d+(?:\.\d+)+[a-z]?)\.t})
+    regex(%r{url=.*?/chordii-v?(\d+(?:\.\d+)+[a-z]?)\.t})
   end
 end

--- a/Livecheckables/cmu-pocketsphinx.rb
+++ b/Livecheckables/cmu-pocketsphinx.rb
@@ -1,6 +1,6 @@
 class CmuPocketsphinx
   livecheck do
     url :stable
-    regex(%r{url=.+?/pocketsphinx-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/pocketsphinx-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/cmu-sphinxbase.rb
+++ b/Livecheckables/cmu-sphinxbase.rb
@@ -1,6 +1,6 @@
 class CmuSphinxbase
   livecheck do
     url :stable
-    regex(%r{url=.+?/sphinxbase-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/sphinxbase-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/cntlm.rb
+++ b/Livecheckables/cntlm.rb
@@ -1,6 +1,6 @@
 class Cntlm
   livecheck do
     url :stable
-    regex(%r{url=.+?/cntlm-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/cntlm-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/cppcms.rb
+++ b/Livecheckables/cppcms.rb
@@ -1,6 +1,6 @@
 class Cppcms
   livecheck do
     url :stable
-    regex(%r{url=.+?/cppcms-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/cppcms-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/dex2jar.rb
+++ b/Livecheckables/dex2jar.rb
@@ -1,6 +1,6 @@
 class Dex2jar
   livecheck do
     url :stable
-    regex(%r{url=.+?/dex2jar-v?(\d+(?:\.\d+)+)\.(?:t|z)})
+    regex(%r{url=.*?/dex2jar-v?(\d+(?:\.\d+)+)\.(?:t|z)})
   end
 end

--- a/Livecheckables/dfu-programmer.rb
+++ b/Livecheckables/dfu-programmer.rb
@@ -1,6 +1,6 @@
 class DfuProgrammer
   livecheck do
     url "https://sourceforge.net/projects/dfu-programmer/rss"
-    regex(%r{url=.+?/dfu-programmer-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/dfu-programmer-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/djview4.rb
+++ b/Livecheckables/djview4.rb
@@ -1,6 +1,6 @@
 class Djview4
   livecheck do
     url :stable
-    regex(%r{url=.+?/djview-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/djview-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/docbook2x.rb
+++ b/Livecheckables/docbook2x.rb
@@ -1,6 +1,6 @@
 class Docbook2x
   livecheck do
     url "https://sourceforge.net/projects/docbook2x/rss"
-    regex(%r{url=.+?/docbook2X-v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/docbook2X-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/espeak.rb
+++ b/Livecheckables/espeak.rb
@@ -1,6 +1,6 @@
 class Espeak
   livecheck do
     url :stable
-    regex(%r{url=.+?/espeak-v?(\d+(?:\.\d+)+)(?:-source)?\.(?:t|z)}i)
+    regex(%r{url=.*?/espeak-v?(\d+(?:\.\d+)+)(?:-source)?\.(?:t|z)}i)
   end
 end

--- a/Livecheckables/etl.rb
+++ b/Livecheckables/etl.rb
@@ -1,6 +1,6 @@
 class Etl
   livecheck do
     url :stable
-    regex(%r{url=.+?/releases/.+?/ETL-v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/releases/.+?/ETL-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/ex-vi.rb
+++ b/Livecheckables/ex-vi.rb
@@ -1,6 +1,6 @@
 class ExVi
   livecheck do
     url :stable
-    regex(%r{url=.+?/ex-v?(\d+)\.t}i)
+    regex(%r{url=.*?/ex-v?(\d+)\.t}i)
   end
 end

--- a/Livecheckables/expect.rb
+++ b/Livecheckables/expect.rb
@@ -1,6 +1,6 @@
 class Expect
   livecheck do
     url :stable
-    regex(%r{url=.+?/expect-?v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/expect-?v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/faad2.rb
+++ b/Livecheckables/faad2.rb
@@ -1,6 +1,6 @@
 class Faad2
   livecheck do
     url :stable
-    regex(/url=.+faad2-(\d+(?:\.\d+)*)\.t/)
+    regex(/url=.*?faad2-(\d+(?:\.\d+)*)\.t/)
   end
 end

--- a/Livecheckables/fetchmail.rb
+++ b/Livecheckables/fetchmail.rb
@@ -1,6 +1,6 @@
 class Fetchmail
   livecheck do
     url :stable
-    regex(%r{url=.+?/branch_\d+(?:\.\d+)*?/fetchmail-v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/branch_\d+(?:\.\d+)*?/fetchmail-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/findent.rb
+++ b/Livecheckables/findent.rb
@@ -1,6 +1,6 @@
 class Findent
   livecheck do
     url :stable
-    regex(%r{url=.+?/findent-v?(\d+(?:\.\d+)+)\.(?:t|z)})
+    regex(%r{url=.*?/findent-v?(\d+(?:\.\d+)+)\.(?:t|z)})
   end
 end

--- a/Livecheckables/ftgl.rb
+++ b/Livecheckables/ftgl.rb
@@ -1,6 +1,6 @@
 class Ftgl
   livecheck do
     url :stable
-    regex(%r{url=.+?/ftgl-v?(\d+(?:\.\d+)+(?:-rc\d*)?)\.t}i)
+    regex(%r{url=.*?/ftgl-v?(\d+(?:\.\d+)+(?:-rc\d*)?)\.t}i)
   end
 end

--- a/Livecheckables/ganglia.rb
+++ b/Livecheckables/ganglia.rb
@@ -1,6 +1,6 @@
 class Ganglia
   livecheck do
     url "https://downloads.sourceforge.net/project/ganglia/"
-    regex(%r{url=.+?/ganglia-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/ganglia-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/gauche.rb
+++ b/Livecheckables/gauche.rb
@@ -1,6 +1,6 @@
 class Gauche
   livecheck do
     url "https://sourceforge.net/projects/gauche/rss"
-    regex(%r{url=.+?/Gauche-v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/Gauche-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/gnu-cobol.rb
+++ b/Livecheckables/gnu-cobol.rb
@@ -1,6 +1,6 @@
 class GnuCobol
   livecheck do
     url :stable
-    regex(%r{url=.+?/gnucobol-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/gnucobol-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/gpcslots2.rb
+++ b/Livecheckables/gpcslots2.rb
@@ -1,6 +1,6 @@
 class Gpcslots2
   livecheck do
     url :stable
-    regex(%r{url=.+?/gpcslots2.v?(\d+(?:[-_.]\d+)+[a-z]?)})
+    regex(%r{url=.*?/gpcslots2.v?(\d+(?:[-_.]\d+)+[a-z]?)})
   end
 end

--- a/Livecheckables/gplcver.rb
+++ b/Livecheckables/gplcver.rb
@@ -3,6 +3,6 @@ class Gplcver
   # available version at the time of writing was `2.12a`.
   livecheck do
     url :stable
-    regex(%r{url=.+?/gplcver-v?(\d+(?:\.\d+)+[a-z]?)\.src\.}i)
+    regex(%r{url=.*?/gplcver-v?(\d+(?:\.\d+)+[a-z]?)\.src\.}i)
   end
 end

--- a/Livecheckables/gqview.rb
+++ b/Livecheckables/gqview.rb
@@ -1,6 +1,6 @@
 class Gqview
   livecheck do
     url :stable
-    regex(%r{url=.+?/gqview/[^/]+/gqview-v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/gqview/[^/]+/gqview-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/harbour.rb
+++ b/Livecheckables/harbour.rb
@@ -1,6 +1,6 @@
 class Harbour
   livecheck do
     url "https://sourceforge.net/projects/harbour-project/rss"
-    regex(%r{url=.+?/harbour-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/harbour-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/irrlicht.rb
+++ b/Livecheckables/irrlicht.rb
@@ -1,6 +1,6 @@
 class Irrlicht
   livecheck do
     url "https://sourceforge.net/projects/irrlicht/rss"
-    regex(%r{url=.+?/irrlicht-v?(\d+(?:\.\d+)+)\.(?:t|z)})
+    regex(%r{url=.*?/irrlicht-v?(\d+(?:\.\d+)+)\.(?:t|z)})
   end
 end

--- a/Livecheckables/itpp.rb
+++ b/Livecheckables/itpp.rb
@@ -1,6 +1,6 @@
 class Itpp
   livecheck do
     url "https://sourceforge.net/projects/itpp/rss"
-    regex(%r{url=.+?/itpp-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/itpp-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/jags.rb
+++ b/Livecheckables/jags.rb
@@ -1,6 +1,6 @@
 class Jags
   livecheck do
     url :stable
-    regex(%r{url=.+?/JAGS-v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/JAGS-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/jnethack.rb
+++ b/Livecheckables/jnethack.rb
@@ -1,6 +1,6 @@
 class Jnethack
   livecheck do
     url "https://osdn.net/projects/jnethack/releases/rss"
-    regex(%r{url=.+?/jnethack-v?(\d+(?:\.\d+)+(?:-\d+(?:\.\d+)+)?)\.})
+    regex(%r{url=.*?/jnethack-v?(\d+(?:\.\d+)+(?:-\d+(?:\.\d+)+)?)\.})
   end
 end

--- a/Livecheckables/jnettop.rb
+++ b/Livecheckables/jnettop.rb
@@ -1,6 +1,6 @@
 class Jnettop
   livecheck do
     url :stable
-    regex(%r{url=.+?/jnettop-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/jnettop-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/kettle.rb
+++ b/Livecheckables/kettle.rb
@@ -1,6 +1,6 @@
 class Kettle
   livecheck do
     url :stable
-    regex(%r{url=.+?/pdi-ce-v?(\d+(?:\.\d+)+(?:-\d+)?)\.(?:z|t)})
+    regex(%r{url=.*?/pdi-ce-v?(\d+(?:\.\d+)+(?:-\d+)?)\.(?:z|t)})
   end
 end

--- a/Livecheckables/libid3tag.rb
+++ b/Livecheckables/libid3tag.rb
@@ -1,6 +1,6 @@
 class Libid3tag
   livecheck do
     url :stable
-    regex(%r{url=.+?/libid3tag-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
+    regex(%r{url=.*?/libid3tag-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end

--- a/Livecheckables/libmaa.rb
+++ b/Livecheckables/libmaa.rb
@@ -1,6 +1,6 @@
 class Libmaa
   livecheck do
     url "https://sourceforge.net/projects/dict/"
-    regex(%r{url=.+?/libmaa-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/libmaa-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/libngspice.rb
+++ b/Livecheckables/libngspice.rb
@@ -1,6 +1,6 @@
 class Libngspice
   livecheck do
     url "https://sourceforge.net/projects/ngspice/rss"
-    regex(%r{url=.+?/ngspice-v?(\d+(?:\.\d+)*)\.t})
+    regex(%r{url=.*?/ngspice-v?(\d+(?:\.\d+)*)\.t})
   end
 end

--- a/Livecheckables/libpano.rb
+++ b/Livecheckables/libpano.rb
@@ -1,6 +1,6 @@
 class Libpano
   livecheck do
     url :stable
-    regex(%r{url=.+?/libpano(\d+-\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/libpano(\d+-\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/libquvi.rb
+++ b/Livecheckables/libquvi.rb
@@ -1,6 +1,6 @@
 class Libquvi
   livecheck do
     url :stable
-    regex(%r{url=.+?/libquvi-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/libquvi-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/libspnav.rb
+++ b/Livecheckables/libspnav.rb
@@ -1,6 +1,6 @@
 class Libspnav
   livecheck do
     url :stable
-    regex(%r{url=.+?/libspnav-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/libspnav-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/libvo-aacenc.rb
+++ b/Livecheckables/libvo-aacenc.rb
@@ -1,6 +1,6 @@
 class LibvoAacenc
   livecheck do
     url "https://sourceforge.net/projects/opencore-amr/rss"
-    regex(%r{url=.+?/vo-aacenc-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/vo-aacenc-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/libwmf.rb
+++ b/Livecheckables/libwmf.rb
@@ -1,6 +1,6 @@
 class Libwmf
   livecheck do
     url :stable
-    regex(%r{url=.+?/libwmf-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/libwmf-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/little-cms.rb
+++ b/Livecheckables/little-cms.rb
@@ -1,6 +1,6 @@
 class LittleCms
   livecheck do
     url :stable
-    regex(%r{url=.+?/lcms-v?(1(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/lcms-v?(1(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/locateme.rb
+++ b/Livecheckables/locateme.rb
@@ -1,6 +1,6 @@
 class Locateme
   livecheck do
     url :stable
-    regex(%r{url=.+?/LocateMe-v?(\d+(?:\.\d+)+)\.(?:t|z)}i)
+    regex(%r{url=.*?/LocateMe-v?(\d+(?:\.\d+)+)\.(?:t|z)}i)
   end
 end

--- a/Livecheckables/log4c.rb
+++ b/Livecheckables/log4c.rb
@@ -1,6 +1,6 @@
 class Log4c
   livecheck do
     url :stable
-    regex(%r{url=.+?/log4c-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/log4c-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/mad.rb
+++ b/Livecheckables/mad.rb
@@ -1,6 +1,6 @@
 class Mad
   livecheck do
     url :stable
-    regex(%r{url=.+?/libmad-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
+    regex(%r{url=.*?/libmad-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end

--- a/Livecheckables/madplay.rb
+++ b/Livecheckables/madplay.rb
@@ -1,6 +1,6 @@
 class Madplay
   livecheck do
     url :stable
-    regex(%r{url=.+?/madplay-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
+    regex(%r{url=.*?/madplay-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end

--- a/Livecheckables/makepp.rb
+++ b/Livecheckables/makepp.rb
@@ -1,6 +1,6 @@
 class Makepp
   livecheck do
     url :stable
-    regex(%r{url=.+?/makepp-v?(\d+\.\d+)\.t})
+    regex(%r{url=.*?/makepp-v?(\d+\.\d+)\.t})
   end
 end

--- a/Livecheckables/mcpp.rb
+++ b/Livecheckables/mcpp.rb
@@ -1,6 +1,6 @@
 class Mcpp
   livecheck do
     url :stable
-    regex(%r{url=.+?/mcpp-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/mcpp-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/mhash.rb
+++ b/Livecheckables/mhash.rb
@@ -1,6 +1,6 @@
 class Mhash
   livecheck do
     url :stable
-    regex(%r{url=.+?/mhash-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/mhash-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/mingw-w64.rb
+++ b/Livecheckables/mingw-w64.rb
@@ -1,6 +1,6 @@
 class MingwW64
   livecheck do
     url :stable
-    regex(%r{url=.+?release/mingw-w64-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?release/mingw-w64-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/minidjvu.rb
+++ b/Livecheckables/minidjvu.rb
@@ -1,6 +1,6 @@
 class Minidjvu
   livecheck do
     url "https://sourceforge.net/projects/minidjvu/"
-    regex(%r{url=.+?/minidjvu-v?((?!0\.33)\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/minidjvu-v?((?!0\.33)\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/mkvalidator.rb
+++ b/Livecheckables/mkvalidator.rb
@@ -1,6 +1,6 @@
 class Mkvalidator
   livecheck do
     url :stable
-    regex(%r{url=.+?/mkvalidator-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/mkvalidator-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/mp3wrap.rb
+++ b/Livecheckables/mp3wrap.rb
@@ -1,6 +1,6 @@
 class Mp3wrap
   livecheck do
     url :stable
-    regex(%r{url=.+?/mp3wrap-v?(\d+(?:\.\d+)+)(?:-src)?\.t})
+    regex(%r{url=.*?/mp3wrap-v?(\d+(?:\.\d+)+)(?:-src)?\.t})
   end
 end

--- a/Livecheckables/mpg123.rb
+++ b/Livecheckables/mpg123.rb
@@ -1,6 +1,6 @@
 class Mpg123
   livecheck do
     url "https://sourceforge.net/projects/mpg123/rss"
-    regex(%r{url=.+?/mpg123-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/mpg123-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/mpgtx.rb
+++ b/Livecheckables/mpgtx.rb
@@ -1,6 +1,6 @@
 class Mpgtx
   livecheck do
     url :stable
-    regex(%r{url=.+?/mpgtx-v?(\d+(?:\.\d+)+(?:-\d+)?)(?:-src)?\.t})
+    regex(%r{url=.*?/mpgtx-v?(\d+(?:\.\d+)+(?:-\d+)?)(?:-src)?\.t})
   end
 end

--- a/Livecheckables/msdl.rb
+++ b/Livecheckables/msdl.rb
@@ -1,6 +1,6 @@
 class Msdl
   livecheck do
     url :stable
-    regex(%r{url=.+?/msdl-v?(\d+(?:\.\d+)+(?:-r\d+)?)\.t}i)
+    regex(%r{url=.*?/msdl-v?(\d+(?:\.\d+)+(?:-r\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/naturaldocs.rb
+++ b/Livecheckables/naturaldocs.rb
@@ -1,6 +1,6 @@
 class Naturaldocs
   livecheck do
     url :stable
-    regex(%r{url=.+?/Natural.?Docs.v?(\d+(?:\.\d+)+)\.(?:t|z)}i)
+    regex(%r{url=.*?/Natural.?Docs.v?(\d+(?:\.\d+)+)\.(?:t|z)}i)
   end
 end

--- a/Livecheckables/net-snmp.rb
+++ b/Livecheckables/net-snmp.rb
@@ -1,6 +1,6 @@
 class NetSnmp
   livecheck do
     url "https://sourceforge.net/projects/net-snmp/"
-    regex(%r{url=.+?/net-snmp-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/net-snmp-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/ngspice.rb
+++ b/Livecheckables/ngspice.rb
@@ -1,6 +1,6 @@
 class Ngspice
   livecheck do
     url "https://sourceforge.net/projects/ngspice/rss"
-    regex(%r{url=.+?/ngspice-v?(\d+(?:\.\d+)*)\.t})
+    regex(%r{url=.*?/ngspice-v?(\d+(?:\.\d+)*)\.t})
   end
 end

--- a/Livecheckables/nrpe.rb
+++ b/Livecheckables/nrpe.rb
@@ -1,6 +1,6 @@
 class Nrpe
   livecheck do
     url :stable
-    regex(%r{url=.+?/nrpe-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/nrpe-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/pdftohtml.rb
+++ b/Livecheckables/pdftohtml.rb
@@ -1,6 +1,6 @@
 class Pdftohtml
   livecheck do
     url :stable
-    regex(%r{url=.+?/pdftohtml-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
+    regex(%r{url=.*?/pdftohtml-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end

--- a/Livecheckables/perltidy.rb
+++ b/Livecheckables/perltidy.rb
@@ -1,6 +1,6 @@
 class Perltidy
   livecheck do
     url :stable
-    regex(%r{url=.+?/Perl-Tidy-(\d+)\.t}i)
+    regex(%r{url=.*?/Perl-Tidy-(\d+)\.t}i)
   end
 end

--- a/Livecheckables/pidgin.rb
+++ b/Livecheckables/pidgin.rb
@@ -1,6 +1,6 @@
 class Pidgin
   livecheck do
     url :stable
-    regex(%r{url=.+?/pidgin-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/pidgin-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/pngcheck.rb
+++ b/Livecheckables/pngcheck.rb
@@ -1,6 +1,6 @@
 class Pngcheck
   livecheck do
     url :stable
-    regex(%r{url=.+?/pngcheck-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/pngcheck-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/portmidi.rb
+++ b/Livecheckables/portmidi.rb
@@ -1,6 +1,6 @@
 class Portmidi
   livecheck do
     url :stable
-    regex(%r{url=.+?/portmidi-src-(\d+)\.}i)
+    regex(%r{url=.*?/portmidi-src-(\d+)\.}i)
   end
 end

--- a/Livecheckables/primer3.rb
+++ b/Livecheckables/primer3.rb
@@ -1,6 +1,6 @@
 class Primer3
   livecheck do
     url :stable
-    regex(%r{url=.+?/primer3-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/primer3-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/proctools.rb
+++ b/Livecheckables/proctools.rb
@@ -1,6 +1,6 @@
 class Proctools
   livecheck do
     url :stable
-    regex(%r{url=.+?/proctools/[^/]+/proctools-v?(\d+(?:\.\d+)+(?:pre\d+)?)\.t}i)
+    regex(%r{url=.*?/proctools/[^/]+/proctools-v?(\d+(?:\.\d+)+(?:pre\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/putmail-queue.rb
+++ b/Livecheckables/putmail-queue.rb
@@ -1,6 +1,6 @@
 class PutmailQueue
   livecheck do
     url :stable
-    regex(%r{url=.+?/putmail-queue-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/putmail-queue-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/qmmp.rb
+++ b/Livecheckables/qmmp.rb
@@ -1,6 +1,6 @@
 class Qmmp
   livecheck do
     url "https://sourceforge.net/projects/qmmp-dev/rss"
-    regex(%r{url=.+?/qmmp-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/qmmp-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/qrupdate.rb
+++ b/Livecheckables/qrupdate.rb
@@ -1,6 +1,6 @@
 class Qrupdate
   livecheck do
     url :homepage
-    regex(%r{url=.+?/qrupdate-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/qrupdate-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/quvi.rb
+++ b/Livecheckables/quvi.rb
@@ -1,6 +1,6 @@
 class Quvi
   livecheck do
     url :stable
-    regex(%r{url=.+?/quvi-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/quvi-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/rtf2latex2e.rb
+++ b/Livecheckables/rtf2latex2e.rb
@@ -1,6 +1,6 @@
 class Rtf2latex2e
   livecheck do
     url :stable
-    regex(%r{url=.+?/rtf2latex2e-v?(\d+(?:[-_.]\d+)+)\.t})
+    regex(%r{url=.*?/rtf2latex2e-v?(\d+(?:[-_.]\d+)+)\.t})
   end
 end

--- a/Livecheckables/saxon.rb
+++ b/Livecheckables/saxon.rb
@@ -1,6 +1,6 @@
 class Saxon
   livecheck do
     url :stable
-    regex(%r{url=.+?/SaxonHE(\d+(?:[-.]\d+)+)J?\.(?:t|z)}i)
+    regex(%r{url=.*?/SaxonHE(\d+(?:[-.]\d+)+)J?\.(?:t|z)}i)
   end
 end

--- a/Livecheckables/sc68.rb
+++ b/Livecheckables/sc68.rb
@@ -1,6 +1,6 @@
 class Sc68
   livecheck do
     url :stable
-    regex(%r{url=.+?/sc68-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/sc68-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/sdcc.rb
+++ b/Livecheckables/sdcc.rb
@@ -1,6 +1,6 @@
 class Sdcc
   livecheck do
     url "https://sourceforge.net/projects/sdcc/rss"
-    regex(%r{url=.+?/sdcc-src-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/sdcc-src-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/sdedit.rb
+++ b/Livecheckables/sdedit.rb
@@ -1,6 +1,6 @@
 class Sdedit
   livecheck do
     url :stable
-    regex(%r{url=.+?/sdedit-v?(\d+(?:\.\d+)+)\.jar})
+    regex(%r{url=.*?/sdedit-v?(\d+(?:\.\d+)+)\.jar})
   end
 end

--- a/Livecheckables/simutrans.rb
+++ b/Livecheckables/simutrans.rb
@@ -1,6 +1,6 @@
 class Simutrans
   livecheck do
     url "https://sourceforge.net/projects/simutrans/rss"
-    regex(%r{url=.+?/simutrans-src-v?(\d+(?:[-_.]\d+)+)\.(?:t|z)})
+    regex(%r{url=.*?/simutrans-src-v?(\d+(?:[-_.]\d+)+)\.(?:t|z)})
   end
 end

--- a/Livecheckables/slashem.rb
+++ b/Livecheckables/slashem.rb
@@ -1,6 +1,6 @@
 class Slashem
   livecheck do
     url :stable
-    regex(%r{url=.+?/slashem-source/([^/]+)/[^.]+\.t})
+    regex(%r{url=.*?/slashem-source/([^/]+)/[^.]+\.t})
   end
 end

--- a/Livecheckables/squirrel.rb
+++ b/Livecheckables/squirrel.rb
@@ -1,6 +1,6 @@
 class Squirrel
   livecheck do
     url :stable
-    regex(%r{url=.+?/squirrel.v?(\d+(?:[-_]\d+)+).stable\.t})
+    regex(%r{url=.*?/squirrel.v?(\d+(?:[-_]\d+)+).stable\.t})
   end
 end

--- a/Livecheckables/ssldump.rb
+++ b/Livecheckables/ssldump.rb
@@ -3,6 +3,6 @@ class Ssldump
   # (0.9b3) is available at the time of writing.
   livecheck do
     url :stable
-    regex(%r{url=.+?/ssldump/([^/]+)/[^/]+\.t})
+    regex(%r{url=.*?/ssldump/([^/]+)/[^/]+\.t})
   end
 end

--- a/Livecheckables/sstp-client.rb
+++ b/Livecheckables/sstp-client.rb
@@ -1,6 +1,6 @@
 class SstpClient
   livecheck do
     url :stable
-    regex(%r{url=.+?/sstp-client-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/sstp-client-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/streamripper.rb
+++ b/Livecheckables/streamripper.rb
@@ -1,6 +1,6 @@
 class Streamripper
   livecheck do
     url :stable
-    regex(%r{url=.+?/streamripper-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/streamripper-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/synfig.rb
+++ b/Livecheckables/synfig.rb
@@ -1,6 +1,6 @@
 class Synfig
   livecheck do
     url "https://sourceforge.net/projects/synfig/"
-    regex(%r{url=.+?/synfig-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/synfig-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/tcl-tk.rb
+++ b/Livecheckables/tcl-tk.rb
@@ -1,6 +1,6 @@
 class TclTk
   livecheck do
     url "https://sourceforge.net/projects/tcl/rss"
-    regex(%r{url=.+?/(?:tcl|tk).?v?(\d+(?:\.\d+)+)-src\.t}i)
+    regex(%r{url=.*?/(?:tcl|tk).?v?(\d+(?:\.\d+)+)-src\.t}i)
   end
 end

--- a/Livecheckables/timidity.rb
+++ b/Livecheckables/timidity.rb
@@ -1,6 +1,6 @@
 class Timidity
   livecheck do
     url :stable
-    regex(%r{url=.+?/TiMidity%2B%2B-v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/TiMidity%2B%2B-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/tivodecode.rb
+++ b/Livecheckables/tivodecode.rb
@@ -1,6 +1,6 @@
 class Tivodecode
   livecheck do
     url :stable
-    regex(%r{url=.+?/tivodecode-v?(\d+(?:\.\d+)+(?:pre\d+)?)\.t})
+    regex(%r{url=.*?/tivodecode-v?(\d+(?:\.\d+)+(?:pre\d+)?)\.t})
   end
 end

--- a/Livecheckables/tta.rb
+++ b/Livecheckables/tta.rb
@@ -1,6 +1,6 @@
 class Tta
   livecheck do
     url :stable
-    regex(%r{url=.+?/libtta-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/libtta-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/ttf2pt1.rb
+++ b/Livecheckables/ttf2pt1.rb
@@ -1,6 +1,6 @@
 class Ttf2pt1
   livecheck do
     url "https://sourceforge.net/projects/ttf2pt1/rss"
-    regex(%r{url=.+?/ttf2pt1-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/ttf2pt1-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/udis86.rb
+++ b/Livecheckables/udis86.rb
@@ -1,6 +1,6 @@
 class Udis86
   livecheck do
     url "https://sourceforge.net/projects/udis86/rss"
-    regex(%r{url=.+?/udis86-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/udis86-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/unzip.rb
+++ b/Livecheckables/unzip.rb
@@ -1,6 +1,6 @@
 class Unzip
   livecheck do
     url :stable
-    regex(%r{url=.+?(?:%20)?v?(\d+(?:\.\d+)+)/unzip\d+\.t}i)
+    regex(%r{url=.*?(?:%20)?v?(\d+(?:\.\d+)+)/unzip\d+\.t}i)
   end
 end

--- a/Livecheckables/vncsnapshot.rb
+++ b/Livecheckables/vncsnapshot.rb
@@ -1,6 +1,6 @@
 class Vncsnapshot
   livecheck do
     url :stable
-    regex(%r{url=.+?/vncsnapshot-v?(\d+(?:\.\d+)+[a-z]?)-src\.t}i)
+    regex(%r{url=.*?/vncsnapshot-v?(\d+(?:\.\d+)+[a-z]?)-src\.t}i)
   end
 end

--- a/Livecheckables/w3m.rb
+++ b/Livecheckables/w3m.rb
@@ -1,6 +1,6 @@
 class W3m
   livecheck do
     url "https://sourceforge.net/projects/w3m/rss"
-    regex(%r{url=.+?/w3m-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/w3m-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/wv2.rb
+++ b/Livecheckables/wv2.rb
@@ -1,6 +1,6 @@
 class Wv2
   livecheck do
     url :stable
-    regex(%r{url=.+?/wv2-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/wv2-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/xmlsh.rb
+++ b/Livecheckables/xmlsh.rb
@@ -1,6 +1,6 @@
 class Xmlsh
   livecheck do
     url :stable
-    regex(%r{url=.+?/v?(\d+(?:\.\d+)+)/xmlsh}i)
+    regex(%r{url=.*?/v?(\d+(?:\.\d+)+)/xmlsh}i)
   end
 end

--- a/Livecheckables/zboy.rb
+++ b/Livecheckables/zboy.rb
@@ -1,6 +1,6 @@
 class Zboy
   livecheck do
     url :head
-    regex(%r{url=.+?/zboy-v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/zboy-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/zint.rb
+++ b/Livecheckables/zint.rb
@@ -1,6 +1,6 @@
 class Zint
   livecheck do
     url "https://sourceforge.net/projects/zint/rss"
-    regex(%r{url=.+?/zint-v?(\d+(?:\.\d+)+)\.t})
+    regex(%r{url=.*?/zint-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/zip.rb
+++ b/Livecheckables/zip.rb
@@ -1,6 +1,6 @@
 class Zip
   livecheck do
     url :stable
-    regex(%r{url=.+?/v?(\d+(?:\.\d+)+)/zip\d+\.(?:t|z)})
+    regex(%r{url=.*?/v?(\d+(?:\.\d+)+)/zip\d+\.(?:t|z)})
   end
 end

--- a/Livecheckables/zssh.rb
+++ b/Livecheckables/zssh.rb
@@ -1,6 +1,6 @@
 class Zssh
   livecheck do
     url :stable
-    regex(%r{url=.+?/zssh-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
+    regex(%r{url=.*?/zssh-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end


### PR DESCRIPTION
This PR changes `url=.+?` to `url=.*?`. A leading `/`, if present, has not been removed. The only 'exception' in this PR is `faad2`, which had `url=.+` earlier and `url=.*?` now.