### PR TITLE
Use odebug instead of puts... if Homebrew.args.debug?

### DIFF
--- a/livecheck/extend/formulary.rb
+++ b/livecheck/extend/formulary.rb
@@ -28,7 +28,7 @@ module Formulary
 
       lc_path = livecheckable_path(path)
       if lc_path&.exist?
-        puts "Loading #{lc_path}" if Homebrew.args.debug?
+        odebug "Loading #{lc_path}"
         mod.module_eval(lc_path.read, lc_path)
       end
 


### PR DESCRIPTION
Debug messages that use `odebug` are formatted differently than `puts ... if Homebrew.args.debug?` -- it helps quickly find them in the output.