### PR TITLE
diffoscope: remove livecheckable

### DIFF
--- a/Livecheckables/diffoscope.rb
+++ b/Livecheckables/diffoscope.rb
@@ -1,6 +1,0 @@
-class Diffoscope
-  livecheck do
-    url :stable
-    regex(%r{/diffoscope-([0-9,.]+)\.t}i)
-  end
-end


### PR DESCRIPTION
The PyPI strategy was working for this one, and it seemed like a Livecheckable was unnecessary. The output before and after the change are identical (version matches and latest).