### PR TITLE
Align HTML attribute delimiters with current usage

### DIFF
--- a/Livecheckables/cataclysm.rb
+++ b/Livecheckables/cataclysm.rb
@@ -1,6 +1,6 @@
 class Cataclysm
   livecheck do
     url "https://github.com/CleverRaven/Cataclysm-DDA/releases/latest"
-    regex(%r{href=.*?/tag/([^"'>]+)["'>]}i)
+    regex(%r{href=.*?/tag/([^"' >]+)["' >]}i)
   end
 end

--- a/Livecheckables/ifstat.rb
+++ b/Livecheckables/ifstat.rb
@@ -1,6 +1,6 @@
 class Ifstat
   livecheck do
     url :homepage
-    regex(/href=['"]?ifstat-v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=["']?ifstat[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/neo4j.rb
+++ b/Livecheckables/neo4j.rb
@@ -1,7 +1,7 @@
 class Neo4j
   livecheck do
     url "https://neo4j.com/download-center/"
-    regex(/href=.*?edition=community[^ '">]+release=v?(\d+(?:\.\d+)+)[& '">]
-          |href=.*?release=v?(\d+(?:\.\d+)+)[^ '">]+edition=community/ix)
+    regex(/href=.*?edition=community[^"' >]+release=v?(\d+(?:\.\d+)+)[&"' >]
+          |href=.*?release=v?(\d+(?:\.\d+)+)[^"' >]+edition=community/ix)
   end
 end

--- a/Livecheckables/nkf.rb
+++ b/Livecheckables/nkf.rb
@@ -1,6 +1,6 @@
 class Nkf
   livecheck do
     url "https://osdn.net/projects/nkf/releases/"
-    regex(%r{=.*?rel/nkf/v?(\d+(?:\.\d+)+[a-z]?)[ '"]}i)
+    regex(%r{=.*?rel/nkf/v?(\d+(?:\.\d+)+[a-z]?)["' >]}i)
   end
 end

--- a/Livecheckables/node@12.rb
+++ b/Livecheckables/node@12.rb
@@ -1,6 +1,6 @@
 class NodeAT12
   livecheck do
     url "https://nodejs.org/dist/"
-    regex(%r{href=.*?v?(12(?:\.\d+){2})/?['"]})
+    regex(%r{href=.*?v?(12(?:\.\d+){2})/?["' >]}i)
   end
 end

--- a/Livecheckables/ttyrec.rb
+++ b/Livecheckables/ttyrec.rb
@@ -1,6 +1,6 @@
 class Ttyrec
   livecheck do
     url :homepage
-    regex(/href=['"]?ttyrec-v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=["']?ttyrec[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
We've been standardizing on `["']`, `["' >]`, etc. and we updated most instances while working on the `href=` regexes but there were still a few lingering cases.

This brings these instances up to date while also addressing some other clean-up tasks in the process:

* Replace the delimiter between software name and version in file name with `[._-]`
* Make regex case insensitive unless case sensitivity is needed