### PR TITLE
nss: update url and regex

### DIFF
--- a/Livecheckables/nss.rb
+++ b/Livecheckables/nss.rb
@@ -1,6 +1,6 @@
 class Nss
   livecheck do
-    url "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_Releases"
-    regex(/href="[^"]*?NSS_(\d+(?:\.\d+)+)_release_notes"/)
+    url "https://ftp.mozilla.org/pub/security/nss/releases/"
+    regex(%r{href=.*?NSS[._-]v?(\d+(?:[._]\d+)+)[._-]RTM/?["' >]}i)
   end
 end


### PR DESCRIPTION
This PR updates `nss`'s `url` to align with the location of the stable archive file. The `regex` has also been updated as a consequence, and has been brought up to current standards.