### PR TITLE
Update ([0-9.]+) to v?(\d{6,8}) in regexes

### DIFF
--- a/Livecheckables/acpica.rb
+++ b/Livecheckables/acpica.rb
@@ -1,6 +1,6 @@
 class Acpica
   livecheck do
     url "https://acpica.org/downloads"
-    regex(/current release of ACPICA is version <strong>([0-9.]+) </i)
+    regex(/current release of ACPICA is version <strong>v?(\d{6,8}) </i)
   end
 end

--- a/Livecheckables/dwarfutils.rb
+++ b/Livecheckables/dwarfutils.rb
@@ -1,6 +1,6 @@
 class Dwarfutils
   livecheck do
     url :homepage
-    regex(%r{href=(?:["']?|.*?/)libdwarf-([0-9.]+)\.t}i)
+    regex(%r{href=(?:["']?|.*?/)libdwarf-v?(\d{6,8})\.t}i)
   end
 end

--- a/Livecheckables/puzzles.rb
+++ b/Livecheckables/puzzles.rb
@@ -1,6 +1,6 @@
 class Puzzles
   livecheck do
     url "https://www.freshports.org/games/sgt-puzzles"
-    regex(/puzzles-([0-9.]+)\..*?\.t/i)
+    regex(/puzzles-v?(\d{6,8})\..*?\.t/i)
   end
 end

--- a/Livecheckables/wtf.rb
+++ b/Livecheckables/wtf.rb
@@ -1,6 +1,6 @@
 class Wtf
   livecheck do
     url :homepage
-    regex(%r{.*?/wtf-([0-9.]+)\.t}i)
+    regex(%r{.*?/wtf-v?(\d{6,8})\.t}i)
   end
 end


### PR DESCRIPTION
This PR depends on #1210 due to changes in `dwarfutils`.

I've updated `([0-9.]+)` in date-based version regexes to `v?(\d{6,8})`.

CI may fail for `wtf`'s livecheck as SourceForge is having problems.