### PR TITLE
popt: update regex and comment

### DIFF
--- a/Livecheckables/popt.rb
+++ b/Livecheckables/popt.rb
@@ -1,11 +1,10 @@
 class Popt
-  # Until rpm.org releases a new version beyond 1.16, it's unclear whether
-  # checking the rpm.org archive index (http://ftp.rpm.org/mirror/popt/) would
-  # give us the latest version. As of writing this, there's a 1.18 release
-  # candidate at: http://ftp.rpm.org/releases/testing/popt-1.18-rc1.tar.gz
-  # Checking the Git repo seems like a safe bet until we see how this plays out.
+  # The stable archive is found at http://ftp.rpm.org/popt/releases/popt-1.x/
+  # but it's unclear whether this would be a reliable check in the long term.
+  # We're simply checking the Git repository tags for the moment, as we
+  # shouldn't encounter problems with this method.
   livecheck do
     url :homepage
-    regex(/^(?:popt)?[._-]v?(\d+(?:[._-]\d+)+)(?:-release)?$/i)
+    regex(/^(?:popt[._-])?v?(\d+(?:[._-]\d+)+)(?:-release)?$/i)
   end
 end


### PR DESCRIPTION
This updates the regex in the existing livecheckable for `popt` to move the delimiter between the software name and version (i.e., `[._-]`) into the non-capturing group for the software name. This makes the preceding `popt-` part on tags like `popt-1.18-release` or `popt-1_2_3` optional, which was the actual intention here.

While I was at it, I updated the comment to reflect the current situation, as there's now a stable 1.18 release at http://ftp.rpm.org/popt/releases/popt-1.x/