### PR TITLE
perl: update regex

### DIFF
--- a/Livecheckables/perl.rb
+++ b/Livecheckables/perl.rb
@@ -1,6 +1,6 @@
 class Perl
   livecheck do
     url "https://www.cpan.org/src/"
-    regex(/href=.*?perl-v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?perl[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
@miccal brought it to our attention that Perl uses even-numbered minor versions to indicate stable releases (with odd-numbered versions being development releases).

This updates the regex in the existing livecheckable for `perl` to restrict matching to even-numbered minor versions, in the same way that we do for a number of other checks (primarly GNOME-related).