### PR TITLE
pg_top: add livecheckable

### DIFF
--- a/Livecheckables/pg_top.rb
+++ b/Livecheckables/pg_top.rb
@@ -1,0 +1,9 @@
+class PgTop
+  # We're currently checking the pg_top GitLab repository, since there are new
+  # 4.0.0 prerelease versions there that aren't at the existing stable source
+  # (i.e., https://ftp.postgresql.org/pub/projects/pgFoundry/ptop/pg_top/).
+  livecheck do
+    url "https://gitlab.com/pg_top/pg_top.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
The default check for `pg_top` has been loudly failing for quite some time, since the homepage was a Git repository that had been removed. The formula has been updated to use the current homepage instead (an HTML page) but the default check isn't able to work with any of the sources in the formula without a livecheckable.

This adds a livecheckable for `pg_top` that checks the current GitLab repository's tags. The newest stable version at the moment is still 3.7.0 but there are recent alpha versions of 4.0.0. The reason why I'm using the GitLab repo in this check is that the current stable source in the formula doesn't contain the 4.0.0 alpha releases, so we may miss the stable release in the future if we used that source. Once the stable 4.0.0 release occurs sometime in the future, we can work on updating the check to something more appropriate.