### PR TITLE
Update ([0-9.]+) in regexes

### DIFF
--- a/Livecheckables/abnfgen.rb
+++ b/Livecheckables/abnfgen.rb
@@ -1,6 +1,6 @@
 class Abnfgen
   livecheck do
     url :homepage
-    regex(%r{href=.*?/abnfgen-([0-9.]+)\.t}i)
+    regex(%r{href=.*?/abnfgen-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/adns.rb
+++ b/Livecheckables/adns.rb
@@ -1,6 +1,6 @@
 class Adns
   livecheck do
     url "https://www.chiark.greenend.org.uk/~ian/adns/ftp/"
-    regex(/href=.*?adns-([0-9.]+)\.t/i)
+    regex(/href=.*?adns-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/aircrack-ng.rb
+++ b/Livecheckables/aircrack-ng.rb
@@ -1,6 +1,6 @@
 class AircrackNg
   livecheck do
     url :homepage
-    regex(/href=.*?aircrack-ng-([0-9.]+)\.t/i)
+    regex(/href=.*?aircrack-ng-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ansible-lint.rb
+++ b/Livecheckables/ansible-lint.rb
@@ -1,6 +1,6 @@
 class AnsibleLint
   livecheck do
     url :stable
-    regex(/href=.*?ansible-lint-([0-9.]+)\.t/i)
+    regex(/href=.*?ansible-lint-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ansible.rb
+++ b/Livecheckables/ansible.rb
@@ -1,6 +1,6 @@
 class Ansible
   livecheck do
     url "https://releases.ansible.com/ansible/"
-    regex(/href=.*?ansible-([0-9.]+)\.t/i)
+    regex(/href=.*?ansible-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/antlr.rb
+++ b/Livecheckables/antlr.rb
@@ -1,6 +1,6 @@
 class Antlr
   livecheck do
     url "https://www.antlr.org/download/"
-    regex(/antlr-([0-9.]+)-complete\.jar/i)
+    regex(/antlr-v?(\d+(?:\.\d+)+)-complete\.jar/i)
   end
 end

--- a/Livecheckables/antlr4-cpp-runtime.rb
+++ b/Livecheckables/antlr4-cpp-runtime.rb
@@ -1,6 +1,6 @@
 class Antlr4CppRuntime
   livecheck do
     url "https://www.antlr.org/download/"
-    regex(/antlr4-cpp-runtime-([0-9.]+)-source\.zip/i)
+    regex(/antlr4-cpp-runtime-v?(\d+(?:\.\d+)+)-source\.zip/i)
   end
 end

--- a/Livecheckables/archivemount.rb
+++ b/Livecheckables/archivemount.rb
@@ -1,6 +1,6 @@
 class Archivemount
   livecheck do
     url :homepage
-    regex(/href=.*?archivemount-([0-9.]+)\.t/i)
+    regex(/href=.*?archivemount-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/asio.rb
+++ b/Livecheckables/asio.rb
@@ -1,6 +1,6 @@
 class Asio
   livecheck do
     url "https://sourceforge.net/projects/asio/"
-    regex(%r{Stable.*?/asio-([0-9.]+)\.t}i)
+    regex(%r{Stable.*?/asio-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/astyle.rb
+++ b/Livecheckables/astyle.rb
@@ -1,6 +1,6 @@
 class Astyle
   livecheck do
     url "https://sourceforge.net/projects/astyle/"
-    regex(%r{.*?/astyle_([0-9.]+)_}i)
+    regex(%r{.*?/astyle_v?(\d+(?:\.\d+)+)_}i)
   end
 end

--- a/Livecheckables/atlassian-cli.rb
+++ b/Livecheckables/atlassian-cli.rb
@@ -1,6 +1,6 @@
 class AtlassianCli
   livecheck do
     url "https://marketplace.atlassian.com/plugins/org.swift.atlassian.cli/versions"
-    regex(/class="version">([0-9.]+)</i)
+    regex(/class="version">v?(\d+(?:\.\d+)+)</i)
   end
 end

--- a/Livecheckables/augustus.rb
+++ b/Livecheckables/augustus.rb
@@ -1,6 +1,6 @@
 class Augustus
   livecheck do
     url "http://bioinf.uni-greifswald.de/augustus/binaries/"
-    regex(/href=.*?augustus-([0-9.]+)\.t/i)
+    regex(/href=.*?augustus-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/autogen.rb
+++ b/Livecheckables/autogen.rb
@@ -1,6 +1,6 @@
 class Autogen
   livecheck do
     url "https://ftp.gnu.org/gnu/autogen/"
-    regex(%r{href=.*?rel([0-9.]+)/?["' >]}i)
+    regex(%r{href=.*?rel(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/aws-elasticbeanstalk.rb
+++ b/Livecheckables/aws-elasticbeanstalk.rb
@@ -1,6 +1,6 @@
 class AwsElasticbeanstalk
   livecheck do
     url :stable
-    regex(/href=.*?awsebcli-([0-9.]+)\.t/i)
+    regex(/href=.*?awsebcli-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/babeld.rb
+++ b/Livecheckables/babeld.rb
@@ -1,6 +1,6 @@
 class Babeld
   livecheck do
     url "https://www.irif.fr/~jch/software/files/"
-    regex(/href=.*?babeld-([0-9.]+)\.t/i)
+    regex(/href=.*?babeld-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/baresip.rb
+++ b/Livecheckables/baresip.rb
@@ -1,6 +1,6 @@
 class Baresip
   livecheck do
     url "http://www.creytiv.com/pub/"
-    regex(/href=.*?baresip-([0-9.]+)\.t/i)
+    regex(/href=.*?baresip-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/batik.rb
+++ b/Livecheckables/batik.rb
@@ -1,6 +1,6 @@
 class Batik
   livecheck do
     url "https://xmlgraphics.apache.org/batik/download.html"
-    regex(/href=.*?batik-bin-([0-9.]+)\.t/i)
+    regex(/href=.*?batik-bin-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/bibtex2html.rb
+++ b/Livecheckables/bibtex2html.rb
@@ -1,6 +1,6 @@
 class Bibtex2html
   livecheck do
     url :homepage
-    regex(/The current version is ([0-9.]+) and/i)
+    regex(/The current version is v?(\d+(?:\.\d+)+) and/i)
   end
 end

--- a/Livecheckables/bibutils.rb
+++ b/Livecheckables/bibutils.rb
@@ -1,6 +1,6 @@
 class Bibutils
   livecheck do
     url "sourceforge.net/projects/bibutils/files/"
-    regex(%r{/bibutils/files/bibutils_([0-9.]+)_src\.t}i)
+    regex(%r{/bibutils/files/bibutils_v?(\d+(?:\.\d+)+)_src\.t}i)
   end
 end

--- a/Livecheckables/bitlbee.rb
+++ b/Livecheckables/bitlbee.rb
@@ -1,6 +1,6 @@
 class Bitlbee
   livecheck do
     url "https://get.bitlbee.org/src/"
-    regex(/href=.*?bitlbee-([0-9.]+)\.t/i)
+    regex(/href=.*?bitlbee-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/boost.rb
+++ b/Livecheckables/boost.rb
@@ -1,6 +1,6 @@
 class Boost
   livecheck do
     url "https://www.boost.org/feed/downloads.rss"
-    regex(/Version ([0-9.]+)/)
+    regex(/Version v?(\d+(?:\.\d+)+)/)
   end
 end

--- a/Livecheckables/bzt.rb
+++ b/Livecheckables/bzt.rb
@@ -1,6 +1,6 @@
 class Bzt
   livecheck do
     url :stable
-    regex(/href=.*?bzt-([0-9.]+)\.t/i)
+    regex(/href=.*?bzt-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/c-kermit.rb
+++ b/Livecheckables/c-kermit.rb
@@ -1,6 +1,6 @@
 class CKermit
   livecheck do
     url "http://www.kermitproject.org/ck90.html"
-    regex(/The current C-Kermit release is ([0-9.]+) /i)
+    regex(/The current C-Kermit release is v?(\d+(?:\.\d+)+) /i)
   end
 end

--- a/Livecheckables/cabal-install.rb
+++ b/Livecheckables/cabal-install.rb
@@ -1,6 +1,6 @@
 class CabalInstall
   livecheck do
     url "https://www.haskell.org/cabal/download.html"
-    regex(/cabal-install tool \(version ([0-9.]+)/i)
+    regex(/cabal-install tool \(version v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/cabextract.rb
+++ b/Livecheckables/cabextract.rb
@@ -1,6 +1,6 @@
 class Cabextract
   livecheck do
     url "https://github.com/kyz/libmspack.git"
-    regex(/v([0-9.]+)/i)
+    regex(/v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/camlp5.rb
+++ b/Livecheckables/camlp5.rb
@@ -1,6 +1,6 @@
 class Camlp5
   livecheck do
     url :homepage
-    regex(%r{The current distributed version is <b>([0-9.]+)</b>}i)
+    regex(%r{The current distributed version is <b>v?(\d+(?:\.\d+)+)</b>}i)
   end
 end

--- a/Livecheckables/cfitsio.rb
+++ b/Livecheckables/cfitsio.rb
@@ -1,6 +1,6 @@
 class Cfitsio
   livecheck do
     url :homepage
-    regex(/Download the latest ([0-9.]+) version of CFITSIO/i)
+    regex(/Download the latest v?(\d+(?:\.\d+)+) version of CFITSIO/i)
   end
 end

--- a/Livecheckables/cgdb.rb
+++ b/Livecheckables/cgdb.rb
@@ -1,6 +1,6 @@
 class Cgdb
   livecheck do
     url "https://cgdb.me/files/"
-    regex(/href=.*?cgdb-([0-9.]+)\.t/i)
+    regex(/href=.*?cgdb-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/charm-tools.rb
+++ b/Livecheckables/charm-tools.rb
@@ -1,6 +1,6 @@
 class CharmTools
   livecheck do
     url :stable
-    regex(/href=.*?charm-tools-([0-9.]+)\.t/i)
+    regex(/href=.*?charm-tools-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/check_postgres.rb
+++ b/Livecheckables/check_postgres.rb
@@ -1,6 +1,6 @@
 class CheckPostgres
   livecheck do
     url "https://bucardo.org/check_postgres/"
-    regex(/latest version.*?([0-9.]+)/i)
+    regex(/latest version.*?v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/chicken.rb
+++ b/Livecheckables/chicken.rb
@@ -1,6 +1,6 @@
 class Chicken
   livecheck do
     url "https://code.call-cc.org/releases/current/"
-    regex(/href=.*?chicken-([0-9.]+)\.t/i)
+    regex(/href=.*?chicken-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/chuck.rb
+++ b/Livecheckables/chuck.rb
@@ -1,6 +1,6 @@
 class Chuck
   livecheck do
     url "https://chuck.cs.princeton.edu/release/files/"
-    regex(/href=.*?chuck-([0-9.]+)\.t/i)
+    regex(/href=.*?chuck-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/clamav.rb
+++ b/Livecheckables/clamav.rb
@@ -1,6 +1,6 @@
 class Clamav
   livecheck do
     url "https://www.clamav.net/downloads"
-    regex(/href=.*?clamav-([0-9.]+)\.t/i)
+    regex(/href=.*?clamav-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/clhep.rb
+++ b/Livecheckables/clhep.rb
@@ -1,6 +1,6 @@
 class Clhep
   livecheck do
     url :homepage
-    regex(%r{atest release.*?<b>([0-9.]+)</b>}im)
+    regex(%r{atest release.*?<b>v?(\d+(?:\.\d+)+)</b>}im)
   end
 end

--- a/Livecheckables/clog.rb
+++ b/Livecheckables/clog.rb
@@ -1,6 +1,6 @@
 class Clog
   livecheck do
     url "https://gothenburgbitfactory.org"
-    regex(%r{gothenburgbitfactory.org/download/clog-([0-9.]+)\.t}i)
+    regex(%r{gothenburgbitfactory.org/download/clog-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/cmake.rb
+++ b/Livecheckables/cmake.rb
@@ -1,6 +1,6 @@
 class Cmake
   livecheck do
     url "https://cmake.org/download/"
-    regex(/Latest Release \(([0-9.]+)\)/i)
+    regex(/Latest Release \(v?(\d+(?:\.\d+)+)\)/i)
   end
 end

--- a/Livecheckables/codemod.rb
+++ b/Livecheckables/codemod.rb
@@ -1,6 +1,6 @@
 class Codemod
   livecheck do
     url :stable
-    regex(/href=.*?codemod-([0-9.]+)\.t/i)
+    regex(/href=.*?codemod-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/colordiff.rb
+++ b/Livecheckables/colordiff.rb
@@ -1,6 +1,6 @@
 class Colordiff
   livecheck do
     url :homepage
-    regex(/colordiff-([0-9.]+)\.t/i)
+    regex(/colordiff-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/convmv.rb
+++ b/Livecheckables/convmv.rb
@@ -1,6 +1,6 @@
 class Convmv
   livecheck do
     url :homepage
-    regex(/convmv-([0-9.]+)\.t/i)
+    regex(/convmv-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/csvkit.rb
+++ b/Livecheckables/csvkit.rb
@@ -1,6 +1,6 @@
 class Csvkit
   livecheck do
     url :stable
-    regex(/href=.*?csvkit-([0-9.]+)\.t/i)
+    regex(/href=.*?csvkit-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/cuba.rb
+++ b/Livecheckables/cuba.rb
@@ -1,6 +1,6 @@
 class Cuba
   livecheck do
     url :homepage
-    regex(/href=.*?Cuba-([0-9.]+)\.t/i)
+    regex(/href=.*?Cuba-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/cython.rb
+++ b/Livecheckables/cython.rb
@@ -1,6 +1,6 @@
 class Cython
   livecheck do
     url :stable
-    regex(/href=.*?Cython-([0-9.]+)\.t/i)
+    regex(/href=.*?Cython-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dar.rb
+++ b/Livecheckables/dar.rb
@@ -1,6 +1,6 @@
 class Dar
   livecheck do
     url "https://sourceforge.net/projects/dar/"
-    regex(%r{.*?/dar-([0-9.]+)\.t}i)
+    regex(%r{.*?/dar-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/dbus-glib.rb
+++ b/Livecheckables/dbus-glib.rb
@@ -1,6 +1,6 @@
 class DbusGlib
   livecheck do
     url "https://dbus.freedesktop.org/releases/dbus-glib/"
-    regex(/href=.*?dbus-glib-([0-9.]+)\.t/i)
+    regex(/href=.*?dbus-glib-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dcraw.rb
+++ b/Livecheckables/dcraw.rb
@@ -1,6 +1,6 @@
 class Dcraw
   livecheck do
     url "https://distfiles.macports.org/dcraw/"
-    regex(/href=.*?dcraw-([0-9.]+)\.t/i)
+    regex(/href=.*?dcraw-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/deark.rb
+++ b/Livecheckables/deark.rb
@@ -1,6 +1,6 @@
 class Deark
   livecheck do
     url "https://entropymine.com/deark/releases/"
-    regex(/href=.*?deark-([0-9.]+)\.t/i)
+    regex(/href=.*?deark-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dfix.rb
+++ b/Livecheckables/dfix.rb
@@ -1,6 +1,6 @@
 class Dfix
   livecheck do
     url "https://code.dlang.org/packages/dfix"
-    regex(%r{"badge">([0-9.]+)</strong>}i)
+    regex(%r{"badge">v?(\d+(?:\.\d+)+)</strong>}i)
   end
 end

--- a/Livecheckables/doitlive.rb
+++ b/Livecheckables/doitlive.rb
@@ -1,6 +1,6 @@
 class Doitlive
   livecheck do
     url :stable
-    regex(/href=.*?doitlive-([0-9.]+)\.t/i)
+    regex(/href=.*?doitlive-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dsh.rb
+++ b/Livecheckables/dsh.rb
@@ -1,6 +1,6 @@
 class Dsh
   livecheck do
     url "https://www.netfort.gr.jp/~dancer/software/downloads/"
-    regex(/href=.*?dsh-([0-9.]+)\.t/i)
+    regex(/href=.*?dsh-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dtc.rb
+++ b/Livecheckables/dtc.rb
@@ -1,6 +1,6 @@
 class Dtc
   livecheck do
     url "https://mirrors.edge.kernel.org/pub/software/utils/dtc/"
-    regex(/href=.*?dtc-([0-9.]+)\.t/i)
+    regex(/href=.*?dtc-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/duply.rb
+++ b/Livecheckables/duply.rb
@@ -1,6 +1,6 @@
 class Duply
   livecheck do
     url :homepage
-    regex(%r{<title><!\[CDATA\[/duply \(simple duplicity\).*?duply_([0-9.]+)\.t}i)
+    regex(%r{<title><!\[CDATA\[/duply \(simple duplicity\).*?duply_v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/dvdauthor.rb
+++ b/Livecheckables/dvdauthor.rb
@@ -1,6 +1,6 @@
 class Dvdauthor
   livecheck do
     url "https://sourceforge.net/projects/dvdauthor/"
-    regex(%r{/dvdauthor-([0-9.]+)\.t}i)
+    regex(%r{/dvdauthor-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/dvdrtools.rb
+++ b/Livecheckables/dvdrtools.rb
@@ -1,6 +1,6 @@
 class Dvdrtools
   livecheck do
     url "https://download.savannah.gnu.org/releases/dvdrtools/"
-    regex(/href=.*?dvdrtools-([0-9.]+)\.t/i)
+    regex(/href=.*?dvdrtools-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dwdiff.rb
+++ b/Livecheckables/dwdiff.rb
@@ -1,6 +1,6 @@
 class Dwdiff
   livecheck do
     url "https://os.ghalkes.nl/dist/"
-    regex(/href=.*?dwdiff-([0-9.]+)\.t/i)
+    regex(/href=.*?dwdiff-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dxflib.rb
+++ b/Livecheckables/dxflib.rb
@@ -1,6 +1,6 @@
 class Dxflib
   livecheck do
     url "https://www.ribbonsoft.com/en/dxflib-downloads"
-    regex(/href=.*?dxflib-([0-9.]+)-src\.t/i)
+    regex(/href=.*?dxflib-v?(\d+(?:\.\d+)+)-src\.t/i)
   end
 end

--- a/Livecheckables/dxpy.rb
+++ b/Livecheckables/dxpy.rb
@@ -1,6 +1,6 @@
 class Dxpy
   livecheck do
     url :stable
-    regex(/href=.*?dxpy-([0-9.]+)\.t/i)
+    regex(/href=.*?dxpy-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/e2fsprogs.rb
+++ b/Livecheckables/e2fsprogs.rb
@@ -1,6 +1,6 @@
 class E2fsprogs
   livecheck do
     url "https://sourceforge.net/projects/e2fsprogs/"
-    regex(/e2fsprogs-([0-9.]+)\.t/i)
+    regex(/e2fsprogs-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/eccodes.rb
+++ b/Livecheckables/eccodes.rb
@@ -1,6 +1,6 @@
 class Eccodes
   livecheck do
     url "https://software.ecmwf.int/wiki/display/ECC/Releases"
-    regex(/href=.*?eccodes-([0-9.]+)-Source\.t/i)
+    regex(/href=.*?eccodes-v?(\d+(?:\.\d+)+)-Source\.t/i)
   end
 end

--- a/Livecheckables/erlang.rb
+++ b/Livecheckables/erlang.rb
@@ -1,6 +1,6 @@
 class Erlang
   livecheck do
     url :head
-    regex(/OTP-([0-9.]+)$/i)
+    regex(/OTP-v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/exact-image.rb
+++ b/Livecheckables/exact-image.rb
@@ -1,6 +1,6 @@
 class ExactImage
   livecheck do
     url "https://dl.exactcode.de/oss/exact-image/"
-    regex(/href=.*?exact-image-([0-9.]+)\.t/i)
+    regex(/href=.*?exact-image-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/exiftran.rb
+++ b/Livecheckables/exiftran.rb
@@ -1,6 +1,6 @@
 class Exiftran
   livecheck do
     url "https://www.kraxel.org/releases/fbida/"
-    regex(/href=.*?fbida-([0-9.]+)\.t/i)
+    regex(/href=.*?fbida-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/exomizer.rb
+++ b/Livecheckables/exomizer.rb
@@ -1,6 +1,6 @@
 class Exomizer
   livecheck do
     url "https://bitbucket.org/magli143/exomizer/wiki/browse/downloads/"
-    regex(/href=.*?exomizer-([0-9.]+)\.zip/i)
+    regex(/href=.*?exomizer-v?(\d+(?:\.\d+)+)\.zip/i)
   end
 end

--- a/Livecheckables/fatsort.rb
+++ b/Livecheckables/fatsort.rb
@@ -1,6 +1,6 @@
 class Fatsort
   livecheck do
     url "https://sourceforge.net/projects/fatsort/"
-    regex(/fatsort-([0-9.]+)\.[0-9]+\.t/i)
+    regex(/fatsort-v?(\d+(?:\.\d+)+)\.[0-9]+\.t/i)
   end
 end

--- a/Livecheckables/fb-client.rb
+++ b/Livecheckables/fb-client.rb
@@ -1,6 +1,6 @@
 class FbClient
   livecheck do
     url :homepage
-    regex(%r{Latest release:.*?/fb-([0-9.]+)\.t}i)
+    regex(%r{Latest release:.*?/fb-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/ffmpeg.rb
+++ b/Livecheckables/ffmpeg.rb
@@ -1,6 +1,6 @@
 class Ffmpeg
   livecheck do
     url "https://ffmpeg.org/download.html"
-    regex(/ffmpeg-([0-9.]+)\.t/i)
+    regex(/ffmpeg-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/fftw.rb
+++ b/Livecheckables/fftw.rb
@@ -1,6 +1,6 @@
 class Fftw
   livecheck do
     url "http://fftw.org/"
-    regex(%r{latest official release.*? <b>([0-9.]+)</b>}i)
+    regex(%r{latest official release.*? <b>v?(\d+(?:\.\d+)+)</b>}i)
   end
 end

--- a/Livecheckables/flawfinder.rb
+++ b/Livecheckables/flawfinder.rb
@@ -1,6 +1,6 @@
 class Flawfinder
   livecheck do
     url :homepage
-    regex(/href=.*?flawfinder-([0-9.]+)\.t/i)
+    regex(/href=.*?flawfinder-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/flowgrind.rb
+++ b/Livecheckables/flowgrind.rb
@@ -1,6 +1,6 @@
 class Flowgrind
   livecheck do
     url :homepage
-    regex(/Latest version is flowgrind-([0-9.]+)/i)
+    regex(/Latest version is flowgrind-v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/flyway.rb
+++ b/Livecheckables/flyway.rb
@@ -1,6 +1,6 @@
 class Flyway
   livecheck do
     url :homepage
-    regex(/Get Started with Flyway\s+([0-9.]+) </im)
+    regex(/Get Started with Flyway\s+v?(\d+(?:\.\d+)+) </im)
   end
 end

--- a/Livecheckables/fontconfig.rb
+++ b/Livecheckables/fontconfig.rb
@@ -1,6 +1,6 @@
 class Fontconfig
   livecheck do
     url :homepage
-    regex(/current stable.*? ([0-9.]+)\./i)
+    regex(/current stable.*? v?(\d+(?:\.\d+)+)\./i)
   end
 end

--- a/Livecheckables/fox.rb
+++ b/Livecheckables/fox.rb
@@ -1,6 +1,6 @@
 class Fox
   livecheck do
     url "http://www.fox-toolkit.org/news.html"
-    regex(/FOX STABLE ([0-9.]+)/i)
+    regex(/FOX STABLE v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/fpc.rb
+++ b/Livecheckables/fpc.rb
@@ -1,6 +1,6 @@
 class Fpc
   livecheck do
     url "https://sourceforge.net/projects/freepascal/"
-    regex(%r{/Linux/([0-9.]+)/readme.txt}i)
+    regex(%r{/Linux/v?(\d+(?:\.\d+)+)/readme.txt}i)
   end
 end

--- a/Livecheckables/freeciv.rb
+++ b/Livecheckables/freeciv.rb
@@ -1,6 +1,6 @@
 class Freeciv
   livecheck do
     url "https://sourceforge.net/projects/freeciv/"
-    regex(%r{/freeciv-([0-9.]+)\.t.*?z.*?/}i)
+    regex(%r{/freeciv-v?(\d+(?:\.\d+)+)\.t.*?z.*?/}i)
   end
 end

--- a/Livecheckables/freexl.rb
+++ b/Livecheckables/freexl.rb
@@ -1,6 +1,6 @@
 class Freexl
   livecheck do
     url :homepage
-    regex(%r{current version is <b>([0-9.]+)</b>}i)
+    regex(%r{current version is <b>v?(\d+(?:\.\d+)+)</b>}i)
   end
 end

--- a/Livecheckables/fuse-emulator.rb
+++ b/Livecheckables/fuse-emulator.rb
@@ -1,6 +1,6 @@
 class FuseEmulator
   livecheck do
     url "https://sourceforge.net/projects/fuse-emulator/"
-    regex(%r{/fuse/[0-9.]+/fuse-([0-9.]+)\.t}i)
+    regex(%r{/fuse/[0-9.]+/fuse-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/gdal.rb
+++ b/Livecheckables/gdal.rb
@@ -1,6 +1,6 @@
 class Gdal
   livecheck do
     url "https://download.osgeo.org/gdal/CURRENT/"
-    regex(/href=.*?gdal-([0-9.]+)\.t/i)
+    regex(/href=.*?gdal-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/geeqie.rb
+++ b/Livecheckables/geeqie.rb
@@ -1,6 +1,6 @@
 class Geeqie
   livecheck do
     url :homepage
-    regex(/href=.*?geeqie-([0-9.]+)\.t/i)
+    regex(/href=.*?geeqie-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gerbv.rb
+++ b/Livecheckables/gerbv.rb
@@ -1,6 +1,6 @@
 class Gerbv
   livecheck do
     url "https://sourceforge.net/projects/gerbv/"
-    regex(%r{/gerbv/gerbv-([0-9.]+)/}i)
+    regex(%r{/gerbv/gerbv-v?(\d+(?:\.\d+)+)/}i)
   end
 end

--- a/Livecheckables/gloox.rb
+++ b/Livecheckables/gloox.rb
@@ -1,6 +1,6 @@
 class Gloox
   livecheck do
     url :homepage
-    regex(%r{Latest stable version.*?/gloox-([0-9.]+)\.t}i)
+    regex(%r{Latest stable version.*?/gloox-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/gmic.rb
+++ b/Livecheckables/gmic.rb
@@ -1,6 +1,6 @@
 class Gmic
   livecheck do
     url "https://gmic.eu/files/source/"
-    regex(/gmic_([0-9.]+)\.t/i)
+    regex(/gmic_v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gnupg.rb
+++ b/Livecheckables/gnupg.rb
@@ -1,6 +1,6 @@
 class Gnupg
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gnupg/"
-    regex(/gnupg-([0-9.]+)\.t/i)
+    regex(/gnupg-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gnustep-make.rb
+++ b/Livecheckables/gnustep-make.rb
@@ -1,6 +1,6 @@
 class GnustepMake
   livecheck do
     url "http://ftpmain.gnustep.org/pub/gnustep/core/"
-    regex(/href=.*?gnustep-make-([0-9.]+)\.t/i)
+    regex(/href=.*?gnustep-make-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/go.rb
+++ b/Livecheckables/go.rb
@@ -1,6 +1,6 @@
 class Go
   livecheck do
     url "https://golang.org/dl/"
-    regex(/go([0-9.]+)\.src/i)
+    regex(/gov?(\d+(?:\.\d+)+)\.src/i)
   end
 end

--- a/Livecheckables/gpgme.rb
+++ b/Livecheckables/gpgme.rb
@@ -1,6 +1,6 @@
 class Gpgme
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gpgme/"
-    regex(/gpgme-([0-9.]+)\.t/i)
+    regex(/gpgme-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gphoto2.rb
+++ b/Livecheckables/gphoto2.rb
@@ -1,6 +1,6 @@
 class Gphoto2
   livecheck do
     url "https://sourceforge.net/projects/gphoto/"
-    regex(%r{.*?/gphoto2-([0-9.]+)\.t}i)
+    regex(%r{.*?/gphoto2-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/gpsim.rb
+++ b/Livecheckables/gpsim.rb
@@ -1,6 +1,6 @@
 class Gpsim
   livecheck do
     url "https://sourceforge.net/projects/gpsim/"
-    regex(%r{/gpsim-([0-9.]+)\.t}i)
+    regex(%r{/gpsim-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/graph-tool.rb
+++ b/Livecheckables/graph-tool.rb
@@ -1,6 +1,6 @@
 class GraphTool
   livecheck do
     url "https://downloads.skewed.de/graph-tool/"
-    regex(/href=.*?graph-tool-([0-9.]+)\.t/i)
+    regex(/href=.*?graph-tool-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/graphicsmagick.rb
+++ b/Livecheckables/graphicsmagick.rb
@@ -1,6 +1,6 @@
 class Graphicsmagick
   livecheck do
     url :homepage
-    regex(/<td>([0-9.]+) \(Released/i)
+    regex(/<td>v?(\d+(?:\.\d+)+) \(Released/i)
   end
 end

--- a/Livecheckables/gromacs.rb
+++ b/Livecheckables/gromacs.rb
@@ -1,6 +1,6 @@
 class Gromacs
   livecheck do
     url "https://ftp.gromacs.org/pub/gromacs/"
-    regex(/href=.*?gromacs-([0-9.]+)\.t/i)
+    regex(/href=.*?gromacs-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/groonga.rb
+++ b/Livecheckables/groonga.rb
@@ -1,6 +1,6 @@
 class Groonga
   livecheck do
     url :homepage
-    regex(%r{>([0-9.]+)</a> is the latest release}i)
+    regex(%r{>v?(\d+(?:\.\d+)+)</a> is the latest release}i)
   end
 end

--- a/Livecheckables/gwyddion.rb
+++ b/Livecheckables/gwyddion.rb
@@ -1,6 +1,6 @@
 class Gwyddion
   livecheck do
     url "http://gwyddion.net/download.php"
-    regex(/stable version Gwyddion ([0-9.]+):/i)
+    regex(/stable version Gwyddion v?(\d+(?:\.\d+)+):/i)
   end
 end

--- a/Livecheckables/haproxy.rb
+++ b/Livecheckables/haproxy.rb
@@ -1,6 +1,6 @@
 class Haproxy
   livecheck do
     url :homepage
-    regex(/haproxy-([0-9.]+)\.t/i)
+    regex(/haproxy-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/hdf5@1.8.rb
+++ b/Livecheckables/hdf5@1.8.rb
@@ -1,6 +1,6 @@
 class Hdf5AT18
   livecheck do
     url "https://support.hdfgroup.org/ftp/HDF5/current18/src/"
-    regex(/hdf5-([0-9.]+)\.t/i)
+    regex(/hdf5-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/hercules.rb
+++ b/Livecheckables/hercules.rb
@@ -1,6 +1,6 @@
 class Hercules
   livecheck do
     url :homepage
-    regex(/href=.*?hercules-([0-9.]+)\.t/i)
+    regex(/href=.*?hercules-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/hevea.rb
+++ b/Livecheckables/hevea.rb
@@ -1,6 +1,6 @@
 class Hevea
   livecheck do
     url :homepage
-    regex(/Current version is ([0-9.]+)\./i)
+    regex(/Current version is v?(\d+(?:\.\d+)+)\./i)
   end
 end

--- a/Livecheckables/homebank.rb
+++ b/Livecheckables/homebank.rb
@@ -1,6 +1,6 @@
 class Homebank
   livecheck do
     url "http://homebank.free.fr/public/"
-    regex(/HREF="homebank-([0-9.]+)\.t/i)
+    regex(/HREF="homebank-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/hspell.rb
+++ b/Livecheckables/hspell.rb
@@ -1,6 +1,6 @@
 class Hspell
   livecheck do
     url "http://hspell.ivrix.org.il/download.html"
-    regex(/HREF="hspell-([0-9.]+)\.t/i)
+    regex(/HREF="hspell-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/html-xml-utils.rb
+++ b/Livecheckables/html-xml-utils.rb
@@ -1,6 +1,6 @@
 class HtmlXmlUtils
   livecheck do
     url :homepage
-    regex(/href=.*?html-xml-utils-([0-9.]+)\.t/i)
+    regex(/href=.*?html-xml-utils-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/httrack.rb
+++ b/Livecheckables/httrack.rb
@@ -1,6 +1,6 @@
 class Httrack
   livecheck do
     url "https://mirror.httrack.com/historical/"
-    regex(/httrack-([0-9.]+)\./i)
+    regex(/httrack-v?(\d+(?:\.\d+)+)\./i)
   end
 end

--- a/Livecheckables/i2p.rb
+++ b/Livecheckables/i2p.rb
@@ -1,6 +1,6 @@
 class I2p
   livecheck do
     url "https://geti2p.net/en/download"
-    regex(/i2pinstall_([0-9.]+)\.jar/i)
+    regex(/i2pinstall_v?(\d+(?:\.\d+)+)\.jar/i)
   end
 end

--- a/Livecheckables/i2util.rb
+++ b/Livecheckables/i2util.rb
@@ -1,6 +1,6 @@
 class I2util
   livecheck do
     url "http://software.internet2.edu/sources/I2util/"
-    regex(/href=.*?I2util-([0-9.]+)\.t/i)
+    regex(/href=.*?I2util-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/icarus-verilog.rb
+++ b/Livecheckables/icarus-verilog.rb
@@ -1,6 +1,6 @@
 class IcarusVerilog
   livecheck do
     url "https://ftp.openbsd.org/pub/OpenBSD/distfiles/"
-    regex(/href=.*?verilog-([0-9.]+)\.t/i)
+    regex(/href=.*?verilog-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/icbirc.rb
+++ b/Livecheckables/icbirc.rb
@@ -1,6 +1,6 @@
 class Icbirc
   livecheck do
     url :homepage
-    regex(/href=.*?icbirc-([0-9.]+)\.t/i)
+    regex(/href=.*?icbirc-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/idnits.rb
+++ b/Livecheckables/idnits.rb
@@ -1,6 +1,6 @@
 class Idnits
   livecheck do
     url :homepage
-    regex(/href=.*?idnits-([0-9.]+)\.t/i)
+    regex(/href=.*?idnits-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ii.rb
+++ b/Livecheckables/ii.rb
@@ -1,6 +1,6 @@
 class Ii
   livecheck do
     url "https://dl.suckless.org/tools/"
-    regex(/href=.*?ii-([0-9.]+)\.t/i)
+    regex(/href=.*?ii-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ircd-hybrid.rb
+++ b/Livecheckables/ircd-hybrid.rb
@@ -1,6 +1,6 @@
 class IrcdHybrid
   livecheck do
     url "https://sourceforge.net/projects/ircd-hybrid/"
-    regex(/ircd-hybrid-([0-9.]+)\.t/i)
+    regex(/ircd-hybrid-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/isl.rb
+++ b/Livecheckables/isl.rb
@@ -1,6 +1,6 @@
 class Isl
   livecheck do
     url "http://isl.gforge.inria.fr/"
-    regex(/href=.*?isl-([0-9.]+)\.t/i)
+    regex(/href=.*?isl-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/itex2mml.rb
+++ b/Livecheckables/itex2mml.rb
@@ -1,6 +1,6 @@
 class Itex2mml
   livecheck do
     url "https://golem.ph.utexas.edu/~distler/code/itexToMML/view/head:/itex-src/itex2MML.h"
-    regex(/#define ITEX2MML_VERSION &quot;([0-9.]+)&quot;/i)
+    regex(/#define ITEX2MML_VERSION &quot;v?(\d+(?:\.\d+)+)&quot;/i)
   end
 end

--- a/Livecheckables/ivykis.rb
+++ b/Livecheckables/ivykis.rb
@@ -1,6 +1,6 @@
 class Ivykis
   livecheck do
     url :homepage
-    regex(%r{/ivykis-([0-9.]+)\.t}i)
+    regex(%r{/ivykis-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/jansson.rb
+++ b/Livecheckables/jansson.rb
@@ -1,6 +1,6 @@
 class Jansson
   livecheck do
     url "https://digip.org/jansson/releases/"
-    regex(/href=.*?jansson-([0-9.]+)\.t/i)
+    regex(/href=.*?jansson-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/jenkins-job-builder.rb
+++ b/Livecheckables/jenkins-job-builder.rb
@@ -1,6 +1,6 @@
 class JenkinsJobBuilder
   livecheck do
     url :stable
-    regex(/href=.*?jenkins-job-builder-([0-9.]+)\.t/i)
+    regex(/href=.*?jenkins-job-builder-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/joe.rb
+++ b/Livecheckables/joe.rb
@@ -1,6 +1,6 @@
 class Joe
   livecheck do
     url "https://sourceforge.net/projects/joe-editor/"
-    regex(%r{/joe-([0-9.]+)\.t}i)
+    regex(%r{/joe-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/jruby.rb
+++ b/Livecheckables/jruby.rb
@@ -1,6 +1,6 @@
 class Jruby
   livecheck do
     url "http://jruby.org/download"
-    regex(%r{href=.*?/jruby-dist-([0-9.]+)-bin\.t}i)
+    regex(%r{href=.*?/jruby-dist-v?(\d+(?:\.\d+)+)-bin\.t}i)
   end
 end

--- a/Livecheckables/keepassc.rb
+++ b/Livecheckables/keepassc.rb
@@ -1,6 +1,6 @@
 class Keepassc
   livecheck do
     url :stable
-    regex(/href=.*?keepassc-([0-9.]+)\.t/i)
+    regex(/href=.*?keepassc-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/keepkey-agent.rb
+++ b/Livecheckables/keepkey-agent.rb
@@ -1,6 +1,6 @@
 class KeepkeyAgent
   livecheck do
     url :stable
-    regex(/href=.*?keepkey_agent-([0-9.]+)\.t/i)
+    regex(/href=.*?keepkey_agent-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/klavaro.rb
+++ b/Livecheckables/klavaro.rb
@@ -1,6 +1,6 @@
 class Klavaro
   livecheck do
     url "https://sourceforge.net/projects/klavaro/"
-    regex(%r{/klavaro-([0-9.]+)\.t}i)
+    regex(%r{/klavaro-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/knock.rb
+++ b/Livecheckables/knock.rb
@@ -1,6 +1,6 @@
 class Knock
   livecheck do
     url "https://www.zeroflux.org/projects/knock"
-    regex(%r{The current version of knockd is <strong>([0-9.]+)</strong>}i)
+    regex(%r{The current version of knockd is <strong>v?(\d+(?:\.\d+)+)</strong>}i)
   end
 end

--- a/Livecheckables/knot-resolver.rb
+++ b/Livecheckables/knot-resolver.rb
@@ -1,6 +1,6 @@
 class KnotResolver
   livecheck do
     url "https://secure.nic.cz/files/knot-resolver/"
-    regex(/href=.*?knot-resolver-([0-9.]+)\.t/i)
+    regex(/href=.*?knot-resolver-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/knot.rb
+++ b/Livecheckables/knot.rb
@@ -1,6 +1,6 @@
 class Knot
   livecheck do
     url "https://secure.nic.cz/files/knot-dns/"
-    regex(/href=.*?knot-([0-9.]+)\.t/i)
+    regex(/href=.*?knot-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/krb5.rb
+++ b/Livecheckables/krb5.rb
@@ -1,6 +1,6 @@
 class Krb5
   livecheck do
     url :homepage
-    regex(/Current release: .*?>krb5-([0-9.]+)</i)
+    regex(/Current release: .*?>krb5-v?(\d+(?:\.\d+)+)</i)
   end
 end

--- a/Livecheckables/ktoblzcheck.rb
+++ b/Livecheckables/ktoblzcheck.rb
@@ -1,6 +1,6 @@
 class Ktoblzcheck
   livecheck do
     url "https://sourceforge.net/projects/ktoblzcheck/"
-    regex(%r{/ktoblzcheck-([0-9.]+)\.t}i)
+    regex(%r{/ktoblzcheck-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/launch.rb
+++ b/Livecheckables/launch.rb
@@ -1,6 +1,6 @@
 class Launch
   livecheck do
     url "https://sabi.net/nriley/software/"
-    regex(/href=.*?launch-([0-9.]+)\.t/i)
+    regex(/href=.*?launch-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/lbdb.rb
+++ b/Livecheckables/lbdb.rb
@@ -1,6 +1,6 @@
 class Lbdb
   livecheck do
     url "https://www.spinnaker.de/lbdb/download/"
-    regex(/href=.*?lbdb_([0-9.]+)\.t/i)
+    regex(/href=.*?lbdb_v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ledit.rb
+++ b/Livecheckables/ledit.rb
@@ -1,6 +1,6 @@
 class Ledit
   livecheck do
     url :homepage
-    regex(/current .*? is ([0-9.]+) /i)
+    regex(/current .*? is v?(\d+(?:\.\d+)+) /i)
   end
 end

--- a/Livecheckables/lft.rb
+++ b/Livecheckables/lft.rb
@@ -1,6 +1,6 @@
 class Lft
   livecheck do
     url :homepage
-    regex(/value="lft-([0-9.]+)\.t/i)
+    regex(/value="lft-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libarchive.rb
+++ b/Livecheckables/libarchive.rb
@@ -1,6 +1,6 @@
 class Libarchive
   livecheck do
     url "https://libarchive.org/downloads/"
-    regex(/libarchive-([0-9.]+)\.t/i)
+    regex(/libarchive-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libassuan.rb
+++ b/Livecheckables/libassuan.rb
@@ -1,6 +1,6 @@
 class Libassuan
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libassuan/"
-    regex(/libassuan-([0-9.]+)\.t/i)
+    regex(/libassuan-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libbpg.rb
+++ b/Livecheckables/libbpg.rb
@@ -1,6 +1,6 @@
 class Libbpg
   livecheck do
     url :homepage
-    regex(/href=.*?libbpg-([0-9.]+)\.t/i)
+    regex(/href=.*?libbpg-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libdap.rb
+++ b/Livecheckables/libdap.rb
@@ -1,6 +1,6 @@
 class Libdap
   livecheck do
     url "https://www.opendap.org/pub/source/"
-    regex(/href=.*?libdap-([0-9.]+)\.t/i)
+    regex(/href=.*?libdap-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libdiscid.rb
+++ b/Livecheckables/libdiscid.rb
@@ -1,6 +1,6 @@
 class Libdiscid
   livecheck do
     url "http://ftp.musicbrainz.org/pub/musicbrainz/libdiscid/"
-    regex(/href=.*?libdiscid-([0-9.]+)\.t/i)
+    regex(/href=.*?libdiscid-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libdsk.rb
+++ b/Livecheckables/libdsk.rb
@@ -1,6 +1,6 @@
 class Libdsk
   livecheck do
     url :homepage
-    regex(%r{Stable version.*?/libdsk-([0-9.]+)\.t}im)
+    regex(%r{Stable version.*?/libdsk-v?(\d+(?:\.\d+)+)\.t}im)
   end
 end

--- a/Livecheckables/libfixbuf.rb
+++ b/Livecheckables/libfixbuf.rb
@@ -1,6 +1,6 @@
 class Libfixbuf
   livecheck do
     url "https://tools.netsa.cert.org/fixbuf/download.html"
-    regex(%r{releases/libfixbuf-([0-9.]+)\.t}i)
+    regex(%r{releases/libfixbuf-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libgig.rb
+++ b/Livecheckables/libgig.rb
@@ -1,6 +1,6 @@
 class Libgig
   livecheck do
     url "https://download.linuxsampler.org/packages/"
-    regex(/href=.*?libgig-([0-9.]+)\.t/i)
+    regex(/href=.*?libgig-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libgpg-error.rb
+++ b/Livecheckables/libgpg-error.rb
@@ -1,6 +1,6 @@
 class LibgpgError
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libgpg-error/"
-    regex(/libgpg-error-([0-9.]+)\.t/i)
+    regex(/libgpg-error-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libgphoto2.rb
+++ b/Livecheckables/libgphoto2.rb
@@ -1,6 +1,6 @@
 class Libgphoto2
   livecheck do
     url "https://sourceforge.net/projects/gphoto/"
-    regex(%r{.*?/libgphoto2-([0-9.]+)\.t}i)
+    regex(%r{.*?/libgphoto2-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libgsm.rb
+++ b/Livecheckables/libgsm.rb
@@ -1,6 +1,6 @@
 class Libgsm
   livecheck do
     url :homepage
-    regex(/href=.*?gsm-([0-9.]+)\.t/i)
+    regex(/href=.*?gsm-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libidn2.rb
+++ b/Livecheckables/libidn2.rb
@@ -1,6 +1,6 @@
 class Libidn2
   livecheck do
     url "https://ftp.gnu.org/gnu/libidn/"
-    regex(/href=.*?libidn2-([0-9.]+)\.t/i)
+    regex(/href=.*?libidn2-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libinfinity.rb
+++ b/Livecheckables/libinfinity.rb
@@ -1,6 +1,6 @@
 class Libinfinity
   livecheck do
     url "http://releases.0x539.de/libinfinity/"
-    regex(/href=.*?libinfinity-([0-9.]+)\.t/i)
+    regex(/href=.*?libinfinity-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libksba.rb
+++ b/Livecheckables/libksba.rb
@@ -1,6 +1,6 @@
 class Libksba
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libksba/"
-    regex(/libksba-([0-9.]+)\.t/i)
+    regex(/libksba-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/liblwgeom.rb
+++ b/Livecheckables/liblwgeom.rb
@@ -1,6 +1,6 @@
 class Liblwgeom
   livecheck do
     url "https://download.osgeo.org/postgis/source/"
-    regex(/href=.*?postgis-([0-9.]+)\.t/i)
+    regex(/href=.*?postgis-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libmodplug.rb
+++ b/Livecheckables/libmodplug.rb
@@ -1,6 +1,6 @@
 class Libmodplug
   livecheck do
     url "https://sourceforge.net/projects/modplug-xmms/"
-    regex(%r{/libmodplug-([0-9.]+)\.t}i)
+    regex(%r{/libmodplug-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libofx.rb
+++ b/Livecheckables/libofx.rb
@@ -1,6 +1,6 @@
 class Libofx
   livecheck do
     url "https://sourceforge.net/projects/libofx/"
-    regex(%r{/libofx-([0-9.]+)\.t}i)
+    regex(%r{/libofx-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libowfat.rb
+++ b/Livecheckables/libowfat.rb
@@ -1,6 +1,6 @@
 class Libowfat
   livecheck do
     url :homepage
-    regex(/href=.*?libowfat-([0-9.]+)\.t/i)
+    regex(/href=.*?libowfat-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libpng.rb
+++ b/Livecheckables/libpng.rb
@@ -1,6 +1,6 @@
 class Libpng
   livecheck do
     url "https://sourceforge.net/projects/libpng/"
-    regex(%r{/libpng-([0-9.]+)\.t}i)
+    regex(%r{/libpng-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libre.rb
+++ b/Livecheckables/libre.rb
@@ -1,6 +1,6 @@
 class Libre
   livecheck do
     url "http://www.creytiv.com/pub/"
-    regex(/href=.*?re-([0-9.]+)\.t/i)
+    regex(/href=.*?re-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/librem.rb
+++ b/Livecheckables/librem.rb
@@ -1,6 +1,6 @@
 class Librem
   livecheck do
     url "http://www.creytiv.com/pub/"
-    regex(/href=.*?rem-([0-9.]+)\.t/i)
+    regex(/href=.*?rem-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libshout.rb
+++ b/Livecheckables/libshout.rb
@@ -1,6 +1,6 @@
 class Libshout
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/libshout/"
-    regex(/href=.*?libshout-([0-9.]+)\.t/i)
+    regex(/href=.*?libshout-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libsmi.rb
+++ b/Livecheckables/libsmi.rb
@@ -1,6 +1,6 @@
 class Libsmi
   livecheck do
     url "https://www.ibr.cs.tu-bs.de/projects/libsmi/download/"
-    regex(/href=.*?libsmi-([0-9.]+)\.t/i)
+    regex(/href=.*?libsmi-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libspectrum.rb
+++ b/Livecheckables/libspectrum.rb
@@ -1,6 +1,6 @@
 class Libspectrum
   livecheck do
     url "https://sourceforge.net/projects/fuse-emulator/"
-    regex(%r{/libspectrum/[0-9.]+/libspectrum-([0-9.]+)\.t}i)
+    regex(%r{/libspectrum/[0-9.]+/libspectrum-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libxmlsec1.rb
+++ b/Livecheckables/libxmlsec1.rb
@@ -1,6 +1,6 @@
 class Libxmlsec1
   livecheck do
     url "https://www.aleksey.com/xmlsec/download/"
-    regex(/href=.*?xmlsec1-([0-9.]+)\.t/i)
+    regex(/href=.*?xmlsec1-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libxslt.rb
+++ b/Livecheckables/libxslt.rb
@@ -1,6 +1,6 @@
 class Libxslt
   livecheck do
     url "http://xmlsoft.org/sources/"
-    regex(/href=.*?libxslt-([0-9.]+)\.t/i)
+    regex(/href=.*?libxslt-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libzip.rb
+++ b/Livecheckables/libzip.rb
@@ -1,6 +1,6 @@
 class Libzip
   livecheck do
     url "https://libzip.org/download/"
-    regex(/href=.*?libzip-([0-9.]+)\.t/i)
+    regex(/href=.*?libzip-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/link-grammar.rb
+++ b/Livecheckables/link-grammar.rb
@@ -1,6 +1,6 @@
 class LinkGrammar
   livecheck do
     url :homepage
-    regex(/href=.*?link-grammar-([0-9.]+)\.t/i)
+    regex(/href=.*?link-grammar-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/links.rb
+++ b/Livecheckables/links.rb
@@ -1,6 +1,6 @@
 class Links
   livecheck do
     url "http://links.twibright.com/download.php"
-    regex(/Current version is ([0-9.]+)\. /i)
+    regex(/Current version is v?(\d+(?:\.\d+)+)\. /i)
   end
 end

--- a/Livecheckables/little-cms2.rb
+++ b/Livecheckables/little-cms2.rb
@@ -1,6 +1,6 @@
 class LittleCms2
   livecheck do
     url "http://www.littlecms.com/download.html"
-    regex(%r{<h1>Current version is ([0-9.]+)</h1>}i)
+    regex(%r{<h1>Current version is v?(\d+(?:\.\d+)+)</h1>}i)
   end
 end

--- a/Livecheckables/log4cplus.rb
+++ b/Livecheckables/log4cplus.rb
@@ -1,6 +1,6 @@
 class Log4cplus
   livecheck do
     url "https://sourceforge.net/projects/log4cplus/"
-    regex(%r{/log4cplus-stable/.*?/log4cplus-([0-9.]+)\.t}i)
+    regex(%r{/log4cplus-stable/.*?/log4cplus-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/log4cpp.rb
+++ b/Livecheckables/log4cpp.rb
@@ -1,6 +1,6 @@
 class Log4cpp
   livecheck do
     url "https://sourceforge.net/projects/log4cpp/files/log4cpp-1.1.x%20%28new%29/log4cpp-1.1/"
-    regex(/log4cpp-([0-9.]+)\.t/i)
+    regex(/log4cpp-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/log4shib.rb
+++ b/Livecheckables/log4shib.rb
@@ -1,6 +1,6 @@
 class Log4shib
   livecheck do
     url "https://shibboleth.net/downloads/log4shib/latest/"
-    regex(/href=.*?log4shib-([0-9.]+)\.t/i)
+    regex(/href=.*?log4shib-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/lwtools.rb
+++ b/Livecheckables/lwtools.rb
@@ -1,6 +1,6 @@
 class Lwtools
   livecheck do
     url "http://www.lwtools.ca/releases/lwtools/"
-    regex(/href=.*?lwtools-([0-9.]+)\.t/i)
+    regex(/href=.*?lwtools-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/lynis.rb
+++ b/Livecheckables/lynis.rb
@@ -1,6 +1,6 @@
 class Lynis
   livecheck do
     url "https://cisofy.com/downloads/lynis/"
-    regex(%r{href=.*?/lynis-([0-9.]+)\.t}i)
+    regex(%r{href=.*?/lynis-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/lzlib.rb
+++ b/Livecheckables/lzlib.rb
@@ -1,6 +1,6 @@
 class Lzlib
   livecheck do
     url "https://download.savannah.gnu.org/releases/lzip/lzlib/"
-    regex(/href=.*?lzlib-([0-9.]+)\.t/i)
+    regex(/href=.*?lzlib-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/lzop.rb
+++ b/Livecheckables/lzop.rb
@@ -1,6 +1,6 @@
 class Lzop
   livecheck do
     url "https://www.lzop.org/download/"
-    regex(/href=.*?lzop-([0-9.]+)\.t/i)
+    regex(/href=.*?lzop-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/mairix.rb
+++ b/Livecheckables/mairix.rb
@@ -1,6 +1,6 @@
 class Mairix
   livecheck do
     url "https://sourceforge.net/projects/mairix/"
-    regex(%r{/mairix-([0-9.]+)\.t}i)
+    regex(%r{/mairix-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/mariadb.rb
+++ b/Livecheckables/mariadb.rb
@@ -1,6 +1,6 @@
 class Mariadb
   livecheck do
     url "https://downloads.mariadb.org/"
-    regex(/Download ([0-9.]+) Stable Now/i)
+    regex(/Download v?(\d+(?:\.\d+)+) Stable Now/i)
   end
 end

--- a/Livecheckables/maxima.rb
+++ b/Livecheckables/maxima.rb
@@ -1,6 +1,6 @@
 class Maxima
   livecheck do
     url "https://sourceforge.net/projects/maxima/"
-    regex(%r{/maxima-([0-9.]+)\.t}i)
+    regex(%r{/maxima-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/mednafen.rb
+++ b/Livecheckables/mednafen.rb
@@ -1,6 +1,6 @@
 class Mednafen
   livecheck do
     url "https://mednafen.github.io/releases/"
-    regex(/href=.*?mednafen-([0-9.]+)\.t/i)
+    regex(/href=.*?mednafen-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/mercurial.rb
+++ b/Livecheckables/mercurial.rb
@@ -1,6 +1,6 @@
 class Mercurial
   livecheck do
     url "https://www.mercurial-scm.org/release/"
-    regex(/href=.*?mercurial-([0-9.]+)\.t/i)
+    regex(/href=.*?mercurial-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/mk-configure.rb
+++ b/Livecheckables/mk-configure.rb
@@ -1,6 +1,6 @@
 class MkConfigure
   livecheck do
     url "https://sourceforge.net/projects/mk-configure/"
-    regex(%r{.*?/mk-configure-([0-9.]+)\.t}i)
+    regex(%r{.*?/mk-configure-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/mlkit.rb
+++ b/Livecheckables/mlkit.rb
@@ -1,6 +1,6 @@
 class Mlkit
   livecheck do
     url :head
-    regex(/mlkit-([0-9.]+)$/i)
+    regex(/mlkit-v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/modules.rb
+++ b/Livecheckables/modules.rb
@@ -1,6 +1,6 @@
 class Modules
   livecheck do
     url "https://sourceforge.net/projects/modules/"
-    regex(%r{.*?/modules-([0-9.]+)\.t}i)
+    regex(%r{.*?/modules-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/mpc.rb
+++ b/Livecheckables/mpc.rb
@@ -1,6 +1,6 @@
 class Mpc
   livecheck do
     url "https://www.musicpd.org/download/mpc/0/"
-    regex(/href=.*?mpc-([0-9.]+)\.t/i)
+    regex(/href=.*?mpc-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/mupdf.rb
+++ b/Livecheckables/mupdf.rb
@@ -1,6 +1,6 @@
 class Mupdf
   livecheck do
     url "https://mupdf.com/downloads/archive/"
-    regex(/href=.*?mupdf-([0-9.]+)-source\.t/i)
+    regex(/href=.*?mupdf-v?(\d+(?:\.\d+)+)-source\.t/i)
   end
 end

--- a/Livecheckables/mutt.rb
+++ b/Livecheckables/mutt.rb
@@ -1,6 +1,6 @@
 class Mutt
   livecheck do
     url :homepage
-    regex(/Mutt ([0-9.]+) was released/i)
+    regex(/Mutt v?(\d+(?:\.\d+)+) was released/i)
   end
 end

--- a/Livecheckables/nano.rb
+++ b/Livecheckables/nano.rb
@@ -1,6 +1,6 @@
 class Nano
   livecheck do
     url "https://www.nano-editor.org/download.php"
-    regex(/nano-([0-9.]+)\.t/i)
+    regex(/nano-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/nanopb-generator.rb
+++ b/Livecheckables/nanopb-generator.rb
@@ -1,6 +1,6 @@
 class NanopbGenerator
   livecheck do
     url "https://jpa.kapsi.fi/nanopb/download/"
-    regex(/href=.*?nanopb-([0-9.]+)\.t/i)
+    regex(/href=.*?nanopb-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/nco.rb
+++ b/Livecheckables/nco.rb
@@ -1,6 +1,6 @@
 class Nco
   livecheck do
     url "https://sourceforge.net/projects/nco/"
-    regex(%r{/nco-([0-9.]+)\.t}i)
+    regex(%r{/nco-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/netpbm.rb
+++ b/Livecheckables/netpbm.rb
@@ -1,6 +1,6 @@
 class Netpbm
   livecheck do
     url "https://sourceforge.net/p/netpbm/code/HEAD/tree/stable/"
-    regex(/Release ([0-9.]+)/i)
+    regex(/Release v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/nginx.rb
+++ b/Livecheckables/nginx.rb
@@ -1,6 +1,6 @@
 class Nginx
   livecheck do
     url :homepage
-    regex(%r{nginx-([0-9.]+)</a>\nmainline version has been released}i)
+    regex(%r{nginx-v?(\d+(?:\.\d+)+)</a>\nmainline version has been released}i)
   end
 end

--- a/Livecheckables/nickle.rb
+++ b/Livecheckables/nickle.rb
@@ -1,6 +1,6 @@
 class Nickle
   livecheck do
     url "https://www.nickle.org/release/"
-    regex(/href=.*?nickle-([0-9.]+)\.t/i)
+    regex(/href=.*?nickle-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ntl.rb
+++ b/Livecheckables/ntl.rb
@@ -1,6 +1,6 @@
 class Ntl
   livecheck do
     url "https://www.shoup.net/ntl/download.html"
-    regex(/href=.*?ntl-([0-9.]+)\.t/i)
+    regex(/href=.*?ntl-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ocaml-findlib.rb
+++ b/Livecheckables/ocaml-findlib.rb
@@ -1,6 +1,6 @@
 class OcamlFindlib
   livecheck do
     url "http://download.camlcity.org/download/"
-    regex(/href=.*?findlib-([0-9.]+)\.t/i)
+    regex(/href=.*?findlib-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ocrmypdf.rb
+++ b/Livecheckables/ocrmypdf.rb
@@ -1,6 +1,6 @@
 class Ocrmypdf
   livecheck do
     url :stable
-    regex(/href=.*?ocrmypdf-([0-9.]+)\.t/i)
+    regex(/href=.*?ocrmypdf-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/omega-rpg.rb
+++ b/Livecheckables/omega-rpg.rb
@@ -1,6 +1,6 @@
 class OmegaRpg
   livecheck do
     url :homepage
-    regex(/latest.*?>([0-9.]+)</i)
+    regex(/latest.*?>v?(\d+(?:\.\d+)+)</i)
   end
 end

--- a/Livecheckables/open-mpi.rb
+++ b/Livecheckables/open-mpi.rb
@@ -1,6 +1,6 @@
 class OpenMpi
   livecheck do
     url :homepage
-    regex(/MPI v?([0-9.]+) release/i)
+    regex(/MPI v?(\d+(?:\.\d+)+) release/i)
   end
 end

--- a/Livecheckables/openvpn.rb
+++ b/Livecheckables/openvpn.rb
@@ -1,6 +1,6 @@
 class Openvpn
   livecheck do
     url :homepage
-    regex(/href=.*?openvpn-([0-9.]+)\.t/i)
+    regex(/href=.*?openvpn-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pam-u2f.rb
+++ b/Livecheckables/pam-u2f.rb
@@ -1,6 +1,6 @@
 class PamU2f
   livecheck do
     url "https://developers.yubico.com/pam-u2f/Releases/"
-    regex(/href=.*?pam_u2f-([0-9.]+)\.t/i)
+    regex(/href=.*?pam_u2f-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pam_yubico.rb
+++ b/Livecheckables/pam_yubico.rb
@@ -1,6 +1,6 @@
 class PamYubico
   livecheck do
     url "https://developers.yubico.com/yubico-pam/Releases/"
-    regex(/href=.*?pam_yubico-([0-9.]+)\.t/i)
+    regex(/href=.*?pam_yubico-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/paperkey.rb
+++ b/Livecheckables/paperkey.rb
@@ -1,6 +1,6 @@
 class Paperkey
   livecheck do
     url :homepage
-    regex(/paperkey-([0-9.]+)\.t/i)
+    regex(/paperkey-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pazpar2.rb
+++ b/Livecheckables/pazpar2.rb
@@ -1,6 +1,6 @@
 class Pazpar2
   livecheck do
     url "http://ftp.indexdata.dk/pub/pazpar2/"
-    regex(/href=.*?pazpar2-([0-9.]+)\.t/i)
+    regex(/href=.*?pazpar2-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pcre2.rb
+++ b/Livecheckables/pcre2.rb
@@ -1,6 +1,6 @@
 class Pcre2
   livecheck do
     url "https://ftp.pcre.org/pub/pcre/"
-    regex(/href=.*?pcre2-([0-9.]+)\.t/i)
+    regex(/href=.*?pcre2-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/petsc.rb
+++ b/Livecheckables/petsc.rb
@@ -1,6 +1,6 @@
 class Petsc
   livecheck do
     url "https://www.mcs.anl.gov/petsc/download/index.html"
-    regex(/href=.*?petsc-lite-([0-9.]+)\.t/i)
+    regex(/href=.*?petsc-lite-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pgpool-ii.rb
+++ b/Livecheckables/pgpool-ii.rb
@@ -1,6 +1,6 @@
 class PgpoolIi
   livecheck do
     url "https://www.pgpool.net/mediawiki/index.php/Downloads"
-    regex(/download\.php\?f=pgpool-II-([0-9.]+)\.t/i)
+    regex(/download\.php\?f=pgpool-II-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pgroonga.rb
+++ b/Livecheckables/pgroonga.rb
@@ -1,6 +1,6 @@
 class Pgroonga
   livecheck do
     url "https://packages.groonga.org/source/pgroonga/"
-    regex(/href=.*?pgroonga-([0-9.]+)\.t/i)
+    regex(/href=.*?pgroonga-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/phpunit.rb
+++ b/Livecheckables/phpunit.rb
@@ -1,6 +1,6 @@
 class Phpunit
   livecheck do
     url "https://phar.phpunit.de/"
-    regex(/href=.*?phpunit-([0-9.]+)\.phar/i)
+    regex(/href=.*?phpunit-v?(\d+(?:\.\d+)+)\.phar/i)
   end
 end

--- a/Livecheckables/physfs.rb
+++ b/Livecheckables/physfs.rb
@@ -1,6 +1,6 @@
 class Physfs
   livecheck do
     url "https://icculus.org/physfs/downloads/"
-    regex(/href=.*?physfs-([0-9.]+)\.t/i)
+    regex(/href=.*?physfs-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pigz.rb
+++ b/Livecheckables/pigz.rb
@@ -1,6 +1,6 @@
 class Pigz
   livecheck do
     url :homepage
-    regex(/href=.*?pigz-([0-9.]+)\.t/i)
+    regex(/href=.*?pigz-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pike.rb
+++ b/Livecheckables/pike.rb
@@ -1,6 +1,6 @@
 class Pike
   livecheck do
     url "https://pike.lysator.liu.se/download/pub/pike/latest-stable/"
-    regex(/href=.*?Pike-v([0-9.]+)\.t/i)
+    regex(/href=.*?Pike-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pinentry.rb
+++ b/Livecheckables/pinentry.rb
@@ -1,6 +1,6 @@
 class Pinentry
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/pinentry/"
-    regex(/pinentry-([0-9.]+)\.t/i)
+    regex(/pinentry-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/plantuml.rb
+++ b/Livecheckables/plantuml.rb
@@ -1,6 +1,6 @@
 class Plantuml
   livecheck do
     url "https://sourceforge.net/projects/plantuml/"
-    regex(%r{.*?/plantuml-([0-9.]+)\.t}i)
+    regex(%r{.*?/plantuml-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/pngquant.rb
+++ b/Livecheckables/pngquant.rb
@@ -1,6 +1,6 @@
 class Pngquant
   livecheck do
     url "https://pngquant.org/releases.html"
-    regex(%r{href=.*?/pngquant-([0-9.]+)-src\.t}i)
+    regex(%r{href=.*?/pngquant-v?(\d+(?:\.\d+)+)-src\.t}i)
   end
 end

--- a/Livecheckables/poco.rb
+++ b/Livecheckables/poco.rb
@@ -1,6 +1,6 @@
 class Poco
   livecheck do
     url "https://pocoproject.org/releases"
-    regex(%r{href=.*?poco-([0-9.]+)/?["' >]}i)
+    regex(%r{href=.*?poco-v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/pod2man.rb
+++ b/Livecheckables/pod2man.rb
@@ -1,6 +1,6 @@
 class Pod2man
   livecheck do
     url "https://archives.eyrie.org/software/perl/"
-    regex(/href=.*?podlators-([0-9.]+)\.t/i)
+    regex(/href=.*?podlators-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/postgis.rb
+++ b/Livecheckables/postgis.rb
@@ -1,6 +1,6 @@
 class Postgis
   livecheck do
     url "https://download.osgeo.org/postgis/source/"
-    regex(/href=.*?postgis-([0-9.]+)\.t/i)
+    regex(/href=.*?postgis-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/prips.rb
+++ b/Livecheckables/prips.rb
@@ -1,6 +1,6 @@
 class Prips
   livecheck do
     url :homepage
-    regex(/current version .*?prips.*?([0-9.]+)/i)
+    regex(/current version .*?prips.*?v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/privoxy.rb
+++ b/Livecheckables/privoxy.rb
@@ -1,6 +1,6 @@
 class Privoxy
   livecheck do
     url "https://www.privoxy.org/feeds/privoxy-releases.xml"
-    regex(/privoxy-([0-9.]+)-stable-src\./i)
+    regex(/privoxy-v?(\d+(?:\.\d+)+)-stable-src\./i)
   end
 end

--- a/Livecheckables/psqlodbc.rb
+++ b/Livecheckables/psqlodbc.rb
@@ -1,6 +1,6 @@
 class Psqlodbc
   livecheck do
     url "https://ftp.postgresql.org/pub/odbc/versions/src/"
-    regex(/href=.*?psqlodbc-([0-9.]+)\.t/i)
+    regex(/href=.*?psqlodbc-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pv.rb
+++ b/Livecheckables/pv.rb
@@ -1,6 +1,6 @@
 class Pv
   livecheck do
     url :homepage
-    regex(/pv-([0-9.]+)\.t/i)
+    regex(/pv-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/qcachegrind.rb
+++ b/Livecheckables/qcachegrind.rb
@@ -1,6 +1,6 @@
 class Qcachegrind
   livecheck do
     url "https://download.kde.org/stable/applications"
-    regex(%r{href=.*?([0-9.]+)/?["' >]}i)
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/qd.rb
+++ b/Livecheckables/qd.rb
@@ -1,6 +1,6 @@
 class Qd
   livecheck do
     url :homepage
-    regex(/href=.*?qd-([0-9.]+)\.t/i)
+    regex(/href=.*?qd-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/qjackctl.rb
+++ b/Livecheckables/qjackctl.rb
@@ -1,6 +1,6 @@
 class Qjackctl
   livecheck do
     url "https://sourceforge.net/projects/qjackctl/"
-    regex(%r{.*?/qjackctl-([0-9.]+)\.t}i)
+    regex(%r{.*?/qjackctl-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/qsoas.rb
+++ b/Livecheckables/qsoas.rb
@@ -1,6 +1,6 @@
 class Qsoas
   livecheck do
     url "http://bip.cnrs-mrs.fr/bip06/qsoas/downloads.html"
-    regex(/href=.*?qsoas-([0-9.]+)\.t/i)
+    regex(/href=.*?qsoas-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/quex.rb
+++ b/Livecheckables/quex.rb
@@ -1,6 +1,6 @@
 class Quex
   livecheck do
     url "https://sourceforge.net/projects/quex/"
-    regex(%r{.*?/quex-([0-9.]+)\.t}i)
+    regex(%r{.*?/quex-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/recoverjpeg.rb
+++ b/Livecheckables/recoverjpeg.rb
@@ -1,6 +1,6 @@
 class Recoverjpeg
   livecheck do
     url "https://rfc1149.net/download/recoverjpeg/"
-    regex(/href=.*?recoverjpeg-([0-9.]+)\.t/i)
+    regex(/href=.*?recoverjpeg-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/remctl.rb
+++ b/Livecheckables/remctl.rb
@@ -1,6 +1,6 @@
 class Remctl
   livecheck do
     url "https://archives.eyrie.org/software/kerberos/"
-    regex(/href=.*?remctl-([0-9.]+)\.t/i)
+    regex(/href=.*?remctl-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/reminiscence.rb
+++ b/Livecheckables/reminiscence.rb
@@ -1,6 +1,6 @@
 class Reminiscence
   livecheck do
     url :homepage
-    regex(/href=.*?REminiscence-([0-9.]+)\.t/i)
+    regex(/href=.*?REminiscence-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/restund.rb
+++ b/Livecheckables/restund.rb
@@ -1,6 +1,6 @@
 class Restund
   livecheck do
     url "http://www.creytiv.com/pub/"
-    regex(/href=.*?restund-([0-9.]+)\.t/i)
+    regex(/href=.*?restund-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/rpm.rb
+++ b/Livecheckables/rpm.rb
@@ -1,6 +1,6 @@
 class Rpm
   livecheck do
     url "https://github.com/rpm-software-management/rpm.git"
-    regex(/rpm-([0-9.]+)-release/i)
+    regex(/rpm-v?(\d+(?:\.\d+)+)-release/i)
   end
 end

--- a/Livecheckables/rsstail.rb
+++ b/Livecheckables/rsstail.rb
@@ -1,6 +1,6 @@
 class Rsstail
   livecheck do
     url :homepage
-    regex(/Latest release.*HREF="rsstail-([0-9.]+)\.t/i)
+    regex(/Latest release.*HREF="rsstail-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/rubberband.rb
+++ b/Livecheckables/rubberband.rb
@@ -1,6 +1,6 @@
 class Rubberband
   livecheck do
     url :homepage
-    regex(/Rubber Band Library v([0-9.]+) released/i)
+    regex(/Rubber Band Library v?(\d+(?:\.\d+)+) released/i)
   end
 end

--- a/Livecheckables/ruby.rb
+++ b/Livecheckables/ruby.rb
@@ -1,6 +1,6 @@
 class Ruby
   livecheck do
     url "https://www.ruby-lang.org/en/downloads/"
-    regex(/The current stable version is ([0-9.]+)\./i)
+    regex(/The current stable version is v?(\d+(?:\.\d+)+)\./i)
   end
 end

--- a/Livecheckables/s3-backer.rb
+++ b/Livecheckables/s3-backer.rb
@@ -1,6 +1,6 @@
 class S3Backer
   livecheck do
     url "https://build.opensuse.org/package/view_file/openSUSE:Factory/s3backer/s3backer.spec"
-    regex(/Version:\s+([0-9.]+)/i)
+    regex(/Version:\s+v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/scummvm-tools.rb
+++ b/Livecheckables/scummvm-tools.rb
@@ -1,6 +1,6 @@
 class ScummvmTools
   livecheck do
     url "https://www.scummvm.org/downloads/"
-    regex(/href=.*?scummvm-tools-([0-9.]+)\.t/i)
+    regex(/href=.*?scummvm-tools-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/sdl2_gfx.rb
+++ b/Livecheckables/sdl2_gfx.rb
@@ -1,6 +1,6 @@
 class Sdl2Gfx
   livecheck do
     url "https://sourceforge.net/projects/sdl2gfx/"
-    regex(%r{.*?/SDL2_gfx-([0-9.]+)\.t}i)
+    regex(%r{.*?/SDL2_gfx-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/sfk.rb
+++ b/Livecheckables/sfk.rb
@@ -1,6 +1,6 @@
 class Sfk
   livecheck do
     url "https://sourceforge.net/projects/swissfileknife/"
-    regex(%r{swissfileknife/([0-9.]+)/}i)
+    regex(%r{swissfileknife/v?(\d+(?:\.\d+)+)/}i)
   end
 end

--- a/Livecheckables/shapelib.rb
+++ b/Livecheckables/shapelib.rb
@@ -1,6 +1,6 @@
 class Shapelib
   livecheck do
     url "https://download.osgeo.org/shapelib/"
-    regex(/href=.*?shapelib-([0-9.]+)\.t/i)
+    regex(/href=.*?shapelib-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/shared-mime-info.rb
+++ b/Livecheckables/shared-mime-info.rb
@@ -1,6 +1,6 @@
 class SharedMimeInfo
   livecheck do
     url "https://gitlab.freedesktop.org/api/v4/projects/1205/releases"
-    regex(/shared-mime-info ([0-9.]+)/i)
+    regex(/shared-mime-info v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/silk.rb
+++ b/Livecheckables/silk.rb
@@ -1,6 +1,6 @@
 class Silk
   livecheck do
     url :homepage
-    regex(%r{".*?/silk-([0-9.]+)\.t}i)
+    regex(%r{".*?/silk-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/snort.rb
+++ b/Livecheckables/snort.rb
@@ -1,6 +1,6 @@
 class Snort
   livecheck do
     url "https://www.snort.org/downloads"
-    regex(/href=.*?snort-([0-9.]+)\.t/i)
+    regex(/href=.*?snort-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/socat.rb
+++ b/Livecheckables/socat.rb
@@ -1,6 +1,6 @@
 class Socat
   livecheck do
     url "http://www.dest-unreach.org/socat/download/"
-    regex(/socat-([0-9.]+)\.t/i)
+    regex(/socat-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/sonarqube.rb
+++ b/Livecheckables/sonarqube.rb
@@ -1,6 +1,6 @@
 class Sonarqube
   livecheck do
     url "https://binaries.sonarsource.com/Distribution/sonarqube/"
-    regex(/sonarqube-([0-9.]+)\.zip/i)
+    regex(/sonarqube-v?(\d+(?:\.\d+)+)\.zip/i)
   end
 end

--- a/Livecheckables/spring-roo.rb
+++ b/Livecheckables/spring-roo.rb
@@ -1,6 +1,6 @@
 class SpringRoo
   livecheck do
     url :homepage
-    regex(/href=.*?spring-roo-([0-9.]+)\.RELEASE\.zip/i)
+    regex(/href=.*?spring-roo-v?(\d+(?:\.\d+)+)\.RELEASE\.zip/i)
   end
 end

--- a/Livecheckables/sqliteodbc.rb
+++ b/Livecheckables/sqliteodbc.rb
@@ -1,6 +1,6 @@
 class Sqliteodbc
   livecheck do
     url "http://www.ch-werner.de/sqliteodbc/"
-    regex(/HREF="sqliteodbc-([0-9.]+)\.t/i)
+    regex(/HREF="sqliteodbc-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/stm32flash.rb
+++ b/Livecheckables/stm32flash.rb
@@ -1,6 +1,6 @@
 class Stm32flash
   livecheck do
     url :homepage
-    regex(%r{.*?/stm32flash-([0-9.]+)\.t}i)
+    regex(%r{.*?/stm32flash-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/stone-soup.rb
+++ b/Livecheckables/stone-soup.rb
@@ -1,6 +1,6 @@
 class StoneSoup
   livecheck do
     url "https://crawl.develz.org/download.htm"
-    regex(/Stable.*?>([0-9.]+)</i)
+    regex(/Stable.*?>v?(\d+(?:\.\d+)+)</i)
   end
 end

--- a/Livecheckables/stress-ng.rb
+++ b/Livecheckables/stress-ng.rb
@@ -1,6 +1,6 @@
 class StressNg
   livecheck do
     url "https://kernel.ubuntu.com/~cking/tarballs/stress-ng/"
-    regex(/href=.*?stress-ng-([0-9.]+)\.t/i)
+    regex(/href=.*?stress-ng-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/stunnel.rb
+++ b/Livecheckables/stunnel.rb
@@ -1,6 +1,6 @@
 class Stunnel
   livecheck do
     url "https://www.stunnel.org/downloads.html"
-    regex(/href=.*?stunnel-([0-9.]+)\.t/i)
+    regex(/href=.*?stunnel-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/sundials.rb
+++ b/Livecheckables/sundials.rb
@@ -1,6 +1,6 @@
 class Sundials
   livecheck do
     url "https://computation.llnl.gov/projects/sundials/sundials-software"
-    regex(/href=.*?sundials-([0-9.]+)\.t/i)
+    regex(/href=.*?sundials-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/suricata.rb
+++ b/Livecheckables/suricata.rb
@@ -1,6 +1,6 @@
 class Suricata
   livecheck do
     url "https://suricata-ids.org/download/"
-    regex(/suricata-([0-9.]+)\.t/i)
+    regex(/suricata-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/swftools.rb
+++ b/Livecheckables/swftools.rb
@@ -1,6 +1,6 @@
 class Swftools
   livecheck do
     url "http://www.swftools.org/download.html"
-    regex(/href=.*?swftools-([0-9.]+)\.t/i)
+    regex(/href=.*?swftools-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/swift.rb
+++ b/Livecheckables/swift.rb
@@ -1,6 +1,6 @@
 class Swift
   livecheck do
     url "https://swift.org/download/"
-    regex(/Releases<.*?>Swift ([0-9.]+)</im)
+    regex(/Releases<.*?>Swift v?(\d+(?:\.\d+)+)</im)
   end
 end

--- a/Livecheckables/sword.rb
+++ b/Livecheckables/sword.rb
@@ -1,6 +1,6 @@
 class Sword
   livecheck do
     url "https://www.crosswire.org/ftpmirror/pub/sword/source/"
-    regex(%r{href=.*?sword-([0-9.]+)/?["' >]}i)
+    regex(%r{href=.*?sword-v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/sylpheed.rb
+++ b/Livecheckables/sylpheed.rb
@@ -1,6 +1,6 @@
 class Sylpheed
   livecheck do
     url "https://sylpheed.sraoss.jp/en/download.html"
-    regex(%r{stable.*?href=.*?/sylpheed-([0-9.]+)\.t}im)
+    regex(%r{stable.*?href=.*?/sylpheed-v?(\d+(?:\.\d+)+)\.t}im)
   end
 end

--- a/Livecheckables/systemc.rb
+++ b/Livecheckables/systemc.rb
@@ -1,6 +1,6 @@
 class Systemc
   livecheck do
     url "https://www.accellera.org/downloads/standards/systemc"
-    regex(/href=.*?systemc-([0-9.]+)\.t/i)
+    regex(/href=.*?systemc-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/taktuk.rb
+++ b/Livecheckables/taktuk.rb
@@ -1,6 +1,6 @@
 class Taktuk
   livecheck do
     url "https://gforge.inria.fr/frs/?group_id=274"
-    regex(/href=.*?taktuk-([0-9.]+)\.t/i)
+    regex(/href=.*?taktuk-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/talloc.rb
+++ b/Livecheckables/talloc.rb
@@ -1,6 +1,6 @@
 class Talloc
   livecheck do
     url "https://www.samba.org/ftp/talloc/"
-    regex(/href=.*?talloc-([0-9.]+)\.t/i)
+    regex(/href=.*?talloc-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/tcpdump.rb
+++ b/Livecheckables/tcpdump.rb
@@ -1,6 +1,6 @@
 class Tcpdump
   livecheck do
     url "https://www.tcpdump.org/release/"
-    regex(/href=.*?tcpdump-([0-9.]+)\.t/i)
+    regex(/href=.*?tcpdump-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/timelimit.rb
+++ b/Livecheckables/timelimit.rb
@@ -1,6 +1,6 @@
 class Timelimit
   livecheck do
     url :homepage
-    regex(/latest release is .*?timelimit-([0-9.]+)</i)
+    regex(/latest release is .*?timelimit-v?(\d+(?:\.\d+)+)</i)
   end
 end

--- a/Livecheckables/tin.rb
+++ b/Livecheckables/tin.rb
@@ -1,6 +1,6 @@
 class Tin
   livecheck do
     url :homepage
-    regex(%r{tin-current\.t.*?>TIN ([0-9.]+)</A>.*?stable}i)
+    regex(%r{tin-current\.t.*?>TIN v?(\d+(?:\.\d+)+)</A>.*?stable}i)
   end
 end

--- a/Livecheckables/tintin.rb
+++ b/Livecheckables/tintin.rb
@@ -1,6 +1,6 @@
 class Tintin
   livecheck do
     url "https://sourceforge.net/projects/tintin/"
-    regex(%r{.*?/tintin-([0-9.]+)\.t}i)
+    regex(%r{.*?/tintin-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/tor.rb
+++ b/Livecheckables/tor.rb
@@ -1,6 +1,6 @@
 class Tor
   livecheck do
     url "https://dist.torproject.org/"
-    regex(/tor-([0-9.]+)\.t/i)
+    regex(/tor-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/u-boot-tools.rb
+++ b/Livecheckables/u-boot-tools.rb
@@ -1,6 +1,6 @@
 class UBootTools
   livecheck do
     url "https://ftp.denx.de/pub/u-boot/"
-    regex(/href=.*?u-boot-([0-9.]+)\.t/i)
+    regex(/href=.*?u-boot-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ucon64.rb
+++ b/Livecheckables/ucon64.rb
@@ -1,6 +1,6 @@
 class Ucon64
   livecheck do
     url "https://sourceforge.net/projects/ucon64/"
-    regex(%r{.*?/ucon64-([0-9.]+)-src\.t}i)
+    regex(%r{.*?/ucon64-v?(\d+(?:\.\d+)+)-src\.t}i)
   end
 end

--- a/Livecheckables/uftp.rb
+++ b/Livecheckables/uftp.rb
@@ -1,6 +1,6 @@
 class Uftp
   livecheck do
     url "https://sourceforge.net/projects/uftp-multicast/"
-    regex(%r{.*?/uftp-([0-9.]+)\.t}i)
+    regex(%r{.*?/uftp-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/unar.rb
+++ b/Livecheckables/unar.rb
@@ -1,6 +1,6 @@
 class Unar
   livecheck do
     url "https://wakaba.c3.cx/releases/TheUnarchiver/"
-    regex(/unar([0-9.]+)_src/i)
+    regex(/unarv?(\d+(?:\.\d+)+)_src/i)
   end
 end

--- a/Livecheckables/unp64.rb
+++ b/Livecheckables/unp64.rb
@@ -1,6 +1,6 @@
 class Unp64
   livecheck do
     url :homepage
-    regex(/href=.*?unp64.*?UNP64 ([0-9.]+) -/i)
+    regex(/href=.*?unp64.*?UNP64 v?(\d+(?:\.\d+)+) -/i)
   end
 end

--- a/Livecheckables/userspace-rcu.rb
+++ b/Livecheckables/userspace-rcu.rb
@@ -1,6 +1,6 @@
 class UserspaceRcu
   livecheck do
     url "https://www.lttng.org/files/urcu/"
-    regex(/href=.*?userspace-rcu-([0-9.]+)\.t/i)
+    regex(/href=.*?userspace-rcu-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/vice.rb
+++ b/Livecheckables/vice.rb
@@ -1,6 +1,6 @@
 class Vice
   livecheck do
     url :homepage
-    regex(%r{.*?/vice-([0-9.]+)\.t}i)
+    regex(%r{.*?/vice-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/wandio.rb
+++ b/Livecheckables/wandio.rb
@@ -1,6 +1,6 @@
 class Wandio
   livecheck do
     url :homepage
-    regex(/href=.*?wandio-([0-9.]+)\.t/i)
+    regex(/href=.*?wandio-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/wimlib.rb
+++ b/Livecheckables/wimlib.rb
@@ -1,6 +1,6 @@
 class Wimlib
   livecheck do
     url "https://wimlib.net/downloads/"
-    regex(/href=.*?wimlib-([0-9.]+)\.t/i)
+    regex(/href=.*?wimlib-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/wirouter_keyrec.rb
+++ b/Livecheckables/wirouter_keyrec.rb
@@ -1,6 +1,6 @@
 class WirouterKeyrec
   livecheck do
     url :homepage
-    regex(%r{href=.*?/WiRouter_KeyRec_([0-9.]+)\.zip}i)
+    regex(%r{href=.*?/WiRouter_KeyRec_v?(\d+(?:\.\d+)+)\.zip}i)
   end
 end

--- a/Livecheckables/xapian.rb
+++ b/Livecheckables/xapian.rb
@@ -1,6 +1,6 @@
 class Xapian
   livecheck do
     url :homepage
-    regex(/latest stable version.*?is ([0-9.]+)</im)
+    regex(/latest stable version.*?is v?(\d+(?:\.\d+)+)</im)
   end
 end

--- a/Livecheckables/xml-tooling-c.rb
+++ b/Livecheckables/xml-tooling-c.rb
@@ -1,6 +1,6 @@
 class XmlToolingC
   livecheck do
     url "https://shibboleth.net/downloads/c++-opensaml/latest/"
-    regex(/href=.*?xmltooling-([0-9.]+)\.t/i)
+    regex(/href=.*?xmltooling-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/xqilla.rb
+++ b/Livecheckables/xqilla.rb
@@ -1,6 +1,6 @@
 class Xqilla
   livecheck do
     url "https://sourceforge.net/projects/xqilla/"
-    regex(%r{.*?/XQilla-([0-9.]+)\.t}i)
+    regex(%r{.*?/XQilla-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/xz.rb
+++ b/Livecheckables/xz.rb
@@ -1,6 +1,6 @@
 class Xz
   livecheck do
     url :homepage
-    regex(/([0-9.]+) was released/i)
+    regex(/v?(\d+(?:\.\d+)+) was released/i)
   end
 end

--- a/Livecheckables/yaf.rb
+++ b/Livecheckables/yaf.rb
@@ -1,6 +1,6 @@
 class Yaf
   livecheck do
     url "https://tools.netsa.cert.org/yaf/download.html"
-    regex(%r{/yaf-([0-9.]+)\.t}i)
+    regex(%r{/yaf-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/yarn.rb
+++ b/Livecheckables/yarn.rb
@@ -1,6 +1,6 @@
 class Yarn
   livecheck do
     url "https://yarnpkg.com/en/"
-    regex(/Stable:.*?v([0-9.]+)/im)
+    regex(/Stable:.*?v?(\d+(?:\.\d+)+)/im)
   end
 end

--- a/Livecheckables/ykman.rb
+++ b/Livecheckables/ykman.rb
@@ -1,6 +1,6 @@
 class Ykman
   livecheck do
     url "https://developers.yubico.com/yubikey-manager/Releases/"
-    regex(/href=.*?yubikey-manager-([0-9.]+)\.t/i)
+    regex(/href=.*?yubikey-manager-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ykpers.rb
+++ b/Livecheckables/ykpers.rb
@@ -1,6 +1,6 @@
 class Ykpers
   livecheck do
     url "https://developers.yubico.com/yubikey-personalization/Releases/"
-    regex(/href=.*?ykpers-([0-9.]+)\.t/i)
+    regex(/href=.*?ykpers-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/yubico-piv-tool.rb
+++ b/Livecheckables/yubico-piv-tool.rb
@@ -1,6 +1,6 @@
 class YubicoPivTool
   livecheck do
     url "https://developers.yubico.com/yubico-piv-tool/Releases/"
-    regex(/href=.*?yubico-piv-tool-([0-9.]+)\.t/i)
+    regex(/href=.*?yubico-piv-tool-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/zebra.rb
+++ b/Livecheckables/zebra.rb
@@ -1,6 +1,6 @@
 class Zebra
   livecheck do
     url "https://www.indexdata.com/resources/software/zebra"
-    regex(%r{>Latest:</strong>.*?([0-9.]+)<}i)
+    regex(%r{>Latest:</strong>.*?v?(\d+(?:\.\d+)+)<}i)
   end
 end

--- a/Livecheckables/zita-convolver.rb
+++ b/Livecheckables/zita-convolver.rb
@@ -1,6 +1,6 @@
 class ZitaConvolver
   livecheck do
     url "https://kokkinizita.linuxaudio.org/linuxaudio/downloads/index.html"
-    regex(/href=.*?zita-convolver-([0-9.]+)\.t/i)
+    regex(/href=.*?zita-convolver-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/zsh.rb
+++ b/Livecheckables/zsh.rb
@@ -1,6 +1,6 @@
 class Zsh
   livecheck do
     url "https://www.zsh.org/pub/"
-    regex(/zsh-([0-9.]+)\./i)
+    regex(/zsh-v?(\d+(?:\.\d+)+)\./i)
   end
 end


### PR DESCRIPTION
Sorry for the delay with this PR and the less descriptive commit message.

In this PR, I've updated those Livecheckables with `([0-9.]+)` regexes, where the version we're trying to match is neither a year/timestamp nor just a natural number (as is the case with `txr`), to `(\d+(?:\.\d+)+)`.

I haven't, however, prepended the `v?` in this PR. Should I do that as well here? Thanks.