### PR TITLE
libvisio: update url and regex

### DIFF
--- a/Livecheckables/libvisio.rb
+++ b/Livecheckables/libvisio.rb
@@ -1,6 +1,6 @@
 class Libvisio
   livecheck do
-    url "https://dev-www.libreoffice.org/src/"
-    regex(/.*href=.*?libvisio-([0-9.\-]+)\.t/)
+    url "https://dev-www.libreoffice.org/src/libvisio/"
+    regex(/href=.*?libvisio[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `libvisio` livecheckable up to current standards:

* Align the check with the location of the stable archive, when possible
* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.\-]+)`
* Make regex case insensitive unless case sensitivity is needed