### PR TITLE
chkrootkit: update regex

### DIFF
--- a/Livecheckables/chkrootkit.rb
+++ b/Livecheckables/chkrootkit.rb
@@ -1,6 +1,6 @@
 class Chkrootkit
   livecheck do
     url :homepage
-    regex(/href=.*?download[^>]+>chkrootkit v?(\d+(?:\.\d+)+)/i)
+    regex(/href=.*?download[^>]*>chkrootkit v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/chkrootkit.rb
+++ b/Livecheckables/chkrootkit.rb
@@ -1,6 +1,6 @@
 class Chkrootkit
   livecheck do
     url :homepage
-    regex(%r{href="/download/">chkrootkit ([0-9,.]+)})
+    regex(/href=.*?download[^>]+>chkrootkit v?(\d+(?:\.\d+)+)/i)
   end
 end


### PR DESCRIPTION
This PR updates `chkrootkit`'s regex to conform to current standards. I took inspiration from `pidof` for this one, but there may be better alternatives.