### PR TITLE
desktop-file-utils: delete livecheckable

### DIFF
--- a/Livecheckables/desktop-file-utils.rb
+++ b/Livecheckables/desktop-file-utils.rb
@@ -1,6 +1,0 @@
-class DesktopFileUtils
-  livecheck do
-    url "https://www.freedesktop.org/software/desktop-file-utils/releases/"
-    regex(/href=.*?desktop-file-utils-v?(\d+(?:\.\d+)+)\.t/i)
-  end
-end


### PR DESCRIPTION
The existing `desktop-file-utils` livecheckable broke when we added the `Xorg` strategy but this check will work properly if we simply remove the livecheckable.