### PR TITLE
Ignore strategies with a PRIORITY of zero or lower

### DIFF
--- a/livecheck/livecheck_strategy.rb
+++ b/livecheck/livecheck_strategy.rb
@@ -19,7 +19,9 @@ module LivecheckStrategy
   end
 
   def self.from_url(url, regex_provided = nil)
-    usable_strategies = strategies.except(:page_match).values.select do |strategy|
+    usable_strategies = strategies.values.select do |strategy|
+      next if strategy.const_defined?(:PRIORITY) && !strategy::PRIORITY.positive?
+
       strategy.respond_to?(:match?) && strategy.match?(url)
     end
 


### PR DESCRIPTION
This is a simple change that establishes the idea that a `LivecheckStrategy` with a `PRIORITY` of zero (or lower) should be ignored. This allows us to create strategies that aren't applied by default but can be applied through certain conditions internally (e.g., `PageMatch`) or through `strategy :strategy_name` in a `livecheck` block.

This primarily benefits the `PageMatch` strategy, which already has a `PRIORITY` of `0` but we were manually omitting it in `LivecheckStrategy#from_url` (before conditionally including it when a `livecheck` block contains a `regex`).

Besides that, this could also be useful if/when we need to create a strategy that should only be manually applied through `strategy :strategy_name` in a `livecheck` block. For example, I'm working on a `GithubLatest` strategy which checks the "latest" release URL but this should only be applied to repositories that actually have a release marked as "latest". Since this strategy can't be applied to 100% of the URLs it matches, it's better to only allow it to be used manually (where contributors can verify it's appropriate before using it in a `livecheck` block).