### PR TITLE
smpeg2: add livecheckable

### DIFF
--- a/Livecheckables/smpeg2.rb
+++ b/Livecheckables/smpeg2.rb
@@ -1,0 +1,6 @@
+class Smpeg2
+  livecheck do
+    url "http://svn.icculus.org/smpeg/tags/"
+    regex(%r{href=.*?release[._-]v?(2(?:[._]\d+)+)/}i)
+  end
+end


### PR DESCRIPTION
This adds a livecheckable that is similar to the existing `smpeg` check but instead restricts matching to 2.x versions.