### PR TITLE
gcc: update regex

### DIFF
--- a/Livecheckables/gcc.rb
+++ b/Livecheckables/gcc.rb
@@ -1,6 +1,6 @@
 class Gcc
   livecheck do
     url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
-    regex(%r{href=.*?gcc[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
+    regex(%r{href=.*?gcc[._-]v?(\d+(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 end

--- a/Livecheckables/gcc.rb
+++ b/Livecheckables/gcc.rb
@@ -1,6 +1,6 @@
 class Gcc
   livecheck do
     url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
-    regex(%r{href="gcc-(\d+(?:\.\d+)+)(?:/?"|\.t)})
+    regex(%r{href=.*?gcc[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
This PR updates `gcc`'s regex to conform to current standards. They've been using the version directory format consistently since 2003, so I thought it was okay to match only version directories. Let me know if that has to be changed.