### PR TITLE
Update CLI::Parser args handling

### DIFF
--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -32,7 +32,7 @@ module LivecheckStrategy
       match_list = PROJECT_NAME_REGEXES.map { |r| url.match(r) }.compact
       return { matches: {}, regex: regex, url: url } if match_list.empty?
 
-      puts "\nMultiple project names found: #{match_list}\n" if match_list.length > 1 && Homebrew.args.debug?
+      odebug "\nMultiple project names found: #{match_list}\n" if match_list.length > 1
 
       project_name = match_list[0][1]
 


### PR DESCRIPTION
This updates all the current usage of `Homebrew.args` to use an `args` variable instead. In line with how the Homebrew/brew commands handle this, I've updated the functions to accept a named `args` argument.

The instance in the `Gnu` strategy has simply been replaced with `odebug`, as that's more appropriate.

Closes #1248 (I discussed this with Seeker and they were fine with me opening this PR that closes theirs).