### PR TITLE
ii: update regex

### DIFF
--- a/Livecheckables/ii.rb
+++ b/Livecheckables/ii.rb
@@ -1,6 +1,6 @@
 class Ii
   livecheck do
     url "https://dl.suckless.org/tools/"
-    regex(/href=.*?ii-v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?ii[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
The recent update to the regex in the existing livecheckable for `ii` caused it to not match versions that consist of one numeric part like `1` (most versions are like `1.1`, `1.2`, etc.).

This updates the regex to make the `(?:\.\d+)+` part optional (i.e., `(?:\.\d+)*`), which addresses this issue.