### PR TITLE
Add strategy to livecheck DSL

### DIFF
--- a/livecheck/extend/livecheck.rb
+++ b/livecheck/extend/livecheck.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Livecheck can be used to check for newer versions of the software.
+# The livecheck DSL specified in the formula is evaluated the methods
+# of this class, which set the instance variables accordingly. The
+# information is used by brew livecheck when checking for newer versions
+# of the software.
+class Livecheck
+  # The reason for skipping livecheck for the formula.
+  # e.g. `Not maintained`
+  attr_reader :skip_msg
+
+  def initialize(formula)
+    @formula = formula
+    @regex = nil
+    @skip = false
+    @skip_msg = nil
+    @strategy = nil
+    @url = nil
+  end
+
+  # Sets the strategy instance variable to the argument given or returns the
+  # strategy instance variable when no argument is given.
+  # @param symbol [Symbol] corresponding symbol for desired LivecheckStrategy
+  # @return [Symbol, nil]
+  def strategy(symbol = nil)
+    return @strategy if symbol.nil?
+
+    @strategy = symbol if symbol.is_a?(Symbol)
+  end
+
+  # Returns a Hash of all instance variable values.
+  def to_hash
+    {
+      "regex"    => @regex,
+      "skip"     => @skip,
+      "skip_msg" => @skip_msg,
+      "strategy" => @strategy,
+      "url"      => @url,
+    }
+  end
+end


### PR DESCRIPTION
This is an implementation of the oft-mentioned `strategy` feature (née `using`). As described in #301, the purpose of this is to specify the strategy to use in a livecheckable. This is the end result of a number of internal changes that enabled this feature to exist.

Specifying the `strategy` in a livecheckable is generally only necessary when the default strategy that livecheck selects isn't the one that we want. For example, the `Sourceforge` strategy may apply to a given URL but we want to use `PageMatch` instead.

An example of this is as follows:

```ruby
livecheck do
  url :stable
  strategy :page_match
  regex(/href=.*?example[._-]v?(\d+(?:\.\d+)+)\.t/i)
end
```

The argument for `strategy` is a symbol corresponding to the strategy name (with an underscore between words, as in the strategy file names).

Though I initially described some additional functionality for this feature, I think this simple implementation is all that we'll need for now. If we need additional features, we can always expand it in the future.

The only other thing to note is that it was necessary to extend Homebrew/brew's `livecheck.rb` file to implement `strategy` in the `livecheck` DSL. This will be integrated back into Homebrew/brew when that migration occurs.

Closes #301.