### PR TITLE
workflows: revert to macOS-latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     env:
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_ANALYTICS: 1


### PR DESCRIPTION
The `.github/workflows/tests.yml` file was recently updated and this included switching `runs-on` from `macOS-latest` to `ubuntu-latest`. Unfortunately, livecheck encounters some additional SSL errors on Ubuntu that we don't find on macOS (as seen in the `discount` formula in #1232), so it makes sense to switch this back to `macOS-latest`.

Either way, this will be a short-lived change, as this repository will be archived after the homebrew-core and Homebrew/brew migrations are complete (within a month).