### PR TITLE
txr: update regex

### DIFF
--- a/Livecheckables/txr.rb
+++ b/Livecheckables/txr.rb
@@ -1,6 +1,6 @@
 class Txr
   livecheck do
     url "http://www.kylheku.com/cgit/txr"
-    regex(%r{href=.*?/txr-([0-9.]+)\.t}i)
+    regex(/href=.*?txr[._-]v?(\d+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR updates `txr`'s regex to conform to current standards.

They seem to have a 3-digit version number for now but in the past there was a sudden change to 2-digit versions, and then back to 3-digits. I've used just `\d+` but we might want to be stricter.

Also, the preceding `/` wasn't necessary so I removed it, but let me know if it should be added back.