### PR TITLE
ircii: update url and regex

### DIFF
--- a/Livecheckables/ircii.rb
+++ b/Livecheckables/ircii.rb
@@ -1,6 +1,6 @@
 class Ircii
   livecheck do
-    url :homepage
-    regex(/current release is ircII ([0-9]+)/i)
+    url "https://ircii.warped.com/"
+    regex(/href=.*?ircii[._-]v?(\d{6,8})\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `ircii` livecheckable up to current standards:

* Align the check with the location of the stable archive, when possible
* Use `href=.*?` to match the file name within the `href` attribute, when applicable
* Use the `[._-]` delimiter between the software name and version
* Use `v?(\d{6,8})` for date-based versions instead of `([0-9]+)`