### PR TITLE
wwwoffle: update url and regex

### DIFF
--- a/Livecheckables/wwwoffle.rb
+++ b/Livecheckables/wwwoffle.rb
@@ -1,6 +1,6 @@
 class Wwwoffle
   livecheck do
-    url :homepage
-    regex(/The absolute latest version is version ([a-z0-9.]+)\./i)
+    url "https://www.gedanken.org.uk/software/wwwoffle/download/"
+    regex(/href=.*?wwwoffle[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
   end
 end


### PR DESCRIPTION
This brings the existing `wwwoffle` livecheckable up to current standards:

* Align the check with the location of the stable archive, when possible
* Use `href=.*?` to match the file name within the `href` attribute, when applicable
* Use the `[._-]` delimiter between the software name and version
* Use `v?(\d+(?:\.\d+)+[a-z]?)` instead of `([a-z0-9.]+)`, to be more clear about what we want to match