### PR TITLE
Fix new RuboCop offenses

### DIFF
--- a/cmd/livecheck.rb
+++ b/cmd/livecheck.rb
@@ -8,8 +8,7 @@ require_relative "../livecheck/extend/formulary"
 module Homebrew
   module_function
 
-  WATCHLIST_PATH = ENV["HOMEBREW_LIVECHECK_WATCHLIST"]
-  WATCHLIST_PATH ||= Pathname.new(Dir.home)/".brew_livecheck_watchlist"
+  WATCHLIST_PATH = (ENV["HOMEBREW_LIVECHECK_WATCHLIST"] || Pathname.new(Dir.home)/".brew_livecheck_watchlist").freeze
   private_constant :WATCHLIST_PATH
 
   GITHUB_SPECIAL_CASES = %w[

--- a/livecheck/livecheck_strategy/apache.rb
+++ b/livecheck/livecheck_strategy/apache.rb
@@ -2,7 +2,7 @@
 
 module LivecheckStrategy
   class Apache
-    NAME = name.demodulize
+    NAME = name.demodulize.freeze
 
     def self.match?(url)
       %r{www\.apache\.org/dyn}.match?(url)

--- a/livecheck/livecheck_strategy/bitbucket.rb
+++ b/livecheck/livecheck_strategy/bitbucket.rb
@@ -2,7 +2,7 @@
 
 module LivecheckStrategy
   class Bitbucket
-    NAME = name.demodulize
+    NAME = name.demodulize.freeze
 
     def self.match?(url)
       %r{bitbucket\.org(/[^/]+){4}\.\w+}.match?(url)

--- a/livecheck/livecheck_strategy/git.rb
+++ b/livecheck/livecheck_strategy/git.rb
@@ -2,7 +2,7 @@
 
 module LivecheckStrategy
   class Git
-    NAME = name.demodulize
+    NAME = name.demodulize.freeze
     PRIORITY = 8
 
     def self.tag_info(repo_url, filter = nil)
@@ -24,7 +24,7 @@ module LivecheckStrategy
       tags = tag_info(url, regex)
       tags_only_debian = tags.all? { |tag| tag.start_with?("debian/") }
 
-      match_data = { :matches => {}, :regex => regex, :url => url }
+      match_data = { matches: {}, regex: regex, url: url }
       tags.each do |tag|
         # Skip tag if it has a 'debian/' prefix and upstream does not do only
         # 'debian/' prefixed tags

--- a/livecheck/livecheck_strategy/gnome.rb
+++ b/livecheck/livecheck_strategy/gnome.rb
@@ -2,7 +2,7 @@
 
 module LivecheckStrategy
   class Gnome
-    NAME = name.demodulize
+    NAME = name.demodulize.freeze
     NICE_NAME = "GNOME"
 
     # Formulae that do not use GNOME's "even-numbered minor is stable" scheme

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -2,7 +2,7 @@
 
 module LivecheckStrategy
   class Gnu
-    NAME = name.demodulize
+    NAME = name.demodulize.freeze
     NICE_NAME = "GNU"
 
     PROJECT_NAME_REGEXES = [
@@ -31,7 +31,7 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex = nil)
       match_list = PROJECT_NAME_REGEXES.map { |r| url.match(r) }.compact
-      return { :matches => {}, :regex => regex, :url => url } if match_list.empty?
+      return { matches: {}, regex: regex, url: url } if match_list.empty?
 
       puts "\nMultiple project names found: #{match_list}\n" if match_list.length > 1 && Homebrew.args.debug?
 

--- a/livecheck/livecheck_strategy/hackage.rb
+++ b/livecheck/livecheck_strategy/hackage.rb
@@ -2,7 +2,7 @@
 
 module LivecheckStrategy
   class Hackage
-    NAME = name.demodulize
+    NAME = name.demodulize.freeze
 
     def self.match?(url)
       /hackage\.haskell\.org/.match?(url)

--- a/livecheck/livecheck_strategy/launchpad.rb
+++ b/livecheck/livecheck_strategy/launchpad.rb
@@ -2,7 +2,7 @@
 
 module LivecheckStrategy
   class Launchpad
-    NAME = name.demodulize
+    NAME = name.demodulize.freeze
 
     def self.match?(url)
       /launchpad\.net/.match?(url)

--- a/livecheck/livecheck_strategy/npm.rb
+++ b/livecheck/livecheck_strategy/npm.rb
@@ -2,7 +2,7 @@
 
 module LivecheckStrategy
   class Npm
-    NAME = name.demodulize
+    NAME = name.demodulize.freeze
     NICE_NAME = "npm"
 
     def self.match?(url)

--- a/livecheck/livecheck_strategy/page_match.rb
+++ b/livecheck/livecheck_strategy/page_match.rb
@@ -4,7 +4,7 @@ require "open-uri"
 
 module LivecheckStrategy
   class PageMatch
-    NAME = name.demodulize
+    NAME = name.demodulize.freeze
     NICE_NAME = "Page match"
     PRIORITY = 0
 
@@ -16,7 +16,7 @@ module LivecheckStrategy
     private_class_method :page_matches
 
     def self.find_versions(url, regex)
-      match_data = { :matches => {}, :regex => regex, :url => url }
+      match_data = { matches: {}, regex: regex, url: url }
 
       page_matches(url, regex).each do |match|
         match_data[:matches][match] = Version.new(match)

--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -2,7 +2,7 @@
 
 module LivecheckStrategy
   class Pypi
-    NAME = name.demodulize
+    NAME = name.demodulize.freeze
     NICE_NAME = "PyPI"
 
     def self.match?(url)

--- a/livecheck/livecheck_strategy/sourceforge.rb
+++ b/livecheck/livecheck_strategy/sourceforge.rb
@@ -2,7 +2,7 @@
 
 module LivecheckStrategy
   class Sourceforge
-    NAME = name.demodulize
+    NAME = name.demodulize.freeze
     NICE_NAME = "SourceForge"
 
     SPECIAL_CASES = %w[

--- a/livecheck/livecheck_strategy/xorg.rb
+++ b/livecheck/livecheck_strategy/xorg.rb
@@ -4,7 +4,7 @@ require "open-uri"
 
 module LivecheckStrategy
   class Xorg
-    NAME = name.demodulize
+    NAME = name.demodulize.freeze
     NICE_NAME = "X.Org"
 
     @page_data = {}
@@ -15,14 +15,14 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex)
       file_name = File.basename(url)
-      return { :matches => {}, :regex => regex, :url => url } unless file_name.include?("-")
+      return { matches: {}, regex: regex, url: url } unless file_name.include?("-")
 
       package_name = file_name.match(/^(.*)-\d+/)[1]
 
       page_url = url.sub("x.org/pub/", "x.org/archive/").delete_suffix(file_name)
       regex ||= /href=.*?#{package_name}[._-]v?(\d+(?:\.\d+)+)\.t/
 
-      match_data = { :matches => {}, :regex => regex, :url => page_url }
+      match_data = { matches: {}, regex: regex, url: page_url }
 
       # Cache responses to avoid unnecessary duplicate fetches
       @page_data[page_url] = URI.open(page_url).read unless @page_data.key?(page_url)


### PR DESCRIPTION
This fixes some RuboCop offenses that were added in Homebrew/brew:

* Freeze mutable objects assigned to constants
* Use the new Ruby 1.9 hash syntax