### PR TITLE
Update HREF=" to href=.*? in regexes

### DIFF
--- a/Livecheckables/autossh.rb
+++ b/Livecheckables/autossh.rb
@@ -1,6 +1,6 @@
 class Autossh
   livecheck do
     url :homepage
-    regex(/HREF="autossh-([0-9.]+[a-z]+)\.t/i)
+    regex(/href=.*?autossh-([0-9.]+[a-z]+)\.t/i)
   end
 end

--- a/Livecheckables/calc.rb
+++ b/Livecheckables/calc.rb
@@ -1,6 +1,6 @@
 class Calc
   livecheck do
     url "http://www.isthe.com/chongo/src/calc/"
-    regex(/HREF="([0-9,.]+)_IS_LATEST_STABLE"/i)
+    regex(/href=.*?([0-9,.]+)_IS_LATEST_STABLE"/i)
   end
 end

--- a/Livecheckables/dwarfutils.rb
+++ b/Livecheckables/dwarfutils.rb
@@ -1,6 +1,6 @@
 class Dwarfutils
   livecheck do
     url :homepage
-    regex(/href=.*?libdwarf-([0-9.]+)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)libdwarf-([0-9.]+)\.t}i)
   end
 end

--- a/Livecheckables/dwarfutils.rb
+++ b/Livecheckables/dwarfutils.rb
@@ -1,6 +1,6 @@
 class Dwarfutils
   livecheck do
     url :homepage
-    regex(/HREF="libdwarf-([0-9.]+)\.t/i)
+    regex(/href=.*?libdwarf-([0-9.]+)\.t/i)
   end
 end

--- a/Livecheckables/fdclone.rb
+++ b/Livecheckables/fdclone.rb
@@ -1,6 +1,6 @@
 class Fdclone
   livecheck do
     url :homepage
-    regex(%r{HREF="\./FD-([0-9.a-z]+)\.t}i)
+    regex(%r{href=.*?\./FD-([0-9.a-z]+)\.t}i)
   end
 end

--- a/Livecheckables/homebank.rb
+++ b/Livecheckables/homebank.rb
@@ -1,6 +1,6 @@
 class Homebank
   livecheck do
     url "http://homebank.free.fr/public/"
-    regex(/HREF="homebank-v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?homebank-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/hspell.rb
+++ b/Livecheckables/hspell.rb
@@ -1,6 +1,6 @@
 class Hspell
   livecheck do
     url "http://hspell.ivrix.org.il/download.html"
-    regex(/HREF="hspell-v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?hspell-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/rsstail.rb
+++ b/Livecheckables/rsstail.rb
@@ -1,6 +1,6 @@
 class Rsstail
   livecheck do
     url :homepage
-    regex(/Latest release.*HREF="rsstail-v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/Latest release.*href=.*?rsstail-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/sqliteodbc.rb
+++ b/Livecheckables/sqliteodbc.rb
@@ -1,6 +1,6 @@
 class Sqliteodbc
   livecheck do
     url "http://www.ch-werner.de/sqliteodbc/"
-    regex(/HREF="sqliteodbc-v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?sqliteodbc-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR updates instances of `HREF="` to `href=.*?` in Livecheckable regexes. I believe CI might fail (specifically for `hspell`) as SourceForge is experiencing problems right now.

Update (as expected):
```
Error: hspell: 503 Service Temporarily Unavailable
```