### PR TITLE
fizmo: update regex

### DIFF
--- a/Livecheckables/fizmo.rb
+++ b/Livecheckables/fizmo.rb
@@ -1,6 +1,6 @@
 class Fizmo
   livecheck do
     url "https://fizmo.spellbreaker.org/download/"
-    regex(%r{href="../source/fizmo-([0-9.]+)\.t.*?current branch}m)
+    regex(%r{href=.*?/fizmo[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end


### PR DESCRIPTION
This PR updates `fizmo`'s regex to conform to current standards. The leading `/` is necessary to prevent matching versions of `libfizmo`.