### PR TITLE
zsh: update regex

### DIFF
--- a/Livecheckables/zsh.rb
+++ b/Livecheckables/zsh.rb
@@ -1,6 +1,6 @@
 class Zsh
   livecheck do
     url "https://www.zsh.org/pub/"
-    regex(/zsh-v?(\d+(?:\.\d+)+)\./i)
+    regex(/href=.*?zsh[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
Before the recent update to the existing livecheckable's regex for `zsh`, the regex at the time (`/zsh-([0-9.]+)\./i`) was producing a partial match of `5` (along with the good `5.8` version), probably from the `zsh-5.8-doc.tar.xz` file. This was primarily due to the regex being too loose and not including an adequate trailing delimiter (e.g., `\.t`)

This brings the regex up to current standards, which will help to avoid this sort of situation in the future:

* Use `href=.*?` to match the file name within the `href` attribute, when applicable
* Use the `[._-]` delimiter between the software name and version
* Use `\.t` as the trailing delimiter for tarballs