### PR TITLE
wildfly-as: update regex

### DIFF
--- a/Livecheckables/wildfly-as.rb
+++ b/Livecheckables/wildfly-as.rb
@@ -1,6 +1,6 @@
 class WildflyAs
   livecheck do
     url "https://wildfly.org/downloads/"
-    regex(/href=.*?wildfly-([0-9.]+\.Final)\.t/i)
+    regex(/href=.*?wildfly[._-]v?(\d+(?:\.\d+)+\.Final)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `wildfly-as` livecheckable up to current standards:

* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9.]+)`