### PR TITLE
terraform: update url and regex

### DIFF
--- a/Livecheckables/terraform.rb
+++ b/Livecheckables/terraform.rb
@@ -1,6 +1,6 @@
 class Terraform
   livecheck do
-    url "https://github.com/hashicorp/terraform/releases/latest"
-    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    url "https://releases.hashicorp.com/terraform/"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/terraform.rb
+++ b/Livecheckables/terraform.rb
@@ -1,6 +1,6 @@
 class Terraform
   livecheck do
-    url "https://www.terraform.io/downloads.html"
-    regex(%r{href="https://releases.hashicorp.com/terraform/([0-9.]+)})
+    url "https://github.com/hashicorp/terraform/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end


### PR DESCRIPTION
The url for `terraform` has been updated to its GitHub latest release URL, and the regex has been updated accordingly.