### PR TITLE
Update multiple [0-9.]+ to v?(\d+(?:\.\d+)+) in regexes

### DIFF
--- a/Livecheckables/cmockery2.rb
+++ b/Livecheckables/cmockery2.rb
@@ -1,6 +1,6 @@
 class Cmockery2
   livecheck do
     url :head
-    regex(/([0-9]+\.[0-9.]+)/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/kpcli.rb
+++ b/Livecheckables/kpcli.rb
@@ -1,6 +1,6 @@
 class Kpcli
   livecheck do
     url "https://sourceforge.net/projects/kpcli/"
-    regex(%r{.*?/kpcli-([0-9.]+\.[0-9.]+)\.p}i)
+    regex(%r{.*?/kpcli-v?(\d+(?:\.\d+)+)\.p}i)
   end
 end

--- a/Livecheckables/lame.rb
+++ b/Livecheckables/lame.rb
@@ -1,6 +1,6 @@
 class Lame
   livecheck do
     url "https://sourceforge.net/projects/lame/"
-    regex(%r{.*?/lame-([0-9.]+\.[0-9.]+)\.t}i)
+    regex(%r{.*?/lame-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/pcb.rb
+++ b/Livecheckables/pcb.rb
@@ -1,6 +1,6 @@
 class Pcb
   livecheck do
     url "https://sourceforge.net/projects/pcb/"
-    regex(%r{.*?/pcb-([0-9.]+\.[0-9.]+)\.t}i)
+    regex(%r{.*?/pcb-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/ser2net.rb
+++ b/Livecheckables/ser2net.rb
@@ -1,6 +1,6 @@
 class Ser2net
   livecheck do
     url "https://sourceforge.net/projects/ser2net/"
-    regex(%r{.*?/ser2net-([0-9.]+\.[0-9.]+)\.t}i)
+    regex(%r{.*?/ser2net-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/shmcat.rb
+++ b/Livecheckables/shmcat.rb
@@ -1,6 +1,6 @@
 class Shmcat
   livecheck do
     url "https://sourceforge.net/projects/shmcat/"
-    regex(%r{.*?/shmcat-([0-9.]+\.[0-9.]+)\.t}i)
+    regex(%r{.*?/shmcat-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/tclap.rb
+++ b/Livecheckables/tclap.rb
@@ -1,6 +1,6 @@
 class Tclap
   livecheck do
     url "https://sourceforge.net/projects/tclap/"
-    regex(%r{.*?/tclap-([0-9.]+\.[0-9.]+)\.t}i)
+    regex(%r{.*?/tclap-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/v8.rb
+++ b/Livecheckables/v8.rb
@@ -1,6 +1,6 @@
 class V8
   livecheck do
     url "https://omahaproxy.appspot.com/all.json?os=mac&channel=stable"
-    regex(/"v8_version": "(([0-9]+\.){3}[0-9]+)"/i)
+    regex(/"v8_version": "v?(\d+(?:\.\d+)+)"/i)
   end
 end

--- a/Livecheckables/writerperfect.rb
+++ b/Livecheckables/writerperfect.rb
@@ -1,6 +1,6 @@
 class Writerperfect
   livecheck do
     url "https://sourceforge.net/projects/libwpd/"
-    regex(%r{.*?/writerperfect-([0-9.]+\.[0-9.]+)\.t}i)
+    regex(%r{.*?/writerperfect-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end


### PR DESCRIPTION
This PR updates regexes with multiple `[0-9.]+`s to our current default regex. Only `cmockery2` has an extra change – the `^...$` format to prevent matching any unstable tags (if present).