### PR TITLE
phplint: update url and regex

### DIFF
--- a/Livecheckables/phplint.rb
+++ b/Livecheckables/phplint.rb
@@ -1,6 +1,7 @@
 class Phplint
+  # The downloads page uses `href2` attributes instead of `href`.
   livecheck do
-    url "https://www.icosaedro.it/phplint/CHANGES.txt"
-    regex(/Version ([0-9._]+):/i)
+    url "https://www.icosaedro.it/phplint/download.html"
+    regex(/href2?=.*?phplint[._-]v?(\d+(?:\.\d+)+(?:[._-]\d{6,8})?)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `example` livecheckable up to current standards:

* Use the `[._-]` delimiter between the software name and version
* Use some form of `v?(\d+(?:\.\d+)+)` instead of `([0-9._]+)`

Besides the above, this updates the livecheckable to check the first-party downloads page instead of the `CHANGES.txt` file.