### PR TITLE
Update regex for postgresql@9.5 and postgresql@9.6

### DIFF
--- a/Livecheckables/postgresql@9.5.rb
+++ b/Livecheckables/postgresql@9.5.rb
@@ -1,6 +1,6 @@
 class PostgresqlAT95
   livecheck do
     url "https://www.postgresql.org/docs/9.5/static/release.html"
-    regex(/Release ([0-9,.]+)/i)
+    regex(/Release v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/postgresql@9.6.rb
+++ b/Livecheckables/postgresql@9.6.rb
@@ -1,6 +1,6 @@
 class PostgresqlAT96
   livecheck do
     url "https://www.postgresql.org/docs/9.6/static/release.html"
-    regex(/Release ([0-9,.]+)/i)
+    regex(/Release v?(\d+(?:\.\d+)+)/i)
   end
 end


### PR DESCRIPTION
This PR updates the capture group in the regexes of `postgresql@9.5` and `postgresql@9.6`. I had missed updating these two regexes with my previous PR.