### PR TITLE
cabextract: update url and regex

### DIFF
--- a/Livecheckables/cabextract.rb
+++ b/Livecheckables/cabextract.rb
@@ -1,6 +1,6 @@
 class Cabextract
   livecheck do
-    url "https://github.com/kyz/libmspack.git"
-    regex(/v?(\d+(?:\.\d+)+)/i)
+    url :homepage
+    regex(/href=.*?cabextract[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `cabextract` was matching prerelease versions (e.g., `v0.0.20060920alpha`, `v0.10.1alpha`, etc.), since there was no ending delimiter.

This updates the check to use the homepage (since the formula's stable archive comes from the first-party website) and modifies the regex accordingly.