### PR TITLE
afl-fuzz: update regex

### DIFF
--- a/Livecheckables/afl-fuzz.rb
+++ b/Livecheckables/afl-fuzz.rb
@@ -1,6 +1,6 @@
 class AflFuzz
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)b?$/)
+    regex(/^v?(\d+(?:\.\d+)+b?)$/)
   end
 end


### PR DESCRIPTION
The `afl-fuzz` formula was modified in Homebrew/homebrew-core to include the trailing `b` in the version (e.g., `2.57b`). This updates the livecheckable's regex to do the same.