### PR TITLE
gabedit: update url and regex

### DIFF
--- a/Livecheckables/gabedit.rb
+++ b/Livecheckables/gabedit.rb
@@ -1,6 +1,8 @@
 class Gabedit
+  # Consider switching back to checking SourceForge releases once we can alter
+  # the matched version from `250` to `2.5.0`.
   livecheck do
-    url "https://sourceforge.net/projects/gabedit/"
-    regex(%r{/gabedit/Gabedit([0-9]+)/})
+    url "https://sites.google.com/site/allouchear/Home/gabedit/download"
+    regex(/current stable version of gabedit is v?(\d+(?:\.\d+)+)/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `gabedit` checks release archives on SourceForge. Unfortunately these files have a name format like `GabeditSrc250.tar.gz` for version `2.5.0`. Until we have an `alterations` feature, where we could change `250` into `2.5.0`, this check doesn't work properly (i.e., 250 > 2.5.0).

This updates the livecheckable to check the "Downloads" page linked from the `gabedit` homepage. There hasn't been a new release since 2017-07-10, so this may not be infallible but it may be okay for now.