### PR TITLE
unixodbc: update url and regex

### DIFF
--- a/Livecheckables/unixodbc.rb
+++ b/Livecheckables/unixodbc.rb
@@ -1,6 +1,6 @@
 class Unixodbc
   livecheck do
-    url "http://www.unixodbc.org/unixODBC.html"
-    regex(/\s+([0-9.]+) Released/i)
+    url "http://www.unixodbc.org/download.html"
+    regex(/href=.*?unixODBC[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `unixodbc` started to match some additional versions when the regex was updated to be case insensitive. This was appropriate but this check was brought to my attention as a result.

This updates the livecheckable to check the downloads page instead, which is where the stable archive is found.