### PR TITLE
proguard: update url and regex

### DIFF
--- a/Livecheckables/proguard.rb
+++ b/Livecheckables/proguard.rb
@@ -1,6 +1,6 @@
 class Proguard
   livecheck do
-    url "https://sourceforge.net/projects/proguard/"
-    regex(%r{.*?/proguard([0-9.]+)\.t})
+    url "https://github.com/Guardsquare/proguard/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end


### PR DESCRIPTION
The `proguard` formula now uses releases from GitHub, so the current check (SourceForge) wasn't finding the latest release (i.e., `proguard : 7.0.0 ==> 6.2.2`).

This updates the existing livecheckable to check the "latest" release on GitHub.