### PR TITLE
smpeg: update regex

### DIFF
--- a/Livecheckables/smpeg.rb
+++ b/Livecheckables/smpeg.rb
@@ -1,6 +1,6 @@
 class Smpeg
   livecheck do
     url "http://svn.icculus.org/smpeg/tags/"
-    regex(%r{href=.*?release[._-]v?(\d+(?:[._]\d+)+)/}i)
+    regex(%r{href=.*?release[._-]v?([01](?:[._]\d+)+)/}i)
   end
 end


### PR DESCRIPTION
The `smpeg` formula shouldn't be matching releases at 2.0 or later, as that's what the `smpeg2` formula is for.

This updates the regex to restrict matching to major versions of 0 or 1. The latest `smpeg` version is 0.4.5 and there are no 1.x versions but I figured it would be a bit safer than just restricting to a major version of 0.