### PR TITLE
etsh: update regex

### DIFF
--- a/Livecheckables/etsh.rb
+++ b/Livecheckables/etsh.rb
@@ -1,6 +1,6 @@
 class Etsh
   livecheck do
     url "https://etsh.nl/src/"
-    regex(%r{href="etsh[-_](\d+(?:\.\d+)+)(?:(?:\.t)|/)?})
+    regex(/href=.*?etsh[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR updates `etsh`'s regex to conform to current standards.

In #323, the regex was updated to match either the archive files (`\.t`) or the version directories (`/`). However I've reverted to matching just the archive files, as it was sufficient to detect all versions of `etsh` present on the page.

Do let me know if I must change the regex suffix back to what it was after #323.