### PR TITLE
Add #match? method to PageMatch strategy

### DIFF
--- a/livecheck/livecheck_strategy/page_match.rb
+++ b/livecheck/livecheck_strategy/page_match.rb
@@ -7,6 +7,12 @@ module LivecheckStrategy
     NICE_NAME = "Page match"
     PRIORITY = 0
 
+    # PageMatch will technically match any HTTP URL but it's only usable when
+    # there's a `livecheck` block containing a regex.
+    def self.match?(url)
+      %r{^https?://}i.match?(url)
+    end
+
     def self.page_matches(url, regex)
       page = URI.open(url).read
       matches = page.scan(regex)


### PR DESCRIPTION
The `PageMatch` strategy is currently the only one without a `#match?` method, which causes us to have to defensively check `strategy.respond_to?(:match?)` before using `strategy.match?(url)`. I think it's reasonable to require `#match?` for all strategies (both internal and in taps), as `#match?` and `#from_url` are essential for livecheck to be able to apply strategies.

We've previously discussed having `PageMatch#match?` always return `true`. I think it makes sense to use something broad but more specific than just `true`. I've used `%r{^https?://}.match?(url)` here, as I think it makes sense to only apply the strategy to something over HTTP (since it fetches using `open-uri`).

Ideally, we would only apply this strategy to HTML pages, text files, etc. but that's something we could revisit in the future, as it seems like it may be challenging. I'm fine with this for now.