### PR TITLE
vsts-cli: remove livecheckable

### DIFF
--- a/Livecheckables/vsts-cli.rb
+++ b/Livecheckables/vsts-cli.rb
@@ -1,6 +1,0 @@
-class VstsCli
-  livecheck do
-    url :stable
-    regex(/href=.*?vsts-cli-([0-9a-z.]+)\.t/i)
-  end
-end


### PR DESCRIPTION
The Livecheckable was unnecessary thanks to the PyPI strategy. Also, I found this on the "homepage" linked to on PyPI (which happens to be this [repo](https://github.com/Azure/azure-devops-cli-extension)):
```
The Azure CLI with the Azure DevOps Extension has replaced the VSTS CLI. The VSTS CLI
has been deprecated and will no longer be receiving new features. We recommend that users
of the VSTS CLI switch to the Azure CLI and add the Azure DevOps extension.
```