### PR TITLE
autossh: update regex

### DIFF
--- a/Livecheckables/autossh.rb
+++ b/Livecheckables/autossh.rb
@@ -1,6 +1,6 @@
 class Autossh
   livecheck do
     url :homepage
-    regex(/href=.*?autossh[._-]v?(\d+(?:\.\d+)+[a-z]+)\.t/i)
+    regex(/href=.*?autossh[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
   end
 end

--- a/Livecheckables/autossh.rb
+++ b/Livecheckables/autossh.rb
@@ -1,6 +1,6 @@
 class Autossh
   livecheck do
     url :homepage
-    regex(/href=.*?autossh-([0-9.]+[a-z]+)\.t/i)
+    regex(/href=.*?autossh[._-]v?(\d+(?:\.\d+)+[a-z]+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR brings `autossh`'s regex up to current standards. I didn't want to deviate from the earlier regex too much so I've used `[a-z]+`, just as before.