### PR TITLE
Add forward slash to some url=.*? regexes

### DIFF
--- a/Livecheckables/ctags.rb
+++ b/Livecheckables/ctags.rb
@@ -1,6 +1,6 @@
 class Ctags
   livecheck do
     url "https://sourceforge.net/projects/ctags/"
-    regex(/url=.*?ctags-v?(\d+(?:\.\d+)+)\.t/)
+    regex(%r{url=.*?/ctags-v?(\d+(?:\.\d+)+)\.t})
   end
 end

--- a/Livecheckables/faad2.rb
+++ b/Livecheckables/faad2.rb
@@ -1,6 +1,6 @@
 class Faad2
   livecheck do
     url :stable
-    regex(/url=.*?faad2-(\d+(?:\.\d+)*)\.t/)
+    regex(%r{url=.*?/faad2-(\d+(?:\.\d+)*)\.t})
   end
 end


### PR DESCRIPTION
This updates a couple of instances of `url=.*?` to `url=.*?/` to bring them in line with the vast majority of similar regexes. [The only exceptions are `mingw-w64` and `unzip`.]