### PR TITLE
Remove LivecheckStrategy NAME requirement

### DIFF
--- a/livecheck/livecheck_strategy/apache.rb
+++ b/livecheck/livecheck_strategy/apache.rb
@@ -2,8 +2,6 @@
 
 module LivecheckStrategy
   class Apache
-    NAME = name.demodulize.freeze
-
     def self.match?(url)
       %r{www\.apache\.org/dyn}.match?(url)
     end

--- a/livecheck/livecheck_strategy/bitbucket.rb
+++ b/livecheck/livecheck_strategy/bitbucket.rb
@@ -2,8 +2,6 @@
 
 module LivecheckStrategy
   class Bitbucket
-    NAME = name.demodulize.freeze
-
     def self.match?(url)
       %r{bitbucket\.org(/[^/]+){4}\.\w+}.match?(url)
     end

--- a/livecheck/livecheck_strategy/git.rb
+++ b/livecheck/livecheck_strategy/git.rb
@@ -2,7 +2,6 @@
 
 module LivecheckStrategy
   class Git
-    NAME = name.demodulize.freeze
     PRIORITY = 8
 
     def self.tag_info(repo_url, filter = nil)

--- a/livecheck/livecheck_strategy/gnome.rb
+++ b/livecheck/livecheck_strategy/gnome.rb
@@ -2,7 +2,6 @@
 
 module LivecheckStrategy
   class Gnome
-    NAME = name.demodulize.freeze
     NICE_NAME = "GNOME"
 
     # Formulae that do not use GNOME's "even-numbered minor is stable" scheme

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -2,7 +2,6 @@
 
 module LivecheckStrategy
   class Gnu
-    NAME = name.demodulize.freeze
     NICE_NAME = "GNU"
 
     PROJECT_NAME_REGEXES = [

--- a/livecheck/livecheck_strategy/hackage.rb
+++ b/livecheck/livecheck_strategy/hackage.rb
@@ -2,8 +2,6 @@
 
 module LivecheckStrategy
   class Hackage
-    NAME = name.demodulize.freeze
-
     def self.match?(url)
       /hackage\.haskell\.org/.match?(url)
     end

--- a/livecheck/livecheck_strategy/launchpad.rb
+++ b/livecheck/livecheck_strategy/launchpad.rb
@@ -2,8 +2,6 @@
 
 module LivecheckStrategy
   class Launchpad
-    NAME = name.demodulize.freeze
-
     def self.match?(url)
       /launchpad\.net/.match?(url)
     end

--- a/livecheck/livecheck_strategy/npm.rb
+++ b/livecheck/livecheck_strategy/npm.rb
@@ -2,7 +2,6 @@
 
 module LivecheckStrategy
   class Npm
-    NAME = name.demodulize.freeze
     NICE_NAME = "npm"
 
     def self.match?(url)

--- a/livecheck/livecheck_strategy/page_match.rb
+++ b/livecheck/livecheck_strategy/page_match.rb
@@ -4,7 +4,6 @@ require "open-uri"
 
 module LivecheckStrategy
   class PageMatch
-    NAME = name.demodulize.freeze
     NICE_NAME = "Page match"
     PRIORITY = 0
 

--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -2,7 +2,6 @@
 
 module LivecheckStrategy
   class Pypi
-    NAME = name.demodulize.freeze
     NICE_NAME = "PyPI"
 
     def self.match?(url)

--- a/livecheck/livecheck_strategy/sourceforge.rb
+++ b/livecheck/livecheck_strategy/sourceforge.rb
@@ -2,7 +2,6 @@
 
 module LivecheckStrategy
   class Sourceforge
-    NAME = name.demodulize.freeze
     NICE_NAME = "SourceForge"
 
     SPECIAL_CASES = %w[

--- a/livecheck/livecheck_strategy/xorg.rb
+++ b/livecheck/livecheck_strategy/xorg.rb
@@ -4,7 +4,6 @@ require "open-uri"
 
 module LivecheckStrategy
   class Xorg
-    NAME = name.demodulize.freeze
     NICE_NAME = "X.Org"
 
     @page_data = {}


### PR DESCRIPTION
Currently `LivecheckStrategy` classes are required to include `NAME = name.demodulize.freeze`, so that we avoid running this code numerous times within `#latest_version`. Ideally this should be handled within livecheck, so it's not necessary to include this snippet in all `LivecheckStrategy` classes.

This PR aims to achieve this by creating and populating a `@livecheck_strategy_names` hash, which maps a `LivecheckStrategy` to the demodulized strategy name. With this setup, we continue to only run `strategy.name.demodulize` once per strategy over a given run of `brew livecheck`.