### PR TITLE
Change remaining `href=".*?` to `href=.*?`

### DIFF
--- a/Livecheckables/sylpheed.rb
+++ b/Livecheckables/sylpheed.rb
@@ -1,6 +1,6 @@
 class Sylpheed
   livecheck do
     url "https://sylpheed.sraoss.jp/en/download.html"
-    regex(%r{stable.*?href=".*?/sylpheed-([0-9.]+)\.t}m)
+    regex(%r{stable.*?href=.*?/sylpheed-([0-9.]+)\.t}m)
   end
 end

--- a/Livecheckables/xrootd.rb
+++ b/Livecheckables/xrootd.rb
@@ -1,6 +1,6 @@
 class Xrootd
   livecheck do
     url "http://xrootd.org/dload.html"
-    regex(/href=".*?xrootd-([0-9,.]+)\.t/)
+    regex(/href=.*?xrootd-([0-9,.]+)\.t/)
   end
 end


### PR DESCRIPTION
It seems `sylpheed` and `xrootd` still used `href=".*?` so I've updated them to use `href=.*?` instead.