### PR TITLE
sane-backends: update url and regex

### DIFF
--- a/Livecheckables/sane-backends.rb
+++ b/Livecheckables/sane-backends.rb
@@ -1,6 +1,6 @@
 class SaneBackends
   livecheck do
-    url :homepage
-    regex(%r{href="source\.html">SANE-Backends-([0-9.]+)</a>})
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end


### PR DESCRIPTION
The stable archive for `sane-backends` is obtained from GitLab, so I decided to use `head` and match tags instead. Let me know if this should be changed to something else.

Note: About 2 or so years ago they were using `RELEASE_1_0_x` as the tag format, but this has changed since about 11 months ago. If we would like to match the older scheme as well, I'll update the regex.