### PR TITLE
packer: update url and regex

### DIFF
--- a/Livecheckables/packer.rb
+++ b/Livecheckables/packer.rb
@@ -1,6 +1,6 @@
 class Packer
   livecheck do
-    url "https://packer.io/downloads.html"
-    regex(%r{href="https://releases.hashicorp.com/packer/([0-9.]+)})
+    url "https://github.com/hashicorp/packer/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/packer.rb
+++ b/Livecheckables/packer.rb
@@ -1,6 +1,6 @@
 class Packer
   livecheck do
-    url "https://github.com/hashicorp/packer/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url "https://releases.hashicorp.com/packer/"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
This PR updates the url of `packer` to the GitHub `latest` release page, as the stable URL in the Formula is that of the GitHub repository (tag v1.6.0). The regex has been updated accordingly.