### PR TITLE
zanata-client: update url and regex

### DIFF
--- a/Livecheckables/zanata-client.rb
+++ b/Livecheckables/zanata-client.rb
@@ -1,6 +1,6 @@
 class ZanataClient
   livecheck do
-    url "https://docs.zanata.org/en/release/release-notes/"
-    regex(%r{<a href="#[0-9]+">([0-9,.]+)</a></li>})
+    url "https://search.maven.org/remotecontent?filepath=org/zanata/zanata-cli/"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
This PR updates the url for `zanata-client` to align with that of the Formula's stable archive file. We need to match version directories with this url, so the regex has been updated accordingly.