### PR TITLE
Update [0-9.-] and [0-9.\-] in regexes

### DIFF
--- a/Livecheckables/ffe.rb
+++ b/Livecheckables/ffe.rb
@@ -1,6 +1,6 @@
 class Ffe
   livecheck do
     url "https://sourceforge.net/projects/ff-extractor/"
-    regex(%r{/ff-extractor/v?(\d+(?:\.\d+)+(?:-\d+)?)/}i)
+    regex(%r{url=.*?/ffe-v?(\d+(?:\.\d+)+(?:-\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/ffe.rb
+++ b/Livecheckables/ffe.rb
@@ -1,6 +1,6 @@
 class Ffe
   livecheck do
     url "https://sourceforge.net/projects/ff-extractor/"
-    regex(%r{/ff-extractor/([0-9.-]+)/}i)
+    regex(%r{/ff-extractor/v?(\d+(?:\.\d+)+(?:-\d+)?)/}i)
   end
 end

--- a/Livecheckables/gdcm.rb
+++ b/Livecheckables/gdcm.rb
@@ -1,6 +1,6 @@
 class Gdcm
   livecheck do
     url :homepage
-    regex(%r{/gdcm-([0-9.\-]+)\.t}i)
+    regex(%r{/gdcm-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/gputils.rb
+++ b/Livecheckables/gputils.rb
@@ -1,6 +1,6 @@
 class Gputils
   livecheck do
     url "https://sourceforge.net/projects/gputils/"
-    regex(%r{/gputils-([0-9.\-]+)\.t}i)
+    regex(%r{/gputils-v?(\d+(?:\.\d+)+(?:-\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/imagemagick.rb
+++ b/Livecheckables/imagemagick.rb
@@ -1,6 +1,6 @@
 class Imagemagick
   livecheck do
     url "https://www.imagemagick.org/download/"
-    regex(/href=.*?ImageMagick-([0-9.\-]+)\.t/i)
+    regex(/href=.*?ImageMagick-v?(\d+(?:\.\d+)+-\d+)\.t/i)
   end
 end

--- a/Livecheckables/libcdr.rb
+++ b/Livecheckables/libcdr.rb
@@ -1,6 +1,6 @@
 class Libcdr
   livecheck do
     url "https://dev-www.libreoffice.org/src/"
-    regex(/.*href=.*?libcdr-([0-9.\-]+)\.t/i)
+    regex(/.*href=.*?libcdr-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libtiff.rb
+++ b/Livecheckables/libtiff.rb
@@ -1,6 +1,6 @@
 class Libtiff
   livecheck do
     url "https://download.osgeo.org/libtiff/"
-    regex(/href=.*?tiff-([0-9.\-]+)\.t/i)
+    regex(/href=.*?tiff-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libwpd.rb
+++ b/Livecheckables/libwpd.rb
@@ -1,6 +1,6 @@
 class Libwpd
   livecheck do
     url "https://dev-www.libreoffice.org/src/"
-    regex(/.*href=.*?libwpd-([0-9.\-]+)\.t/i)
+    regex(/.*href=.*?libwpd-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libwpg.rb
+++ b/Livecheckables/libwpg.rb
@@ -1,6 +1,6 @@
 class Libwpg
   livecheck do
     url "https://dev-www.libreoffice.org/src/"
-    regex(/.*href=.*?libwpg-([0-9.\-]+)\.t/i)
+    regex(/.*href=.*?libwpg-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/omniorb.rb
+++ b/Livecheckables/omniorb.rb
@@ -1,6 +1,6 @@
 class Omniorb
   livecheck do
     url "https://sourceforge.net/projects/omniorb/"
-    regex(%r{/omniORB-([0-9.\-]+)\.t}i)
+    regex(%r{/omniORB-v?(\d+(?:\.\d+)+(?:-\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/owamp.rb
+++ b/Livecheckables/owamp.rb
@@ -1,6 +1,6 @@
 class Owamp
   livecheck do
     url "http://software.internet2.edu/sources/owamp/"
-    regex(/href=.*?owamp-([0-9.\-]+)\.t/i)
+    regex(/href=.*?owamp-v?(\d+(?:\.\d+)+(?:-\d+)?)\.t/i)
   end
 end

--- a/Livecheckables/udpxy.rb
+++ b/Livecheckables/udpxy.rb
@@ -1,6 +1,6 @@
 class Udpxy
   livecheck do
     url "http://www.udpxy.com/download/1_23/"
-    regex(/href=.*?udpxy.([0-9.\-]+)-prod\.t/i)
+    regex(/href=.*?udpxy.v?(\d+(?:\.\d+)+-\d+)-prod\.t/i)
   end
 end


### PR DESCRIPTION
This PR updates `[0-9.-]` and `[0-9.\-]+` in regexes to conform to our current standards for the capturing group.

* If all versions reported by livecheck before the changes did not contain `-`, `v?(\d+(?:\.\d+)+)` was used.
* If some versions reported by livecheck contained `-`, `v?(\d+(?:\.\d+)+(?:-\d+)?)` was used.
* If `-` was present in all versions reported by livecheck, `v?(\d+(?:\.\d+)+-\d+)` was used.