### PR TITLE
micronaut: update url

### DIFF
--- a/Livecheckables/micronaut.rb
+++ b/Livecheckables/micronaut.rb
@@ -1,6 +1,6 @@
 class Micronaut
   livecheck do
-    url "https://github.com/micronaut-projects/micronaut-core/releases/latest"
+    url "https://github.com/micronaut-projects/micronaut-starter/releases/latest"
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end


### PR DESCRIPTION
The `micronaut` formula now uses releases from micronaut-projects/micronaut-starter, so this updates the livecheckable to check for the "latest" release from this repository.