### PR TITLE
readosm: update regex

### DIFF
--- a/Livecheckables/readosm.rb
+++ b/Livecheckables/readosm.rb
@@ -1,6 +1,6 @@
 class Readosm
   livecheck do
     url :homepage
-    regex(%r{current version is <b>([0-9a-z.]+)</b>}i)
+    regex(/href=.*?readosm[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
   end
 end


### PR DESCRIPTION
`readosm`'s [releases page](http://www.gaia-gis.it/gaia-sins/readosm-sources/) lists all older versions and the current one but the stable archive url we use in homebrew-core matches with the one on the homepage. Thus, the livecheckable url remains unchanged but the regex has been updated to match within the url of the stable archive.