### PR TITLE
boost: update regex

### DIFF
--- a/Livecheckables/boost.rb
+++ b/Livecheckables/boost.rb
@@ -1,6 +1,6 @@
 class Boost
   livecheck do
     url "https://www.boost.org/feed/downloads.rss"
-    regex(/Version v?(\d+(?:\.\d+)+)/)
+    regex(/>Version v?(\d+(?:\.\d+)+)</i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `boost` used a regex that was matching text in the `<copyright>` element of the RSS feed, leading to the inclusion of a `1.0` version from the following text:

```
<copyright>Distributed under the Boost Software License, Version 1.0. (See accompanying file LICENSE_1_0.txt or https://www.boost.org/LICENSE_1_0.txt)</copyright>
```

This updates the regex to restrict matching to text between an opening and closing element, so we're only likely to match the `<title>` elements. If this isn't strict enough in the long run, we can modify the regex to be more explicit (e.g., `/<title[^>]*>Version v?(\d+(?:\.\d+)+)</i`).

Besides this, I've also updated the regex to be case insensitive, since it isn't required for matching with the aforementioned modification.