### PR TITLE
qtfaststart: update url and regex

### DIFF
--- a/Livecheckables/libav.rb
+++ b/Livecheckables/libav.rb
@@ -1,6 +1,6 @@
 class Libav
   livecheck do
     url "https://libav.org/releases/"
-    regex(/href=.*?libav-([0-9.]+)\.t/)
+    regex(/href=.*?libav[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/qtfaststart.rb
+++ b/Livecheckables/qtfaststart.rb
@@ -1,6 +1,6 @@
 class Qtfaststart
   livecheck do
-    url :homepage
-    regex(%r{href="//libav.org/releases/libav-([0-9.]+)\.t})
+    url "https://libav.org/releases/"
+    regex(/href=.*?libav[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR updates `qtfaststart`'s `url` to align with that of the stable archive. The `regex` has also been updated to conform to current standards.