### PR TITLE
Update delimiter before capturing group to [._-] and add v?

### DIFF
--- a/Livecheckables/a52dec.rb
+++ b/Livecheckables/a52dec.rb
@@ -1,6 +1,6 @@
 class A52dec
   livecheck do
     url "http://liba52.sourceforge.net/downloads.html"
-    regex(/href=.*?a52dec-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?a52dec[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/aalib.rb
+++ b/Livecheckables/aalib.rb
@@ -1,6 +1,6 @@
 class Aalib
   livecheck do
     url "https://sourceforge.net/projects/aa-project/files/aa-lib/"
-    regex(/aalib-(\d+(?:\.\d+)+.*?)\.t/i)
+    regex(/aalib[._-]v?(\d+(?:\.\d+)+.*?)\.t/i)
   end
 end

--- a/Livecheckables/aamath.rb
+++ b/Livecheckables/aamath.rb
@@ -1,6 +1,6 @@
 class Aamath
   livecheck do
     url :homepage
-    regex(/aamath-(\d+(?:\.\d+)+)\.t/i)
+    regex(/aamath[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/aardvark_shell_utils.rb
+++ b/Livecheckables/aardvark_shell_utils.rb
@@ -1,6 +1,6 @@
 class AardvarkShellUtils
   livecheck do
     url "http://downloads.laffeycomputer.com/current_builds/shellutils/"
-    regex(/aardvark_shell_utils-(\d+(?:\.\d+)+)\.t/i)
+    regex(/aardvark_shell_utils[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/abuse.rb
+++ b/Livecheckables/abuse.rb
@@ -1,6 +1,6 @@
 class Abuse
   livecheck do
     url "http://abuse.zoy.org/wiki/download"
-    regex(/abuse-(\d+(?:\.\d+)+)\.t/i)
+    regex(/abuse[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/agedu.rb
+++ b/Livecheckables/agedu.rb
@@ -1,6 +1,6 @@
 class Agedu
   livecheck do
     url :homepage
-    regex(/href=.*?agedu-(\d+)(?:\.[\da-z]+)?\.t/i)
+    regex(/href=.*?agedu[._-]v?(\d+)(?:\.[\da-z]+)?\.t/i)
   end
 end

--- a/Livecheckables/alure.rb
+++ b/Livecheckables/alure.rb
@@ -1,6 +1,6 @@
 class Alure
   livecheck do
     url "https://kcat.strangesoft.net/alure-releases/"
-    regex(/alure-(\d+(?:\.\d+)+)/i)
+    regex(/alure[._-]v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/amdatu-bootstrap.rb
+++ b/Livecheckables/amdatu-bootstrap.rb
@@ -1,6 +1,6 @@
 class AmdatuBootstrap
   livecheck do
     url "https://bitbucket.org/amdatuadm/amdatu-bootstrap/downloads/"
-    regex(/href=.*?bootstrap-(?:bin-)?r(\d+(?:\.\d+)*)(?:-bin)?\./i)
+    regex(/href=.*?bootstrap[._-]v?(?:bin-)?r(\d+(?:\.\d+)*)(?:-bin)?\./i)
   end
 end

--- a/Livecheckables/apache-brooklyn-cli.rb
+++ b/Livecheckables/apache-brooklyn-cli.rb
@@ -1,6 +1,6 @@
 class ApacheBrooklynCli
   livecheck do
     url "https://github.com/apache/brooklyn-client.git"
-    regex(%r{^(?:rel/)?apache-brooklyn-(\d+(?:\.\d+)+)$}i)
+    regex(%r{^(?:rel/)?apache-brooklyn[._-]v?(\d+(?:\.\d+)+)$}i)
   end
 end

--- a/Livecheckables/ascii.rb
+++ b/Livecheckables/ascii.rb
@@ -1,6 +1,6 @@
 class Ascii
   livecheck do
     url :homepage
-    regex(/ascii-(\d+(?:\.\d+)+)/i)
+    regex(/ascii[._-]v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/atool.rb
+++ b/Livecheckables/atool.rb
@@ -1,6 +1,6 @@
 class Atool
   livecheck do
     url "https://namesdir.com/mirrors/nongnu/atool/?C=M&O=D"
-    regex(/href=.*?atool-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?atool[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/atool.rb
+++ b/Livecheckables/atool.rb
@@ -1,6 +1,7 @@
 class Atool
   livecheck do
-    url "https://namesdir.com/mirrors/nongnu/atool/?C=M&O=D"
+    url "https://download.savannah.gnu.org/releases/atool/?C=M&O=D"
+    strategy :page_match
     regex(/href=.*?atool[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/aubio.rb
+++ b/Livecheckables/aubio.rb
@@ -1,6 +1,6 @@
 class Aubio
   livecheck do
     url "https://aubio.org/pub/"
-    regex(/href=.*?aubio-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?aubio[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/babl.rb
+++ b/Livecheckables/babl.rb
@@ -1,6 +1,6 @@
 class Babl
   livecheck do
     url "https://download.gimp.org/pub/babl/0.1/"
-    regex(/babl-(\d+(?:\.\d+)*)\.t/i)
+    regex(/babl[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/capnp.rb
+++ b/Livecheckables/capnp.rb
@@ -1,6 +1,6 @@
 class Capnp
   livecheck do
     url "https://capnproto.org/install.html"
-    regex(/capnproto-c\+\+-(\d+(\.\d+)*)\.t/i)
+    regex(/capnproto-c\+\+[._-]v?(\d+(\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/curl.rb
+++ b/Livecheckables/curl.rb
@@ -1,6 +1,6 @@
 class Curl
   livecheck do
     url "https://curl.haxx.se/download/"
-    regex(/curl-(.*?)\.t/i)
+    regex(/curl[._-]v?(.*?)\.t/i)
   end
 end

--- a/Livecheckables/debianutils.rb
+++ b/Livecheckables/debianutils.rb
@@ -1,6 +1,6 @@
 class Debianutils
   livecheck do
     url "https://packages.qa.debian.org/d/debianutils.html"
-    regex(/debianutils_(\d+(?:.\d+)+).dsc/i)
+    regex(/debianutils[._-]v?(\d+(?:.\d+)+).dsc/i)
   end
 end

--- a/Livecheckables/disktype.rb
+++ b/Livecheckables/disktype.rb
@@ -1,6 +1,6 @@
 class Disktype
   livecheck do
     url :head
-    regex(/release_(\d+)/i)
+    regex(/release[._-]v?(\d+)/i)
   end
 end

--- a/Livecheckables/djvulibre.rb
+++ b/Livecheckables/djvulibre.rb
@@ -1,6 +1,6 @@
 class Djvulibre
   livecheck do
     url "https://sourceforge.net/projects/djvu/files/DjVuLibre/"
-    regex(/djvulibre-(\d+(?:\.\d+)+)\.t/i)
+    regex(/djvulibre[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dnsdist.rb
+++ b/Livecheckables/dnsdist.rb
@@ -1,6 +1,6 @@
 class Dnsdist
   livecheck do
     url "https://downloads.powerdns.com/releases/"
-    regex(/dnsdist-(\d+(?:\.\d+)*)\.t/i)
+    regex(/dnsdist[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/dnsperf.rb
+++ b/Livecheckables/dnsperf.rb
@@ -1,6 +1,6 @@
 class Dnsperf
   livecheck do
     url :homepage
-    regex(/dnsperf-(\d+(?:\.\d+)+)\.t/i)
+    regex(/dnsperf[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ekg2.rb
+++ b/Livecheckables/ekg2.rb
@@ -1,6 +1,6 @@
 class Ekg2
   livecheck do
     url :homepage
-    regex(/^ekg2_(\d+(?:\.\d+)+)$/i)
+    regex(/^ekg2[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/elinks.rb
+++ b/Livecheckables/elinks.rb
@@ -1,6 +1,6 @@
 class Elinks
   livecheck do
     url :head
-    regex(/^elinks-(\d+(?:\.\d+)+)$/i)
+    regex(/^elinks[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/emacs.rb
+++ b/Livecheckables/emacs.rb
@@ -1,6 +1,6 @@
 class Emacs
   livecheck do
     url :head
-    regex(/emacs-(\d+\.\d+)$/i)
+    regex(/emacs[._-]v?(\d+\.\d+)$/i)
   end
 end

--- a/Livecheckables/exempi.rb
+++ b/Livecheckables/exempi.rb
@@ -1,6 +1,6 @@
 class Exempi
   livecheck do
     url "https://libopenraw.freedesktop.org/exempi/"
-    regex(/href=.*?exempi-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?exempi[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/faac.rb
+++ b/Livecheckables/faac.rb
@@ -1,6 +1,6 @@
 class Faac
   livecheck do
     url "https://sourceforge.net/projects/faac/files/faac-src/"
-    regex(/faac-(\d+(?:\.\d+)*)\.t/i)
+    regex(/faac[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/faad2.rb
+++ b/Livecheckables/faad2.rb
@@ -1,6 +1,6 @@
 class Faad2
   livecheck do
     url :stable
-    regex(%r{url=.*?/faad2-(\d+(?:\.\d+)*)\.t}i)
+    regex(%r{url=.*?/faad2[._-]v?(\d+(?:\.\d+)*)\.t}i)
   end
 end

--- a/Livecheckables/gdb.rb
+++ b/Livecheckables/gdb.rb
@@ -1,6 +1,6 @@
 class Gdb
   livecheck do
     url "https://ftp.gnu.org/gnu/gdb/?C=M&O=D"
-    regex(/href=.*?gdb-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?gdb[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gegl.rb
+++ b/Livecheckables/gegl.rb
@@ -1,6 +1,6 @@
 class Gegl
   livecheck do
     url "https://download.gimp.org/pub/gegl/0.4/"
-    regex(/gegl-(\d+(?:\.\d+)*)\.t/i)
+    regex(/gegl[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/getmail.rb
+++ b/Livecheckables/getmail.rb
@@ -1,6 +1,6 @@
 class Getmail
   livecheck do
     url :homepage
-    regex(/getmail-(\d+(?:\.\d+)*)\.t/i)
+    regex(/getmail[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/ghostscript.rb
+++ b/Livecheckables/ghostscript.rb
@@ -1,6 +1,6 @@
 class Ghostscript
   livecheck do
     url :head
-    regex(/^ghostscript-(\d+(?:\.\d+)+)$/i)
+    regex(/^ghostscript[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/git.rb
+++ b/Livecheckables/git.rb
@@ -1,6 +1,6 @@
 class Git
   livecheck do
     url "https://www.kernel.org/pub/software/scm/git/"
-    regex(/git-(\d+(?:\.\d+)+)\.t/i)
+    regex(/git[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gnutls.rb
+++ b/Livecheckables/gnutls.rb
@@ -1,6 +1,6 @@
 class Gnutls
   livecheck do
     url "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/"
-    regex(/gnutls-(\d+(?:\.\d+)*)\.t/i)
+    regex(/gnutls[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/graphviz.rb
+++ b/Livecheckables/graphviz.rb
@@ -1,6 +1,6 @@
 class Graphviz
   livecheck do
     url "https://www2.graphviz.org/Packages/stable/portable_source/"
-    regex(/href=.*?graphviz-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?graphviz[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/groovy.rb
+++ b/Livecheckables/groovy.rb
@@ -1,6 +1,6 @@
 class Groovy
   livecheck do
     url "https://dl.bintray.com/groovy/maven/"
-    regex(/groovy-binary-([\d.]+)\.zip/i)
+    regex(/groovy-binary[._-]v?([\d.]+)\.zip/i)
   end
 end

--- a/Livecheckables/groovysdk.rb
+++ b/Livecheckables/groovysdk.rb
@@ -1,6 +1,6 @@
 class Groovysdk
   livecheck do
     url "https://dl.bintray.com/groovy/maven/"
-    regex(/apache-groovy-sdk-([\d.]+)\.zip/i)
+    regex(/apache-groovy-sdk[._-]v?([\d.]+)\.zip/i)
   end
 end

--- a/Livecheckables/gtk+.rb
+++ b/Livecheckables/gtk+.rb
@@ -1,6 +1,6 @@
 class Gtkx
   livecheck do
     url "https://download.gnome.org/sources/gtk+/"
-    regex(/gtk\+-(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
+    regex(/gtk\+[._-]v?(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/gtksourceview.rb
+++ b/Livecheckables/gtksourceview.rb
@@ -1,6 +1,6 @@
 class Gtksourceview
   livecheck do
     url "https://download.gnome.org/sources/gtksourceview/"
-    regex(/gtksourceview-(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
+    regex(/gtksourceview[._-]v?(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/gtksourceview3.rb
+++ b/Livecheckables/gtksourceview3.rb
@@ -1,6 +1,6 @@
 class Gtksourceview3
   livecheck do
     url "https://download.gnome.org/sources/gtksourceview/"
-    regex(/gtksourceview-(3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
+    regex(/gtksourceview[._-]v?(3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/gtksourceview4.rb
+++ b/Livecheckables/gtksourceview4.rb
@@ -1,6 +1,6 @@
 class Gtksourceview4
   livecheck do
     url "https://download.gnome.org/sources/gtksourceview/"
-    regex(/gtksourceview-(4\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
+    regex(/gtksourceview[._-]v?(4\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/gtksourceviewmm.rb
+++ b/Livecheckables/gtksourceviewmm.rb
@@ -1,6 +1,6 @@
 class Gtksourceviewmm
   livecheck do
     url "https://download.gnome.org/sources/gtksourceviewmm/"
-    regex(/gtksourceviewmm-(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
+    regex(/gtksourceviewmm[._-]v?(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/gtksourceviewmm3.rb
+++ b/Livecheckables/gtksourceviewmm3.rb
@@ -1,6 +1,6 @@
 class Gtksourceviewmm3
   livecheck do
     url "https://download.gnome.org/sources/gtksourceviewmm/"
-    regex(/gtksourceviewmm-(3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
+    regex(/gtksourceviewmm[._-]v?(3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/guile.rb
+++ b/Livecheckables/guile.rb
@@ -1,6 +1,6 @@
 class Guile
   livecheck do
     url "https://ftp.gnu.org/gnu/guile/"
-    regex(/href=.*?guile-([\d.]+\.[\d.]+\.[\d.]+)\.t/i)
+    regex(/href=.*?guile[._-]v?([\d.]+\.[\d.]+\.[\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/hdf5.rb
+++ b/Livecheckables/hdf5.rb
@@ -1,6 +1,6 @@
 class Hdf5
   livecheck do
     url "https://www.hdfgroup.org/downloads/hdf5/"
-    regex(/Newsletter for HDF5-(.*?) Release/i)
+    regex(/Newsletter for HDF5[._-]v?(.*?) Release/i)
   end
 end

--- a/Livecheckables/htpdate.rb
+++ b/Livecheckables/htpdate.rb
@@ -1,6 +1,6 @@
 class Htpdate
   livecheck do
     url "http://www.vervest.org/htp/archive/c/?C=M&O=D"
-    regex(/href=.*?htpdate-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?htpdate[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/i386-elf-gdb.rb
+++ b/Livecheckables/i386-elf-gdb.rb
@@ -1,6 +1,6 @@
 class I386ElfGdb
   livecheck do
     url "https://ftp.gnu.org/gnu/gdb/?C=M&O=D"
-    regex(/href=.*?gdb-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?gdb[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ibex.rb
+++ b/Livecheckables/ibex.rb
@@ -1,6 +1,6 @@
 class Ibex
   livecheck do
     url :head
-    regex(/^ibex-(\d+(?:\.\d+)+)$/i)
+    regex(/^ibex[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/ipbt.rb
+++ b/Livecheckables/ipbt.rb
@@ -1,6 +1,6 @@
 class Ipbt
   livecheck do
     url :homepage
-    regex(/ipbt-(\d+)(?:\.[\da-z]+)?\.t/i)
+    regex(/ipbt[._-]v?(\d+)(?:\.[\da-z]+)?\.t/i)
   end
 end

--- a/Livecheckables/jenkins.rb
+++ b/Livecheckables/jenkins.rb
@@ -1,6 +1,6 @@
 class Jenkins
   livecheck do
     url :head
-    regex(/^jenkins-(\d+(?:\.\d+)+)$/i)
+    regex(/^jenkins[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/kawa.rb
+++ b/Livecheckables/kawa.rb
@@ -1,6 +1,6 @@
 class Kawa
   livecheck do
     url "https://ftp.gnu.org/gnu/kawa"
-    regex(/href=.*?kawa-(\d+\.\d+(\.\d+)?)\.zip/i)
+    regex(/href=.*?kawa[._-]v?(\d+\.\d+(\.\d+)?)\.zip/i)
   end
 end

--- a/Livecheckables/libcerf.rb
+++ b/Livecheckables/libcerf.rb
@@ -1,6 +1,6 @@
 class Libcerf
   livecheck do
     url "https://jugit.fz-juelich.de/api/v4/projects/269/releases"
-    regex(/libcerf-(\d+(?:\.\d+)+)/i)
+    regex(/libcerf[._-]v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/libdnet.rb
+++ b/Livecheckables/libdnet.rb
@@ -1,6 +1,6 @@
 class Libdnet
   livecheck do
     url :homepage
-    regex(/^libdnet-(\d+(?:\.\d+)+)$/i)
+    regex(/^libdnet[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/libev.rb
+++ b/Livecheckables/libev.rb
@@ -1,6 +1,6 @@
 class Libev
   livecheck do
     url "http://dist.schmorp.de/libev/"
-    regex(/libev-([\d.]+)\./i)
+    regex(/libev[._-]v?([\d.]+)\./i)
   end
 end

--- a/Livecheckables/libgcrypt.rb
+++ b/Livecheckables/libgcrypt.rb
@@ -1,6 +1,6 @@
 class Libgcrypt
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libgcrypt/"
-    regex(/libgcrypt-(\d+\.\d+\.\d+)/i)
+    regex(/libgcrypt[._-]v?(\d+\.\d+\.\d+)/i)
   end
 end

--- a/Livecheckables/libmetalink.rb
+++ b/Livecheckables/libmetalink.rb
@@ -1,6 +1,6 @@
 class Libmetalink
   livecheck do
     url :stable
-    regex(/libmetalink-(\d+(?:\.\d+)+)$/i)
+    regex(/libmetalink[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/libosinfo.rb
+++ b/Livecheckables/libosinfo.rb
@@ -1,6 +1,6 @@
 class Libosinfo
   livecheck do
     url "https://releases.pagure.org/libosinfo/?C=M&O=D"
-    regex(/href=.*?libosinfo-([\d.]+)\.t/i)
+    regex(/href=.*?libosinfo[._-]v?([\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/libraw.rb
+++ b/Livecheckables/libraw.rb
@@ -1,6 +1,6 @@
 class Libraw
   livecheck do
     url "https://www.libraw.org/download/"
-    regex(/LibRaw-(\d+(?:\.\d+)*)\.t/i)
+    regex(/LibRaw[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/libsndfile.rb
+++ b/Livecheckables/libsndfile.rb
@@ -1,6 +1,6 @@
 class Libsndfile
   livecheck do
     url :homepage
-    regex(/libsndfile-([\d.]+)\.t/i)
+    regex(/libsndfile[._-]v?([\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/libu2f-host.rb
+++ b/Livecheckables/libu2f-host.rb
@@ -1,6 +1,6 @@
 class Libu2fHost
   livecheck do
     url "https://developers.yubico.com/libu2f-host/Releases/"
-    regex(/libu2f-host-(\d+\.\d+\.\d+)\.t/i)
+    regex(/libu2f-host[._-]v?(\d+\.\d+\.\d+)\.t/i)
   end
 end

--- a/Livecheckables/libu2f-server.rb
+++ b/Livecheckables/libu2f-server.rb
@@ -1,6 +1,6 @@
 class Libu2fServer
   livecheck do
     url "https://developers.yubico.com/libu2f-server/Releases/"
-    regex(/href=.*?libu2f-server-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?libu2f-server[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libupnp.rb
+++ b/Livecheckables/libupnp.rb
@@ -1,6 +1,6 @@
 class Libupnp
   livecheck do
     url :stable
-    regex(/^release-(\d+(?:\.\d+)+)$/i)
+    regex(/^release[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/libvirt-glib.rb
+++ b/Livecheckables/libvirt-glib.rb
@@ -1,6 +1,6 @@
 class LibvirtGlib
   livecheck do
     url "https://libvirt.org/sources/glib/"
-    regex(/libvirt-glib-([\d.]+)\.t/i)
+    regex(/libvirt-glib[._-]v?([\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/libvirt.rb
+++ b/Livecheckables/libvirt.rb
@@ -1,6 +1,6 @@
 class Libvirt
   livecheck do
     url "https://libvirt.org/sources/"
-    regex(/href=.*?libvirt-([\d.]+)\.t/i)
+    regex(/href=.*?libvirt[._-]v?([\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/libvterm.rb
+++ b/Livecheckables/libvterm.rb
@@ -1,6 +1,6 @@
 class Libvterm
   livecheck do
     url :homepage
-    regex(/libvterm-(\d+(?:\.\d+)+)\./i)
+    regex(/libvterm[._-]v?(\d+(?:\.\d+)+)\./i)
   end
 end

--- a/Livecheckables/libxml++.rb
+++ b/Livecheckables/libxml++.rb
@@ -1,6 +1,6 @@
 class Libxmlxx
   livecheck do
     url :stable
-    regex(/libxml\+\+-(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
+    regex(/libxml\+\+[._-]v?(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/libxml2.rb
+++ b/Livecheckables/libxml2.rb
@@ -1,6 +1,6 @@
 class Libxml2
   livecheck do
     url "http://xmlsoft.org/sources"
-    regex(/href=.*?libxml2-([\d.]+\.[\d.]+\.[\d.]+)\.t/i)
+    regex(/href=.*?libxml2[._-]v?([\d.]+\.[\d.]+\.[\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/lrzip.rb
+++ b/Livecheckables/lrzip.rb
@@ -1,6 +1,6 @@
 class Lrzip
   livecheck do
     url "http://ck.kolivas.org/apps/lrzip"
-    regex(/lrzip-(\d+(?:\.\d+)+)\.t/i)
+    regex(/lrzip[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/luajit.rb
+++ b/Livecheckables/luajit.rb
@@ -1,6 +1,6 @@
 class Luajit
   livecheck do
     url "https://luajit.org/download.html"
-    regex(/class="downname">LuaJIT-([\d.]+)</i)
+    regex(/class="downname">LuaJIT[._-]v?([\d.]+)</i)
   end
 end

--- a/Livecheckables/lzo.rb
+++ b/Livecheckables/lzo.rb
@@ -1,6 +1,6 @@
 class Lzo
   livecheck do
     url "https://www.oberhumer.com/opensource/lzo/download/"
-    regex(/lzo-([\d.]+)\./i)
+    regex(/lzo[._-]v?([\d.]+)\./i)
   end
 end

--- a/Livecheckables/mawk.rb
+++ b/Livecheckables/mawk.rb
@@ -1,6 +1,6 @@
 class Mawk
   livecheck do
     url "https://invisible-mirror.net/archives/mawk/?C=M&O=D"
-    regex(/href=.*?mawk-(\d+(?:\.\d+)+(?:-\d+)?)\.t/i)
+    regex(/href=.*?mawk[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)\.t/i)
   end
 end

--- a/Livecheckables/mecab-ko-dic.rb
+++ b/Livecheckables/mecab-ko-dic.rb
@@ -1,6 +1,6 @@
 class MecabKoDic
   livecheck do
     url "https://bitbucket.org/eunjeon/mecab-ko-dic/downloads/"
-    regex(/href=.*?mecab-ko-dic-(\d+(?:\.\d+)+-\d+)\.t/i)
+    regex(/href=.*?mecab-ko-dic[._-]v?(\d+(?:\.\d+)+-\d+)\.t/i)
   end
 end

--- a/Livecheckables/mecab-ko.rb
+++ b/Livecheckables/mecab-ko.rb
@@ -1,6 +1,6 @@
 class MecabKo
   livecheck do
     url "https://bitbucket.org/eunjeon/mecab-ko/downloads/"
-    regex(/href=.*?mecab-(\d+(?:\.\d+)+-ko-\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?mecab[._-]v?(\d+(?:\.\d+)+-ko-\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/memcached.rb
+++ b/Livecheckables/memcached.rb
@@ -1,6 +1,6 @@
 class Memcached
   livecheck do
     url :homepage
-    regex(/memcached-(\d+(?:\.\d+){2,})\./i)
+    regex(/memcached[._-]v?(\d+(?:\.\d+){2,})\./i)
   end
 end

--- a/Livecheckables/mesa.rb
+++ b/Livecheckables/mesa.rb
@@ -1,6 +1,6 @@
 class Mesa
   livecheck do
     url "https://archive.mesa3d.org"
-    regex(/href=.*?mesa-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?mesa[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/mkvtoolnix.rb
+++ b/Livecheckables/mkvtoolnix.rb
@@ -1,6 +1,6 @@
 class Mkvtoolnix
   livecheck do
     url "https://mkvtoolnix.download/sources/"
-    regex(/href=.*?mkvtoolnix-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?mkvtoolnix[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/mysql-connector-c++.rb
+++ b/Livecheckables/mysql-connector-c++.rb
@@ -1,6 +1,6 @@
 class MysqlConnectorCxx
   livecheck do
     url :homepage
-    regex(/href=.*?mysql-connector-c%2B%2B-(\d+.\d+.\d+)-/i)
+    regex(/href=.*?mysql-connector-c%2B%2B[._-]v?(\d+.\d+.\d+)-/i)
   end
 end

--- a/Livecheckables/mysql.rb
+++ b/Livecheckables/mysql.rb
@@ -1,6 +1,6 @@
 class Mysql
   livecheck do
     url "https://dev.mysql.com/downloads/mysql/"
-    regex(/href=.*?mysql-(\d+.\d+.\d+)-/i)
+    regex(/href=.*?mysql[._-]v?(\d+.\d+.\d+)-/i)
   end
 end

--- a/Livecheckables/mysql@5.6.rb
+++ b/Livecheckables/mysql@5.6.rb
@@ -1,6 +1,6 @@
 class MysqlAT56
   livecheck do
     url "https://dev.mysql.com/downloads/mysql/5.6.html"
-    regex(/href=.*?mysql-(\d+.\d+.\d+)-/i)
+    regex(/href=.*?mysql[._-]v?(\d+.\d+.\d+)-/i)
   end
 end

--- a/Livecheckables/mysql@5.7.rb
+++ b/Livecheckables/mysql@5.7.rb
@@ -1,6 +1,6 @@
 class MysqlAT57
   livecheck do
     url "https://dev.mysql.com/downloads/mysql/5.7.html"
-    regex(/href=.*?mysql-(\d+.\d+.\d+)-/i)
+    regex(/href=.*?mysql[._-]v?(\d+.\d+.\d+)-/i)
   end
 end

--- a/Livecheckables/nagios-plugins.rb
+++ b/Livecheckables/nagios-plugins.rb
@@ -1,6 +1,6 @@
 class NagiosPlugins
   livecheck do
     url "https://nagios-plugins.org/download/"
-    regex(/href=.*?nagios-plugins-([\d.]+)\.t/i)
+    regex(/href=.*?nagios-plugins[._-]v?([\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/nethack.rb
+++ b/Livecheckables/nethack.rb
@@ -1,6 +1,6 @@
 class Nethack
   livecheck do
     url :head
-    regex(/^NetHack-(\d+(?:\.\d+)+)_Released?$/i)
+    regex(/^NetHack[._-]v?(\d+(?:\.\d+)+)_Released?$/i)
   end
 end

--- a/Livecheckables/opencore-amr.rb
+++ b/Livecheckables/opencore-amr.rb
@@ -1,6 +1,6 @@
 class OpencoreAmr
   livecheck do
     url "https://sourceforge.net/projects/opencore-amr/files/opencore-amr/"
-    regex(/>opencore-amr-([\d.]+)\.t/i)
+    regex(/>opencore-amr[._-]v?([\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/openldap.rb
+++ b/Livecheckables/openldap.rb
@@ -1,6 +1,6 @@
 class Openldap
   livecheck do
     url "https://www.openldap.org/software/download/OpenLDAP/openldap-release/"
-    regex(/openldap-(\d+(?:\.\d+)*)\.t/i)
+    regex(/openldap[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/opensaml.rb
+++ b/Livecheckables/opensaml.rb
@@ -1,6 +1,6 @@
 class Opensaml
   livecheck do
     url "https://shibboleth.net/downloads/c++-opensaml/latest/"
-    regex(/href=.*?opensaml-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?opensaml[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/orc.rb
+++ b/Livecheckables/orc.rb
@@ -1,6 +1,6 @@
 class Orc
   livecheck do
     url "https://gstreamer.freedesktop.org/src/orc/"
-    regex(/href=.*?orc-([\d.]+\.[\d.]+\.[\d.]+)\.t/i)
+    regex(/href=.*?orc[._-]v?([\d.]+\.[\d.]+\.[\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/pari.rb
+++ b/Livecheckables/pari.rb
@@ -1,6 +1,6 @@
 class Pari
   livecheck do
     url "https://pari.math.u-bordeaux.fr/pub/pari/unix/"
-    regex(/pari-(\d+\.\d+\.\d+)/i)
+    regex(/pari[._-]v?(\d+\.\d+\.\d+)/i)
   end
 end

--- a/Livecheckables/pdns.rb
+++ b/Livecheckables/pdns.rb
@@ -1,6 +1,6 @@
 class Pdns
   livecheck do
     url "https://downloads.powerdns.com/releases/"
-    regex(/pdns-(\d+(?:\.\d+)*)\.t/i)
+    regex(/pdns[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/pdnsrec.rb
+++ b/Livecheckables/pdnsrec.rb
@@ -1,6 +1,6 @@
 class Pdnsrec
   livecheck do
     url "https://downloads.powerdns.com/releases/"
-    regex(/pdns-recursor-(\d+(?:\.\d+)*)\.t/i)
+    regex(/pdns-recursor[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/percona-xtrabackup.rb
+++ b/Livecheckables/percona-xtrabackup.rb
@@ -1,6 +1,6 @@
 class PerconaXtrabackup
   livecheck do
     url "https://github.com/percona/percona-xtrabackup.git"
-    regex(/^percona-xtrabackup-(\d+(?:\.\d+)+)$/i)
+    regex(/^percona-xtrabackup[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/perltidy.rb
+++ b/Livecheckables/perltidy.rb
@@ -1,6 +1,6 @@
 class Perltidy
   livecheck do
     url :stable
-    regex(%r{url=.*?/Perl-Tidy-(\d+)\.t}i)
+    regex(%r{url=.*?/Perl-Tidy[._-]v?(\d+)\.t}i)
   end
 end

--- a/Livecheckables/poppler.rb
+++ b/Livecheckables/poppler.rb
@@ -1,6 +1,6 @@
 class Poppler
   livecheck do
     url "https://poppler.freedesktop.org/releases.html"
-    regex(/poppler-(\d+(?:\.\d+)*)\.t/i)
+    regex(/poppler[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/portmidi.rb
+++ b/Livecheckables/portmidi.rb
@@ -1,6 +1,6 @@
 class Portmidi
   livecheck do
     url :stable
-    regex(%r{url=.*?/portmidi-src-(\d+)\.}i)
+    regex(%r{url=.*?/portmidi-src[._-]v?(\d+)\.}i)
   end
 end

--- a/Livecheckables/potrace.rb
+++ b/Livecheckables/potrace.rb
@@ -1,6 +1,6 @@
 class Potrace
   livecheck do
     url "http://potrace.sourceforge.net/"
-    regex(/potrace-(\d+(?:\.\d+)*)\.t/i)
+    regex(/potrace[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/pwncat.rb
+++ b/Livecheckables/pwncat.rb
@@ -1,6 +1,6 @@
 class Pwncat
   livecheck do
     url :stable
-    regex(/href=.*?pwncat-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?pwncat[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/qscintilla2.rb
+++ b/Livecheckables/qscintilla2.rb
@@ -1,6 +1,6 @@
 class Qscintilla2
   livecheck do
     url "https://www.riverbankcomputing.com/software/qscintilla/download"
-    regex(/href=.*?QScintilla(?:.gpl)?-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?QScintilla(?:.gpl)?[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/rakudo-star.rb
+++ b/Livecheckables/rakudo-star.rb
@@ -1,6 +1,6 @@
 class RakudoStar
   livecheck do
     url "https://rakudo.org/dl/star/"
-    regex(/rakudo-star-(\d+(?:\.\d+)+)\.t/i)
+    regex(/rakudo-star[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/rtmpdump.rb
+++ b/Livecheckables/rtmpdump.rb
@@ -1,6 +1,6 @@
 class Rtmpdump
   livecheck do
     url "https://cdn-aws.deb.debian.org/debian/pool/main/r/rtmpdump/"
-    regex(/rtmpdump_(\d.\d\+\d*).*.orig\.t/i)
+    regex(/rtmpdump[._-]v?(\d.\d\+\d*).*.orig\.t/i)
   end
 end

--- a/Livecheckables/sdl2.rb
+++ b/Livecheckables/sdl2.rb
@@ -1,6 +1,6 @@
 class Sdl2
   livecheck do
     url "https://www.libsdl.org/download-2.0.php"
-    regex(/SDL2-(\d+(?:\.\d+)*)/i)
+    regex(/SDL2[._-]v?(\d+(?:\.\d+)*)/i)
   end
 end

--- a/Livecheckables/sdl2_image.rb
+++ b/Livecheckables/sdl2_image.rb
@@ -1,6 +1,6 @@
 class Sdl2Image
   livecheck do
     url :homepage
-    regex(/SDL2_image-(\d+(?:\.\d+)*)/i)
+    regex(/SDL2_image[._-]v?(\d+(?:\.\d+)*)/i)
   end
 end

--- a/Livecheckables/sdl2_mixer.rb
+++ b/Livecheckables/sdl2_mixer.rb
@@ -1,6 +1,6 @@
 class Sdl2Mixer
   livecheck do
     url :homepage
-    regex(/SDL2_mixer-(\d+(?:\.\d+)*)/i)
+    regex(/SDL2_mixer[._-]v?(\d+(?:\.\d+)*)/i)
   end
 end

--- a/Livecheckables/sdl2_net.rb
+++ b/Livecheckables/sdl2_net.rb
@@ -1,6 +1,6 @@
 class Sdl2Net
   livecheck do
     url :homepage
-    regex(/SDL2_net-(\d+(?:\.\d+)*)/i)
+    regex(/SDL2_net[._-]v?(\d+(?:\.\d+)*)/i)
   end
 end

--- a/Livecheckables/sdl2_ttf.rb
+++ b/Livecheckables/sdl2_ttf.rb
@@ -1,6 +1,6 @@
 class Sdl2Ttf
   livecheck do
     url :homepage
-    regex(/SDL2_ttf-(\d+(?:\.\d+)*)/i)
+    regex(/SDL2_ttf[._-]v?(\d+(?:\.\d+)*)/i)
   end
 end

--- a/Livecheckables/shibboleth-sp.rb
+++ b/Livecheckables/shibboleth-sp.rb
@@ -1,6 +1,6 @@
 class ShibbolethSp
   livecheck do
     url "https://shibboleth.net/downloads/service-provider/latest/"
-    regex(/href=.*?shibboleth-sp-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?shibboleth-sp[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/sip.rb
+++ b/Livecheckables/sip.rb
@@ -1,6 +1,6 @@
 class Sip
   livecheck do
     url "https://riverbankcomputing.com/software/sip/download"
-    regex(/sip-(\d+(\.\d+)+)\.t/i)
+    regex(/sip[._-]v?(\d+(\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/sord.rb
+++ b/Livecheckables/sord.rb
@@ -1,6 +1,6 @@
 class Sord
   livecheck do
     url "https://download.drobilla.net"
-    regex(/href=.*?sord-(\d+.\d+.\d+)\.t/i)
+    regex(/href=.*?sord[._-]v?(\d+.\d+.\d+)\.t/i)
   end
 end

--- a/Livecheckables/source-highlight.rb
+++ b/Livecheckables/source-highlight.rb
@@ -1,6 +1,6 @@
 class SourceHighlight
   livecheck do
     url :stable
-    regex(/source-highlight-(\d+(?:\.\d+)+)/i)
+    regex(/source-highlight[._-]v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/spice-gtk.rb
+++ b/Livecheckables/spice-gtk.rb
@@ -1,6 +1,6 @@
 class SpiceGtk
   livecheck do
     url "https://www.spice-space.org/download/gtk/"
-    regex(/href=.*?spice-gtk-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?spice-gtk[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/spigot.rb
+++ b/Livecheckables/spigot.rb
@@ -1,6 +1,6 @@
 class Spigot
   livecheck do
     url :homepage
-    regex(/href=.*?spigot-(\d+)(?:\.[\da-z]+)?\.t/i)
+    regex(/href=.*?spigot[._-]v?(\d+)(?:\.[\da-z]+)?\.t/i)
   end
 end

--- a/Livecheckables/squid.rb
+++ b/Livecheckables/squid.rb
@@ -1,6 +1,6 @@
 class Squid
   livecheck do
     url "http://www.squid-cache.org/Versions/v4/"
-    regex(/squid-(\d+(?:\.\d+)+)-RELEASENOTES\.html/i)
+    regex(/squid[._-]v?(\d+(?:\.\d+)+)-RELEASENOTES\.html/i)
   end
 end

--- a/Livecheckables/sshfs.rb
+++ b/Livecheckables/sshfs.rb
@@ -1,6 +1,6 @@
 class Sshfs
   livecheck do
     url :stable
-    regex(/^sshfs-(\d+(?:\.\d+)+)$/i)
+    regex(/^sshfs[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/swi-prolog.rb
+++ b/Livecheckables/swi-prolog.rb
@@ -1,6 +1,6 @@
 class SwiProlog
   livecheck do
     url "https://www.swi-prolog.org/download/stable/src"
-    regex(/swipl-(\d+\.\d+\.\d+)\.t/i)
+    regex(/swipl[._-]v?(\d+\.\d+\.\d+)\.t/i)
   end
 end

--- a/Livecheckables/tree.rb
+++ b/Livecheckables/tree.rb
@@ -1,6 +1,6 @@
 class Tree
   livecheck do
     url "http://mama.indstate.edu/users/ice/tree/src"
-    regex(/tree-(.*?)\.t/i)
+    regex(/tree[._-]v?(.*?)\.t/i)
   end
 end

--- a/Livecheckables/upscaledb.rb
+++ b/Livecheckables/upscaledb.rb
@@ -1,6 +1,6 @@
 class Upscaledb
   livecheck do
     url "http://files.upscaledb.com/dl/"
-    regex(/href=.*?upscaledb-(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?upscaledb[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/usbredir.rb
+++ b/Livecheckables/usbredir.rb
@@ -1,6 +1,6 @@
 class Usbredir
   livecheck do
     url "https://www.spice-space.org/download/usbredir/"
-    regex(/usbredir-([\d.]+)\.t/i)
+    regex(/usbredir[._-]v?([\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/zbar.rb
+++ b/Livecheckables/zbar.rb
@@ -1,6 +1,6 @@
 class Zbar
   livecheck do
     url "https://sourceforge.net/projects/zbar/"
-    regex(/zbar-(\d+(?:\.\d+)+)\.t/i)
+    regex(/zbar[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This PR updates delimiters before the capturing group to `[._-]` and also adds `v?`.

I compared the matched versions before and after with this script, where `before` and `after` are the JSON livecheck output files read using `JSON.parse`, and list contains all the Livecheckables I anticipated would change.

```ruby
for i in 0..list.length do
  if before[i]["matches"] != after[i]["matches"]
    puts "Hi #{i}"
  end
end
```

There seemed to be no difference though.