### PR TITLE
freetype: update regex

### DIFF
--- a/Livecheckables/freetype.rb
+++ b/Livecheckables/freetype.rb
@@ -1,6 +1,6 @@
 class Freetype
   livecheck do
     url :stable
-    regex(%r{freetype2/([a-zA-Z0-9.]+(?:\.[a-zA-Z0-9.]+)*)}i)
+    regex(%r{url=.*?freetype2/v?(\d+(?:\.\d+)+)/}i)
   end
 end

--- a/Livecheckables/freetype.rb
+++ b/Livecheckables/freetype.rb
@@ -1,6 +1,6 @@
 class Freetype
   livecheck do
     url :stable
-    regex(%r{url=.*?freetype2/v?(\d+(?:\.\d+)+)/}i)
+    regex(/url=.*?freetype[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR updates `freetype`'s regex to conform to current standards. I tried, initially, to match the filename so that we'd have a regex ending with `\.t`, but that doesn't match version `2.9`. So I used the same idea as the earlier regex, but just improved it based on our current standards. Do let me know if there are any changes.