### PR TITLE
strongswan: update url and regex

### DIFF
--- a/Livecheckables/strongswan.rb
+++ b/Livecheckables/strongswan.rb
@@ -1,6 +1,6 @@
 class Strongswan
   livecheck do
-    url "https://www.strongswan.org/download.html"
-    regex(%r{href="https://download.strongswan.org/strongswan-([0-9.]+)\.t})
+    url "https://download.strongswan.org/"
+    regex(/href=.*?strongswan[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
   end
 end


### PR DESCRIPTION
The url for `strongswan` has been updated to align with that of the stable archive file. The regex has been brought up to standards. The reason for `[a-z]?` – there was one `2.4.0a`, and if they decide to include releases named in that format sometime later, we should be able to match them. Let me know if this should be changed.