### PR TITLE
dovecot: update url and regex

### DIFF
--- a/Livecheckables/dovecot.rb
+++ b/Livecheckables/dovecot.rb
@@ -1,6 +1,6 @@
 class Dovecot
   livecheck do
-    url "https://dovecot.org/releases/2.3/"
-    regex(/dovecot-(\d+\.\d+([0-9rc.]+)?)\.t/i)
+    url "https://dovecot.org/download"
+    regex(/href=.*?dovecot[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `dovecot` uses a URL that's restricted to a specific major/minor version. This becomes a problem when a new major/minor release happens, as the check will no longer find new versions and has to be manually updated to work again.

This updates the livecheckable to check the first-party downloads page instead and also brings the regex up to current standards.