### PR TITLE
jpeg: update url and regex

### DIFF
--- a/Livecheckables/jpeg.rb
+++ b/Livecheckables/jpeg.rb
@@ -1,6 +1,6 @@
 class Jpeg
   livecheck do
-    url :homepage
+    url "https://www.ijg.org/files/"
     regex(/href=.*?jpegsrc[._-]v?(\d+[a-z]?)\.t/i)
   end
 end

--- a/Livecheckables/jpeg.rb
+++ b/Livecheckables/jpeg.rb
@@ -1,6 +1,6 @@
 class Jpeg
   livecheck do
     url :homepage
-    regex(/current version is release ([0-9.a-z]+)/i)
+    regex(/href=.*?jpegsrc[._-]v?(\d+[a-z]?)\.t/i)
   end
 end


### PR DESCRIPTION
Updating `jpeg`'s regex to match within the stable archive's URL.