### PR TITLE
libhdhomerun: update regex

### DIFF
--- a/Livecheckables/libhdhomerun.rb
+++ b/Livecheckables/libhdhomerun.rb
@@ -1,6 +1,6 @@
 class Libhdhomerun
   livecheck do
     url :homepage
-    regex(/href=.*?libhdhomerun_([0-9]+)\.t/i)
+    regex(/href=.*?libhdhomerun[._-]v?(\d{6,8})\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `libhdhomerun ` livecheckable up to current standards:

* Use the `[._-]` delimiter between the software name and version
* Use `v?(\d{6,8})` for date-based versions instead of `([0-9]+)`