### PR TITLE
Update capture group in versioned regexes

### DIFF
--- a/Livecheckables/erlang@20.rb
+++ b/Livecheckables/erlang@20.rb
@@ -1,6 +1,6 @@
 class ErlangAT20
   livecheck do
     url "https://github.com/erlang/otp.git"
-    regex(/OTP-(20\.[0-9.]+)/i)
+    regex(/OTP-v?(20(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/ffmpeg@2.8.rb
+++ b/Livecheckables/ffmpeg@2.8.rb
@@ -1,6 +1,6 @@
 class FfmpegAT28
   livecheck do
     url "https://ffmpeg.org/download.html"
-    regex(/ffmpeg-(2\.8\.[0-9.]+)\.t/i)
+    regex(/ffmpeg-v?(2\.8(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/gcc@4.9.rb
+++ b/Livecheckables/gcc@4.9.rb
@@ -1,6 +1,6 @@
 class GccAT49
   livecheck do
     url "https://ftp.gnu.org/gnu/gcc/"
-    regex(%r{href=.*?gcc-(4\.9\.[0-9.]+)/?["' >]}i)
+    regex(%r{href=.*?gcc-v?(4\.9(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/gcc@5.rb
+++ b/Livecheckables/gcc@5.rb
@@ -1,6 +1,6 @@
 class GccAT5
   livecheck do
     url "https://ftp.gnu.org/gnu/gcc/"
-    regex(%r{href=.*?gcc-(5\.[0-9.]+)/?["' >]}i)
+    regex(%r{href=.*?gcc-v?(5(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/gcc@6.rb
+++ b/Livecheckables/gcc@6.rb
@@ -1,6 +1,6 @@
 class GccAT6
   livecheck do
     url "https://ftp.gnu.org/gnu/gcc/"
-    regex(%r{href=.*?gcc-(6\.[0-9.]+)/?["' >]}i)
+    regex(%r{href=.*?gcc-v?(6(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/gcc@7.rb
+++ b/Livecheckables/gcc@7.rb
@@ -1,6 +1,6 @@
 class GccAT7
   livecheck do
     url "https://ftp.gnu.org/gnu/gcc/"
-    regex(%r{href=.*?gcc-(7\.[0-9.]+)/?["' >]}i)
+    regex(%r{href=.*?gcc-v?(7(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/gnupg@1.4.rb
+++ b/Livecheckables/gnupg@1.4.rb
@@ -1,6 +1,6 @@
 class GnupgAT14
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gnupg/"
-    regex(/gnupg-(1\.[0-9.]+)\.t/i)
+    regex(/gnupg-v?(1\.4(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/imagemagick@6.rb
+++ b/Livecheckables/imagemagick@6.rb
@@ -1,6 +1,6 @@
 class ImagemagickAT6
   livecheck do
     url "https://www.imagemagick.org/download/"
-    regex(/href=.*?ImageMagick-(6[0-9.\-]+)\.t/i)
+    regex(/href=.*?ImageMagick-v?(6(?:\.\d+)+(?:-\d+)?)\.t/i)
   end
 end

--- a/Livecheckables/mariadb@10.1.rb
+++ b/Livecheckables/mariadb@10.1.rb
@@ -1,6 +1,6 @@
 class MariadbAT101
   livecheck do
     url "https://downloads.mariadb.org/"
-    regex(/Download (10\.1\.[0-9.]+) Stable Now/i)
+    regex(/Download v?(10\.1(?:\.\d+)+) Stable Now/i)
   end
 end

--- a/Livecheckables/mariadb@10.2.rb
+++ b/Livecheckables/mariadb@10.2.rb
@@ -1,6 +1,6 @@
 class MariadbAT102
   livecheck do
     url "https://downloads.mariadb.org/"
-    regex(/Download (10\.2\.[0-9.]+) Stable Now/i)
+    regex(/Download v?(10\.2(?:\.\d+)+) Stable Now/i)
   end
 end

--- a/Livecheckables/node@10.rb
+++ b/Livecheckables/node@10.rb
@@ -1,6 +1,6 @@
 class NodeAT10
   livecheck do
     url "https://nodejs.org/en/download/releases/"
-    regex(%r{<td data-label="Version">Node.js (10\.[0-9.]+)</td>}i)
+    regex(%r{<td data-label="Version">Node.js v?(10(?:\.\d+)+)</td>}i)
   end
 end

--- a/Livecheckables/openssl@1.1.rb
+++ b/Livecheckables/openssl@1.1.rb
@@ -1,6 +1,6 @@
 class OpensslAT11
   livecheck do
     url "https://www.openssl.org/source/"
-    regex(/href=.*?openssl-(1\.1[0-9a-z.]+)\.t/i)
+    regex(/href=.*?openssl-v?(1\.1(?:\.\d+)+[a-z]?)\.t/i)
   end
 end

--- a/Livecheckables/perl@5.18.rb
+++ b/Livecheckables/perl@5.18.rb
@@ -1,6 +1,6 @@
 class PerlAT518
   livecheck do
     url "https://www.cpan.org/src/5.0/"
-    regex(/href=.*?perl-(5\.18\.[0-9.]+)\.t/i)
+    regex(/href=.*?perl-v?(5\.18(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR updates the capture grouping versioned Livecheckable regexes. The changes are:
* Prepending `v?`
* Using `(?:\.\d+)` and variants

Some of these require extra attention – the livecheck for `gnupg@1.4` was earlier matching 1.2.x versions as well. 

There are also some exceptions where I had to deviate from our usual set of standards, such as `ffmeg@2.8` – they have versions without the patch version number, and while it wouldn't matter for that particular livecheckable, I've still used `*` and not `+` for the minor and patch matching non-capture group.