### PR TITLE
cppad: update regex

### DIFF
--- a/Livecheckables/cppad.rb
+++ b/Livecheckables/cppad.rb
@@ -1,6 +1,6 @@
 class Cppad
   livecheck do
     url :head
-    regex(/(20[0-9]+\.[0-9]+)/i)
+    regex(/^v?(\d{8}(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/cppad.rb
+++ b/Livecheckables/cppad.rb
@@ -1,6 +1,6 @@
 class Cppad
   livecheck do
     url :head
-    regex(/^v?(\d{8}(?:\.\d+)+)$/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end


### PR DESCRIPTION
This PR brings `cppad`'s regex up to current standards. They've consistently used a scheme that's 8 digits followed. by a dot and then a digit (could be digits). I didn't know what'd be the best solution here, but I've gone ahead with `(\d{8}(?:\.\d+)+)`, let me know if I should use something else.