### PR TITLE
dcmtk: update regex

### DIFF
--- a/Livecheckables/dcmtk.rb
+++ b/Livecheckables/dcmtk.rb
@@ -1,6 +1,6 @@
 class Dcmtk
   livecheck do
     url "https://dicom.offis.de/download/dcmtk/release/"
-    regex(/href=.*?dcmtk-([0-9._]+)\.t/i)
+    regex(/href=.*?dcmtk[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `dcmtk` livecheckable up to current standards:

* Replace the delimiter between software name and version in file name with `[._-]`
* Use `v?(\d+(?:\.\d+)+)` instead of `([0-9._]+)`