### PR TITLE
pngcrush: update url and regex

### DIFF
--- a/Livecheckables/pngcrush.rb
+++ b/Livecheckables/pngcrush.rb
@@ -1,6 +1,6 @@
 class Pngcrush
   livecheck do
-    url "https://pmt.sourceforge.io/pngcrush/ChangeLog.html"
-    regex(/Version ([0-9.]+) /i)
+    url :stable
+    regex(%r{url=.*?/pngcrush[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `pngcrush` checks an HTML changelog on SourceForge. Updating the regex to be case insensitive ended up matching more versions than before, which brought this to my attention.

This updates the livecheckable to use the `stable` URL, which uses the SourceForge strategy, and updates the regex accordingly.