### PR TITLE
workflows: revert tap-syntax step to brew style

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,8 @@ jobs:
         mkdir -p $(dirname $(brew --repo $GITHUB_REPOSITORY))
         ln -s $PWD $(brew --repo $GITHUB_REPOSITORY)
 
-    - name: Run brew test-bot --only-tap-syntax
-      run: brew test-bot --only-tap-syntax
+    - name: Run brew style
+      run: brew style $GITHUB_REPOSITORY
 
     - name: Run brew livecheck
       run: brew livecheck


### PR DESCRIPTION
The homebrew-livecheck CI was recently changed to replace the `brew style` step with `brew test-bot --only-tap-syntax`. This was fine until some very recent CI-related changes outside of homebrew-livecheck modified the related behavior.

We're currently seeing audit failures for homebrew-core formulae on our CI here, which we certainly don't want. With this in mind, I discussed this with Dawid and it makes sense to revert the related CI step here back to `brew style`.