### PR TITLE
abcmidi: update regex

### DIFF
--- a/Livecheckables/abcmidi.rb
+++ b/Livecheckables/abcmidi.rb
@@ -1,6 +1,6 @@
 class Abcmidi
   livecheck do
     url :homepage
-    regex(/abcMIDI-(20[0-9]+\.[0-9]+\.[0-9]+)/i)
+    regex(/abcMIDI[._-]v?(\d{4}(?:\.\d+)+)\.zip/i)
   end
 end

--- a/Livecheckables/abcmidi.rb
+++ b/Livecheckables/abcmidi.rb
@@ -1,6 +1,6 @@
 class Abcmidi
   livecheck do
     url :homepage
-    regex(/abcMIDI[._-]v?(\d{4}(?:\.\d+)+)\.zip/i)
+    regex(/href=.*?abcMIDI[._-]v?(\d{4}(?:\.\d+)+)\.zip/i)
   end
 end


### PR DESCRIPTION
This PR brings `abcmidi`'s regex up to current standards. They seem to be using a YYYY.MM.DD format, however I've been strict only with `\d{4}` for the year part of the version. Let me know if there are any changes, thanks!