### PR TITLE
opus: update url and regex

### DIFF
--- a/Livecheckables/opus.rb
+++ b/Livecheckables/opus.rb
@@ -1,6 +1,6 @@
 class Opus
   livecheck do
     url "https://archive.mozilla.org/pub/opus/"
-    regex(/href=.*?opus[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)opus[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/opus.rb
+++ b/Livecheckables/opus.rb
@@ -1,6 +1,6 @@
 class Opus
   livecheck do
-    url "https://www.opus-codec.org/downloads/"
-    regex(%r{href="/release/stable/.*libopus ([0-9,.]+)</a>})
+    url "https://archive.mozilla.org/pub/opus/"
+    regex(/href=.*?opus[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
The `url` for `opus` has been updated to align with that of the stable archive. The new `url` is an index page of all versions. One concern is that either the file format (name) has either varied over the years, or the other names truly denote other software/Formulae. Do let me know if there are any changes.