### PR TITLE
gsoap: update url and regex

### DIFF
--- a/Livecheckables/gsoap.rb
+++ b/Livecheckables/gsoap.rb
@@ -1,6 +1,6 @@
 class Gsoap
   livecheck do
-    url "https://sourceforge.net/projects/gsoap2/files/gsoap-2.8/"
-    regex(%r{/gsoap-2.8/gsoap_(2.8[0-9.]+)\.zip}i)
+    url :stable
+    regex(%r{url=.*?/gsoap[._-]v?(\d+(?:\.\d+)+)\.zip}i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `gsoap` artificially restricts matching to 2.8.x versions, which doesn't seem necessary.

This also replaces the existing SourceForge URL with `:stable`, which uses the `Sourceforge` strategy, and updates the regex accordingly.