### PR TITLE
libwebsockets: update regex

### DIFF
--- a/Livecheckables/libwebsockets.rb
+++ b/Livecheckables/libwebsockets.rb
@@ -1,6 +1,6 @@
 class Libwebsockets
   livecheck do
     url "https://github.com/warmcat/libwebsockets"
-    regex(/^v(.*)/)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `libwebsockets` is picking up an unstable version (i.e. `libwebsockets : 4.0.20 ==> 4.1.0-rc1`).

`libwebsockets` seems to have standardized on a `v1.2` or `v1.2.3` format in their Git tags, so we can simply use the standard regex for Git tags here.