### PR TITLE
Capture Git errors in JSON output

### DIFF
--- a/livecheck/livecheck_strategy/git.rb
+++ b/livecheck/livecheck_strategy/git.rb
@@ -1,17 +1,28 @@
 # frozen_string_literal: true
 
+require "open3"
+
 module LivecheckStrategy
   class Git
     PRIORITY = 8
 
     def self.tag_info(repo_url, filter = nil)
-      raw_tags = `GIT_TERMINAL_PROMPT=0 git ls-remote --tags #{repo_url}`
-      raw_tags.gsub!(%r{^.*\trefs/tags/}, "")
-      raw_tags.delete_suffix!("^{}")
+      stdout_str, stderr_str, _status = Open3.capture3(
+        { "GIT_TERMINAL_PROMPT" => "0" }, "git", "ls-remote", "--tags", repo_url
+      )
 
-      tags = raw_tags.split("\n").uniq.sort
+      tags_data = { tags: [] }
+      tags_data[:messages] = stderr_str.split("\n") unless stderr_str.empty?
+      return tags_data if stdout_str.empty?
+
+      stdout_str.gsub!(%r{^.*\trefs/tags/}, "")
+      stdout_str.delete_suffix!("^{}")
+
+      tags = stdout_str.split("\n").uniq.sort
       tags.select! { |t| t =~ filter } if filter
-      tags
+      tags_data[:tags] = tags
+
+      tags_data
     end
     private_class_method :tag_info
 
@@ -20,11 +31,18 @@ module LivecheckStrategy
     end
 
     def self.find_versions(url, regex = nil)
-      tags = tag_info(url, regex)
-      tags_only_debian = tags.all? { |tag| tag.start_with?("debian/") }
-
       match_data = { matches: {}, regex: regex, url: url }
-      tags.each do |tag|
+
+      tags_data = tag_info(url, regex)
+
+      if tags_data.key?(:messages)
+        match_data[:messages] = tags_data[:messages]
+        return match_data if tags_data[:tags].empty?
+      end
+
+      tags_only_debian = tags_data[:tags].all? { |tag| tag.start_with?("debian/") }
+
+      tags_data[:tags].each do |tag|
         # Skip tag if it has a 'debian/' prefix and upstream does not do only
         # 'debian/' prefixed tags
         next if tag =~ %r{^debian/} && !tags_only_debian


### PR DESCRIPTION
Currently we have an issue where `brew livecheck --json` output isn't valid JSON if the run includes a Git error. Currently the `pg_top` formula produces a Git error (until/unless Homebrew/homebrew-core#56262 is merged) and it ends up being printed before the JSON:

```
fatal: repository 'https://git.postgresql.org/gitweb/?p=pg_top.git/' not found
[{"formula":"pg_top","status":"error","messages":["Unable to get versions"]}]
```

This PR is a first attempt at capturing Git errors in the JSON output. The JSON output on this branch follows the existing format for errors and contains the Git error in the `messages` array:

```json
[{"formula":"pg_top","status":"error","messages":["fatal: repository 'https://git.postgresql.org/gitweb/?p=pg_top.git/' not found"]}]
```

This implementation works fine but I'm not sure if it's quite as nice as I would like it to be, so some feedback on this would be welcome.

For what it's worth, part of the reason why I made the `Git#git_tags` changes like I did was because it may be extended in the future to include the commit hash for the tag in the JSON response. This particular feature was requested by some folks who were working on creating an automated-PR-creation tool.