### PR TITLE
gromacs: update regex

### DIFF
--- a/Livecheckables/gromacs.rb
+++ b/Livecheckables/gromacs.rb
@@ -1,6 +1,6 @@
 class Gromacs
   livecheck do
     url "https://ftp.gromacs.org/pub/gromacs/"
-    regex(/href=.*?gromacs-v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?gromacs-v?(\d+(?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
The recent update to the `gromacs` livecheckable's regex caused it to not match versions that consist of one numeric part like `2016`, `2018`, `2019`, and `2020` (most versions are like `2020.1`, `2020.2`, etc.).

This updates the regex to make the `(?:\.\d+)+` part optional (i.e., `(?:\.\d+)*`), which addresses this issue.