### PR TITLE
percona-toolkit: update regex

### DIFF
--- a/Livecheckables/percona-toolkit.rb
+++ b/Livecheckables/percona-toolkit.rb
@@ -1,6 +1,6 @@
 class PerconaToolkit
   livecheck do
     url "https://www.percona.com/downloads/percona-toolkit/LATEST/"
-    regex(%r{value="percona-toolkit/([0-9\-.]+)"}i)
+    regex(%r{value=.*?percona-toolkit/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end


### PR DESCRIPTION
This PR brings `percona-toolkit`'s regex up to current standards. I figured matching `-` wasn't necessary as no versions reported by livecheck before the change included `-`. Let me know if any changes are required. Thanks!