### PR TITLE
cfr-decompiler: update regex

### DIFF
--- a/Livecheckables/cfr-decompiler.rb
+++ b/Livecheckables/cfr-decompiler.rb
@@ -1,6 +1,6 @@
 class CfrDecompiler
   livecheck do
     url :homepage
-    regex(/href=.*?cfr-([0-9_.]+)\.jar/i)
+    regex(/href=.*?cfr[._-]v?(\d+(?:\.\d+)+)\.jar/i)
   end
 end


### PR DESCRIPTION
This brings the existing `cfr-decompiler` livecheckable up to current standards:

* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9_.]+)`