### PR TITLE
Update PyPI urls to stable Formula urls

### DIFF
--- a/Livecheckables/ccm.rb
+++ b/Livecheckables/ccm.rb
@@ -1,6 +1,6 @@
 class Ccm
   livecheck do
-    url "https://pypi.org/simple/ccm"
+    url :stable
     regex(%r{/ccm-([0-9,.]+)\.t})
   end
 end

--- a/Livecheckables/diffoscope.rb
+++ b/Livecheckables/diffoscope.rb
@@ -1,6 +1,6 @@
 class Diffoscope
   livecheck do
-    url "https://pypi.org/simple/diffoscope"
+    url :stable
     regex(%r{/diffoscope-([0-9,.]+)\.t})
   end
 end

--- a/Livecheckables/eralchemy.rb
+++ b/Livecheckables/eralchemy.rb
@@ -1,6 +1,6 @@
 class Eralchemy
   livecheck do
-    url "https://pypi.org/simple/ERAlchemy/"
+    url :stable
     regex(/href=.*?ERAlchemy-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/pgcli.rb
+++ b/Livecheckables/pgcli.rb
@@ -1,6 +1,6 @@
 class Pgcli
   livecheck do
-    url "https://pypi.org/simple/pgcli/"
+    url :stable
     regex(/href=.*?pgcli-([0-9,.]+)\.t/)
   end
 end

--- a/Livecheckables/pipenv.rb
+++ b/Livecheckables/pipenv.rb
@@ -1,6 +1,6 @@
 class Pipenv
   livecheck do
-    url "https://pypi.org/simple/pipenv"
+    url :stable
     regex(%r{/pipenv-([0-9,.]+)\.t})
   end
 end

--- a/Livecheckables/tox.rb
+++ b/Livecheckables/tox.rb
@@ -1,6 +1,6 @@
 class Tox
   livecheck do
-    url "https://pypi.org/simple/tox"
+    url :stable
     regex(%r{/tox-([0-9,.]+)\.t})
   end
 end


### PR DESCRIPTION
This PR changes `pypi.org/simple/...` urls to the `:stable` Formula url reference. The Livecheckables affected are those not already handled in #1152.