### PR TITLE
Update regexes containing `a-z` and `0-9`

### DIFF
--- a/Livecheckables/cscope.rb
+++ b/Livecheckables/cscope.rb
@@ -1,6 +1,6 @@
 class Cscope
   livecheck do
     url "https://sourceforge.net/projects/cscope/rss"
-    regex(/cscope-([a-zA-Z0-9.]+(?:\.[a-zA-Z0-9.]+)*)\.t/i)
+    regex(/cscope-v?(\d+(?:\.\d+)+[\da-z]*)\.t/i)
   end
 end

--- a/Livecheckables/cscope.rb
+++ b/Livecheckables/cscope.rb
@@ -1,6 +1,6 @@
 class Cscope
   livecheck do
     url "https://sourceforge.net/projects/cscope/rss"
-    regex(/cscope-v?(\d+(?:\.\d+)+[\da-z]*)\.t/i)
+    regex(/cscope-v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
   end
 end

--- a/Livecheckables/discount.rb
+++ b/Livecheckables/discount.rb
@@ -1,6 +1,6 @@
 class Discount
   livecheck do
     url :homepage
-    regex(/href=.*?discount-([0-9a-z.]+)\.t/i)
+    regex(/href=.*?discount-v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
   end
 end

--- a/Livecheckables/fdclone.rb
+++ b/Livecheckables/fdclone.rb
@@ -1,6 +1,6 @@
 class Fdclone
   livecheck do
     url :homepage
-    regex(%r{href=.*?\./FD-([0-9.a-z]+)\.t}i)
+    regex(%r{href=.*?\./FD-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end

--- a/Livecheckables/fig2dev.rb
+++ b/Livecheckables/fig2dev.rb
@@ -1,6 +1,6 @@
 class Fig2dev
   livecheck do
     url "https://sourceforge.net/projects/mcj/"
-    regex(%r{.*?/fig2dev-([0-9a-z.]+)\.t}i)
+    regex(%r{.*?/fig2dev-v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end

--- a/Livecheckables/isc-dhcp.rb
+++ b/Livecheckables/isc-dhcp.rb
@@ -1,6 +1,6 @@
 class IscDhcp
   livecheck do
     url "https://www.isc.org/downloads/"
-    regex(%r{/dhcp-([a-zA-Z0-9.]+)\.t}i)
+    regex(%r{/dhcp-v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/isc-dhcp.rb
+++ b/Livecheckables/isc-dhcp.rb
@@ -1,6 +1,6 @@
 class IscDhcp
   livecheck do
     url "https://www.isc.org/downloads/"
-    regex(%r{/dhcp-v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{/dhcp-v?(\d+(?:\.\d+)+(?:-P\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/mksh.rb
+++ b/Livecheckables/mksh.rb
@@ -1,6 +1,6 @@
 class Mksh
   livecheck do
     url "https://www.mirbsd.org/MirOS/dist/mir/mksh/"
-    regex(/mksh-R([0-9]+[a-z]*)\.t/i)
+    regex(/mksh-R?(\d+[a-z]?)\.t/i)
   end
 end

--- a/Livecheckables/x264.rb
+++ b/Livecheckables/x264.rb
@@ -4,6 +4,6 @@ class X264
   # the version information at the time of writing.
   livecheck do
     url "https://artifacts.videolan.org/x264/release-macos/"
-    regex(%r{href=.*?x264[._-](r\d+)[._-][a-z0-9]+/?["' >]}i)
+    regex(%r{href=.*?x264[._-](r\d+)[._-][\da-z]+/?["' >]}i)
   end
 end


### PR DESCRIPTION
This PR updates regexes containing `0-9` and `a-z`.

Attention required:
* `cscope`: We were matching a version ending in `bl2`, hence the `*`
* `isc-dhcp`: Seems like it doesn't need `[a-z]`
* `mksh`: Made `R` optional (`R?` just like `v?`)
* `x264`: No change in capture group