### PR TITLE
gocr: update url and regex

### DIFF
--- a/Livecheckables/gocr.rb
+++ b/Livecheckables/gocr.rb
@@ -1,6 +1,6 @@
 class Gocr
   livecheck do
-    url :homepage
-    regex(/GOCR ([0-9.]+).*?release/i)
+    url "https://wasd.urz.uni-magdeburg.de/jschulen/ocr/download.html"
+    regex(%r{href=(?:["']?|.*?/)gocr[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for GOCR checks the homepage but after making the regex case insensitive it picks up releases for `libgocr` as well. Livecheck is still reporting the correct latest version but it would be better to deal with this instead of hoping it doesn't ever become a problem.

This simply updates the livecheckable to use the [Download](https://wasd.urz.uni-magdeburg.de/jschulen/ocr/download.html) page and updates the regex to only match archives like `gocr-0.52.tar.gz`.