### PR TITLE
Update ([0-9,.]+) to v?(\d+(?:\.\d+)+) in regexes

### DIFF
--- a/Livecheckables/aescrypt-packetizer.rb
+++ b/Livecheckables/aescrypt-packetizer.rb
@@ -1,6 +1,6 @@
 class AescryptPacketizer
   livecheck do
     url "https://www.aescrypt.com/download/"
-    regex(%r{href=.*?/linux/aescrypt-([0-9,.]+)\.t}i)
+    regex(%r{href=.*?/linux/aescrypt-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/ansifilter.rb
+++ b/Livecheckables/ansifilter.rb
@@ -1,6 +1,6 @@
 class Ansifilter
   livecheck do
     url "http://www.andre-simon.de/zip/download.php"
-    regex(/href=.*?ansifilter-([0-9,.]+)\.t/i)
+    regex(/href=.*?ansifilter-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/argus.rb
+++ b/Livecheckables/argus.rb
@@ -1,6 +1,6 @@
 class Argus
   livecheck do
     url "https://qosient.com/argus/src/"
-    regex(/href=.*?argus-([0-9,.]+)\.t/i)
+    regex(/href=.*?argus-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/aspectj.rb
+++ b/Livecheckables/aspectj.rb
@@ -1,6 +1,6 @@
 class Aspectj
   livecheck do
     url "https://eclipse.org/aspectj/downloads.php"
-    regex(%r{Latest Stable Release.*?/aspectj-([0-9,.]+)\.jar}im)
+    regex(%r{Latest Stable Release.*?/aspectj-v?(\d+(?:\.\d+)+)\.jar}im)
   end
 end

--- a/Livecheckables/augeas.rb
+++ b/Livecheckables/augeas.rb
@@ -1,6 +1,6 @@
 class Augeas
   livecheck do
     url "http://download.augeas.net/"
-    regex(/href=.*?augeas-([0-9,.]+)\.t/i)
+    regex(/href=.*?augeas-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/bonnie++.rb
+++ b/Livecheckables/bonnie++.rb
@@ -1,6 +1,6 @@
 class Bonniexx
   livecheck do
     url "https://www.coker.com.au/bonnie++/experimental/"
-    regex(/bonnie\+\+-([0-9,.]+)\.t/i)
+    regex(/bonnie\+\+-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/calc.rb
+++ b/Livecheckables/calc.rb
@@ -1,6 +1,6 @@
 class Calc
   livecheck do
     url "http://www.isthe.com/chongo/src/calc/"
-    regex(/href=.*?([0-9,.]+)_IS_LATEST_STABLE"/i)
+    regex(/href=.*?v?(\d+(?:\.\d+)+)_IS_LATEST_STABLE"/i)
   end
 end

--- a/Livecheckables/ccm.rb
+++ b/Livecheckables/ccm.rb
@@ -1,6 +1,6 @@
 class Ccm
   livecheck do
     url :stable
-    regex(%r{/ccm-([0-9,.]+)\.t}i)
+    regex(%r{/ccm-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/cimg.rb
+++ b/Livecheckables/cimg.rb
@@ -1,6 +1,6 @@
 class Cimg
   livecheck do
     url "https://cimg.eu/files/"
-    regex(/href=.*?CImg_([0-9,.]+)\.zip/i)
+    regex(/href=.*?CImg_v?(\d+(?:\.\d+)+)\.zip/i)
   end
 end

--- a/Livecheckables/creduce.rb
+++ b/Livecheckables/creduce.rb
@@ -1,6 +1,6 @@
 class Creduce
   livecheck do
     url :homepage
-    regex(/href=.*?creduce-([0-9,.]+)\.t/i)
+    regex(/href=.*?creduce-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/di.rb
+++ b/Livecheckables/di.rb
@@ -1,6 +1,6 @@
 class Di
   livecheck do
     url :homepage
-    regex(%r{<p>Current Version: ([0-9,.]+)</p>}i)
+    regex(%r{<p>Current Version: v?(\d+(?:\.\d+)+)</p>}i)
   end
 end

--- a/Livecheckables/dmenu.rb
+++ b/Livecheckables/dmenu.rb
@@ -1,6 +1,6 @@
 class Dmenu
   livecheck do
     url "https://dl.suckless.org/tools/"
-    regex(/href=.*?dmenu-([0-9,.]+)\.t/i)
+    regex(/href=.*?dmenu-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dnsmasq.rb
+++ b/Livecheckables/dnsmasq.rb
@@ -1,6 +1,6 @@
 class Dnsmasq
   livecheck do
     url "http://www.thekelleys.org.uk/dnsmasq/"
-    regex(/href=.*?dnsmasq-([0-9,.]+)\.t/i)
+    regex(/href=.*?dnsmasq-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dos2unix.rb
+++ b/Livecheckables/dos2unix.rb
@@ -1,6 +1,6 @@
 class Dos2unix
   livecheck do
     url "https://waterlan.home.xs4all.nl/dos2unix/"
-    regex(/href=.*?dos2unix-([0-9,.]+)\.t/i)
+    regex(/href=.*?dos2unix-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/druid.rb
+++ b/Livecheckables/druid.rb
@@ -1,6 +1,6 @@
 class Druid
   livecheck do
     url "https://druid.apache.org/downloads.html"
-    regex(/href=.*?druid-([0-9,.]+)-bin\.t/i)
+    regex(/href=.*?druid-v?(\d+(?:\.\d+)+)-bin\.t/i)
   end
 end

--- a/Livecheckables/duck.rb
+++ b/Livecheckables/duck.rb
@@ -1,6 +1,6 @@
 class Duck
   livecheck do
     url "https://cyberduck.io/changelog/"
-    regex(/href=.*?Cyberduck-([0-9,.]+)\.zip/i)
+    regex(/href=.*?Cyberduck-v?(\d+(?:\.\d+)+)\.zip/i)
   end
 end

--- a/Livecheckables/efl.rb
+++ b/Livecheckables/efl.rb
@@ -1,6 +1,6 @@
 class Efl
   livecheck do
     url "https://download.enlightenment.org/rel/libs/efl/"
-    regex(/href=.*?efl-([0-9,.]+)\.t/i)
+    regex(/href=.*?efl-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/eralchemy.rb
+++ b/Livecheckables/eralchemy.rb
@@ -1,6 +1,6 @@
 class Eralchemy
   livecheck do
     url :stable
-    regex(/href=.*?ERAlchemy-([0-9,.]+)\.t/i)
+    regex(/href=.*?ERAlchemy-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/feh.rb
+++ b/Livecheckables/feh.rb
@@ -1,6 +1,6 @@
 class Feh
   livecheck do
     url :homepage
-    regex(/href=.*?feh-([0-9,.]+)\.t/i)
+    regex(/href=.*?feh-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/fetch-crl.rb
+++ b/Livecheckables/fetch-crl.rb
@@ -1,6 +1,6 @@
 class FetchCrl
   livecheck do
     url "https://dist.eugridpma.info/distribution/util/fetch-crl/"
-    regex(/href=.*?fetch-crl-([0-9,.]+)\.t/i)
+    regex(/href=.*?fetch-crl-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gkrellm.rb
+++ b/Livecheckables/gkrellm.rb
@@ -1,6 +1,6 @@
 class Gkrellm
   livecheck do
     url "http://gkrellm.srcbox.net/releases/"
-    regex(/href=.*?gkrellm-([0-9,.]+)\.t/i)
+    regex(/href=.*?gkrellm-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/irssi.rb
+++ b/Livecheckables/irssi.rb
@@ -1,6 +1,6 @@
 class Irssi
   livecheck do
     url "https://irssi.org/download/"
-    regex(%r{<p>Latest release version: <strong>([0-9,.]+)</strong>}i)
+    regex(%r{<p>Latest release version: <strong>v?(\d+(?:\.\d+)+)</strong>}i)
   end
 end

--- a/Livecheckables/libetonyek.rb
+++ b/Livecheckables/libetonyek.rb
@@ -1,6 +1,6 @@
 class Libetonyek
   livecheck do
     url "https://dev-www.libreoffice.org/src/libetonyek/"
-    regex(/href=.*?libetonyek-([0-9,.]+)\.t/i)
+    regex(/href=.*?libetonyek-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libevent.rb
+++ b/Livecheckables/libevent.rb
@@ -1,6 +1,6 @@
 class Libevent
   livecheck do
     url :homepage
-    regex(/libevent-([0-9,.]+)-stable/i)
+    regex(/libevent-v?(\d+(?:\.\d+)+)-stable/i)
   end
 end

--- a/Livecheckables/libmspub.rb
+++ b/Livecheckables/libmspub.rb
@@ -1,6 +1,6 @@
 class Libmspub
   livecheck do
     url "https://dev-www.libreoffice.org/src/libmspub/"
-    regex(/href=.*?libmspub-([0-9,.]+)\.t/i)
+    regex(/href=.*?libmspub-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libpagemaker.rb
+++ b/Livecheckables/libpagemaker.rb
@@ -1,6 +1,6 @@
 class Libpagemaker
   livecheck do
     url "https://dev-www.libreoffice.org/src/libpagemaker/"
-    regex(/href=.*?libpagemaker-([0-9,.]+)\.t/i)
+    regex(/href=.*?libpagemaker-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libssh2.rb
+++ b/Livecheckables/libssh2.rb
@@ -1,6 +1,6 @@
 class Libssh2
   livecheck do
     url "https://libssh2.org/download/"
-    regex(/libssh2-([0-9,.]+)\./i)
+    regex(/libssh2-v?(\d+(?:\.\d+)+)\./i)
   end
 end

--- a/Livecheckables/libtermkey.rb
+++ b/Livecheckables/libtermkey.rb
@@ -1,6 +1,6 @@
 class Libtermkey
   livecheck do
     url :homepage
-    regex(/href=.*?libtermkey-([0-9,.]+)\.t/i)
+    regex(/href=.*?libtermkey-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/lighttpd.rb
+++ b/Livecheckables/lighttpd.rb
@@ -1,6 +1,6 @@
 class Lighttpd
   livecheck do
     url "https://download.lighttpd.net/lighttpd/releases-1.4.x/"
-    regex(/href=.*?lighttpd-([0-9,.]+)\.t/i)
+    regex(/href=.*?lighttpd-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/logcheck.rb
+++ b/Livecheckables/logcheck.rb
@@ -1,6 +1,6 @@
 class Logcheck
   livecheck do
     url "https://packages.debian.org/unstable/logcheck"
-    regex(/logcheck_([0-9,.]+)\.t/i)
+    regex(/logcheck_v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/monit.rb
+++ b/Livecheckables/monit.rb
@@ -1,6 +1,6 @@
 class Monit
   livecheck do
     url "https://mmonit.com/monit/dist/"
-    regex(/href=.*?monit-([0-9,.]+)\.t/i)
+    regex(/href=.*?monit-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/nagios.rb
+++ b/Livecheckables/nagios.rb
@@ -1,6 +1,6 @@
 class Nagios
   livecheck do
     url "https://sourceforge.net/projects/nagios/"
-    regex(%r{/.*nagios-.*/nagios-([0-9,.]+)\.t}i)
+    regex(%r{/.*nagios-.*/nagios-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/ncmpc.rb
+++ b/Livecheckables/ncmpc.rb
@@ -1,6 +1,6 @@
 class Ncmpc
   livecheck do
     url "https://www.musicpd.org/download/ncmpc/0/"
-    regex(/href=.*?ncmpc-([0-9,.]+)\.t/i)
+    regex(/href=.*?ncmpc-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/nmap.rb
+++ b/Livecheckables/nmap.rb
@@ -1,6 +1,6 @@
 class Nmap
   livecheck do
     url "https://nmap.org/dist/"
-    regex(/href=.*?nmap-([0-9,.]+)\.t/i)
+    regex(/href=.*?nmap-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/packetq.rb
+++ b/Livecheckables/packetq.rb
@@ -1,6 +1,6 @@
 class Packetq
   livecheck do
     url :homepage
-    regex(/href=.*?packetq-([0-9,.]+)\.t/i)
+    regex(/href=.*?packetq-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pcre.rb
+++ b/Livecheckables/pcre.rb
@@ -1,6 +1,6 @@
 class Pcre
   livecheck do
     url "https://ftp.pcre.org/pub/pcre/"
-    regex(/href=.*?pcre-([0-9,.]+)\.t/i)
+    regex(/href=.*?pcre-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pgcli.rb
+++ b/Livecheckables/pgcli.rb
@@ -1,6 +1,6 @@
 class Pgcli
   livecheck do
     url :stable
-    regex(/href=.*?pgcli-([0-9,.]+)\.t/i)
+    regex(/href=.*?pgcli-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pipenv.rb
+++ b/Livecheckables/pipenv.rb
@@ -1,6 +1,6 @@
 class Pipenv
   livecheck do
     url :stable
-    regex(%r{/pipenv-([0-9,.]+)\.t}i)
+    regex(%r{/pipenv-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/pkg-config.rb
+++ b/Livecheckables/pkg-config.rb
@@ -1,6 +1,6 @@
 class PkgConfig
   livecheck do
     url "https://pkg-config.freedesktop.org/releases/"
-    regex(/pkg-config-([0-9,.]+)\./i)
+    regex(/pkg-config-v?(\d+(?:\.\d+)+)\./i)
   end
 end

--- a/Livecheckables/postgresql.rb
+++ b/Livecheckables/postgresql.rb
@@ -1,6 +1,6 @@
 class Postgresql
   livecheck do
     url "https://www.postgresql.org/docs/current/static/release.html"
-    regex(/Release ([0-9,.]+)/i)
+    regex(/Release v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/redis.rb
+++ b/Livecheckables/redis.rb
@@ -1,6 +1,6 @@
 class Redis
   livecheck do
     url "http://download.redis.io/releases/"
-    regex(/href=.*?redis-([0-9,.]+)\.t/i)
+    regex(/href=.*?redis-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/subversion.rb
+++ b/Livecheckables/subversion.rb
@@ -1,6 +1,6 @@
 class Subversion
   livecheck do
     url :homepage
-    regex(/Apache Subversion ([0-9,.]+) Released/i)
+    regex(/Apache Subversion v?(\d+(?:\.\d+)+) Released/i)
   end
 end

--- a/Livecheckables/tox.rb
+++ b/Livecheckables/tox.rb
@@ -1,6 +1,6 @@
 class Tox
   livecheck do
     url :stable
-    regex(%r{/tox-([0-9,.]+)\.t}i)
+    regex(%r{/tox-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/tth.rb
+++ b/Livecheckables/tth.rb
@@ -1,6 +1,6 @@
 class Tth
   livecheck do
     url "http://hutchinson.belmont.ma.us/tth/Version"
-    regex(/"([0-9,.]+)"/i)
+    regex(/"v?(\d+(?:\.\d+)+)"/i)
   end
 end

--- a/Livecheckables/unrar.rb
+++ b/Livecheckables/unrar.rb
@@ -1,6 +1,6 @@
 class Unrar
   livecheck do
     url "https://www.rarlab.com/rar_add.htm"
-    regex(/href=.*?unrarsrc-([0-9,.]+)\.t/i)
+    regex(/href=.*?unrarsrc-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/varnish.rb
+++ b/Livecheckables/varnish.rb
@@ -1,6 +1,6 @@
 class Varnish
   livecheck do
     url "https://varnish-cache.org/releases/"
-    regex(/href=.*?varnish-([0-9,.]+)\.t/i)
+    regex(/href=.*?varnish-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/xrootd.rb
+++ b/Livecheckables/xrootd.rb
@@ -1,6 +1,6 @@
 class Xrootd
   livecheck do
     url "http://xrootd.org/dload.html"
-    regex(/href=.*?xrootd-([0-9,.]+)\.t/i)
+    regex(/href=.*?xrootd-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR updates `([0-9],.]+)` in regexes to `v?(\d+(?:\.\d+)+)`. I've checked that the version matches and latest version remain the same after the changes.