### PR TITLE
sqlite: update regex

### DIFF
--- a/Livecheckables/sqlite.rb
+++ b/Livecheckables/sqlite.rb
@@ -1,6 +1,6 @@
 class Sqlite
   livecheck do
     url "https://sqlite.org/news.html"
-    regex(/(3(?:\.[0-9]+)+)/i)
+    regex(%r{v?(\d+(?:\.\d+)+)</h3>}i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `sqlite` was artificially restricted to a major version of 3 but this didn't seem necessary.

This updates the regex to match versions on the News page in a different manner, which will continue to work when there's a new major version.