### PR TITLE
exiftool: update regex

### DIFF
--- a/Livecheckables/exiftool.rb
+++ b/Livecheckables/exiftool.rb
@@ -1,6 +1,6 @@
 class Exiftool
   livecheck do
     url "https://exiftool.org/history.html"
-    regex(/href=.*?Image[._-]ExifTool[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/production release is.*?href=.*?Image[._-]ExifTool[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/exiftool.rb
+++ b/Livecheckables/exiftool.rb
@@ -1,6 +1,6 @@
 class Exiftool
   livecheck do
     url "https://exiftool.org/history.html"
-    regex(/production release is <a href="Image-ExifTool-([0-9.]+)\.t/)
+    regex(/href=.*?Image[._-]ExifTool[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR updates `exiftool`'s regex to conform to current standards.

Only the stable (production) version seems to have its archive file present on the page, and the text might change in the future, so I thought the usual `href=` matching would suffice.