### PR TITLE
ghc: update url and regex

### DIFF
--- a/Livecheckables/ghc.rb
+++ b/Livecheckables/ghc.rb
@@ -1,6 +1,6 @@
 class Ghc
   livecheck do
-    url "https://www.haskell.org/ghc/download.html"
-    regex(/href="download_ghc_(?:\d+(?:_?\d+)+).html">(\d+(?:\.\d+)+)</)
+    url "https://downloads.haskell.org/~ghc/"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/ghc.rb
+++ b/Livecheckables/ghc.rb
@@ -1,6 +1,6 @@
 class Ghc
   livecheck do
     url "https://downloads.haskell.org/~ghc/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    regex(%r{href=.*?v?(\d+(?:\.\d{1,4})+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
This PR updates `ghc`'s `url` to that of an index page of all releases (which aligns with the stable archive location). The `regex` has also been updated as a result, and it conforms to current standards.