### PR TITLE
boost-build: update regex

### DIFF
--- a/Livecheckables/boost-build.rb
+++ b/Livecheckables/boost-build.rb
@@ -1,6 +1,6 @@
 class BoostBuild
   livecheck do
     url :head
-    regex(/boost-([0-9.]+)/)
+    regex(/^boost[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `boost-build` was matching beta releases, returning a `1.74.0.` version as newest for a `1.74.0.beta1` Git tag.

This restricts matching to releases like `boost-1.73.0` and not `boost-1.69.0-beta1`, `boost-1.2.3-beta1`, `boost-1.30.2-rc1`, etc.