### PR TITLE
extend/formulary: fix formula loading

### DIFF
--- a/livecheck/extend/formulary.rb
+++ b/livecheck/extend/formulary.rb
@@ -11,10 +11,20 @@ module Formulary
       end
     end
 
-    def load_formula(name, path, contents, namespace)
+    def load_formula(name, path, contents, namespace, flags:)
+      raise "Formula loading disabled by HOMEBREW_DISABLE_LOAD_FORMULA!" if Homebrew::EnvConfig.disable_load_formula?
+
       mod = Module.new
       const_set(namespace, mod)
-      mod.module_eval(contents, path)
+
+      begin
+        mod.const_set(:BUILD_FLAGS, flags)
+        mod.module_eval(contents, path)
+      rescue NameError, ArgumentError, ScriptError => e
+        $stderr.puts e.backtrace if Homebrew::EnvConfig.developer?
+        raise FormulaUnreadableError.new(name, e)
+      end
+      class_name = class_s(name)
 
       lc_path = livecheckable_path(path)
       if lc_path&.exist?
@@ -22,12 +32,14 @@ module Formulary
         mod.module_eval(lc_path.read, lc_path)
       end
 
-      class_name = class_s(name)
-
       begin
         mod.const_get(class_name)
       rescue NameError => e
-        raise FormulaUnavailableError, name, e.backtrace
+        class_list = mod.constants
+                        .map { |const_name| mod.const_get(const_name) }
+                        .select { |const| const.is_a?(Class) }
+        new_exception = FormulaClassUnavailableError.new(name, path, class_name, class_list)
+        raise new_exception, "", e.backtrace
       end
     end
   end


### PR DESCRIPTION
Due to recent changes in brew:
https://github.com/Homebrew/brew/commit/24eff8f81ac6bf50916a61bfa28fb9e4d950499a
https://github.com/Homebrew/brew/commit/08e35e9cb4e65c6969016ffaa8af4e1a968ca496
https://github.com/Homebrew/brew/commit/e07b02fde2a423ef6389330a80f4c3e5e71fcfed

Before this PR:
```
➜  homebrew/homebrew-livecheck stash master ✓  brew livecheck k3d --debug
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/k3d.rb
Error: wrong number of arguments (given 5, expected 4)
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-livecheck/livecheck/extend/formulary.rb:14:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:61:in `load_formula_from_path'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:144:in `load_file'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:134:in `klass'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:130:in `get_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:339:in `factory'
/usr/local/Homebrew/Library/Homebrew/cli/args.rb:77:in `block in formulae'
/usr/local/Homebrew/Library/Homebrew/cli/args.rb:76:in `map'
/usr/local/Homebrew/Library/Homebrew/cli/args.rb:76:in `formulae'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-livecheck/cmd/livecheck.rb:97:in `livecheck'
/usr/local/Homebrew/Library/Homebrew/brew.rb:104:in `<main>'
```

After:
```
➜  homebrew/homebrew-livecheck stash fix-formulary ✓  brew livecheck k3d --debug
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/k3d.rb
Loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-livecheck/Livecheckables/k3d.rb

Formula:          k3d
Livecheckable?:   Yes

URL:              https://github.com/rancher/k3d/archive/v3.0.0.tar.gz
URL (processed):  https://github.com/rancher/k3d.git
Strategy:         Git
Regex:            /^v?(\d+(?:\.\d+)+)$/i

Matched Versions:
0.0.1, 0.0.2, 0.1.0, 0.1.1, 0.2.0, 0.3.0, 1.0.0, 1.0.1, 1.0.2, 1.1.0, 1.2.0, 1.2.1, 1.2.2, 1.3.0, 1.3.1, 1.3.2, 1.3.3, 1.3.4, 1.4.0, 1.5.0, 1.5.1, 1.6.0, 1.7.0, 3.0.0
k3d : 3.0.0 ==> 3.0.0
```