### PR TITLE
Improve checks with a file in the regex

### DIFF
--- a/Livecheckables/aalib.rb
+++ b/Livecheckables/aalib.rb
@@ -1,6 +1,6 @@
 class Aalib
   livecheck do
-    url "https://sourceforge.net/projects/aa-project/files/aa-lib/"
-    regex(/aalib[._-]v?(\d+(?:\.\d+)+.*?)\.t/i)
+    url :stable
+    regex(%r{url=.*?/aalib[._-]v?(\d+(?:\.\d+)+.*?)\.t}i)
   end
 end

--- a/Livecheckables/aamath.rb
+++ b/Livecheckables/aamath.rb
@@ -1,6 +1,6 @@
 class Aamath
   livecheck do
     url :homepage
-    regex(/aamath[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?aamath[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/aardvark_shell_utils.rb
+++ b/Livecheckables/aardvark_shell_utils.rb
@@ -1,6 +1,6 @@
 class AardvarkShellUtils
   livecheck do
     url "http://downloads.laffeycomputer.com/current_builds/shellutils/"
-    regex(/aardvark_shell_utils[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?aardvark_shell_utils[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/abuse.rb
+++ b/Livecheckables/abuse.rb
@@ -1,6 +1,6 @@
 class Abuse
   livecheck do
     url "http://abuse.zoy.org/wiki/download"
-    regex(/abuse[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?abuse[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/antlr.rb
+++ b/Livecheckables/antlr.rb
@@ -1,6 +1,6 @@
 class Antlr
   livecheck do
     url "https://www.antlr.org/download/"
-    regex(/antlr[._-]v?(\d+(?:\.\d+)+)-complete\.jar/i)
+    regex(/href=.*?antlr[._-]v?(\d+(?:\.\d+)+)-complete\.jar/i)
   end
 end

--- a/Livecheckables/antlr4-cpp-runtime.rb
+++ b/Livecheckables/antlr4-cpp-runtime.rb
@@ -1,6 +1,6 @@
 class Antlr4CppRuntime
   livecheck do
     url "https://www.antlr.org/download/"
-    regex(/antlr4-cpp-runtime[._-]v?(\d+(?:\.\d+)+)-source\.zip/i)
+    regex(/href=.*?antlr4-cpp-runtime[._-]v?(\d+(?:\.\d+)+)-source\.zip/i)
   end
 end

--- a/Livecheckables/asio.rb
+++ b/Livecheckables/asio.rb
@@ -1,6 +1,6 @@
 class Asio
   livecheck do
-    url "https://sourceforge.net/projects/asio/"
-    regex(%r{Stable.*?/asio[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?Stable.*?/asio[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/aspectj.rb
+++ b/Livecheckables/aspectj.rb
@@ -1,6 +1,6 @@
 class Aspectj
   livecheck do
     url "https://eclipse.org/aspectj/downloads.php"
-    regex(%r{Latest Stable Release.*?/aspectj[._-]v?(\d+(?:\.\d+)+)\.jar}im)
+    regex(%r{Latest Stable Release.*?href=.*?/aspectj[._-]v?(\d+(?:\.\d+)+)\.jar}im)
   end
 end

--- a/Livecheckables/ats2-postiats.rb
+++ b/Livecheckables/ats2-postiats.rb
@@ -1,6 +1,6 @@
 class Ats2Postiats
   livecheck do
     url :stable
-    regex(/ATS2-Postiats[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{url=.*?/ATS2-Postiats[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/babl.rb
+++ b/Livecheckables/babl.rb
@@ -1,6 +1,6 @@
 class Babl
   livecheck do
     url "https://download.gimp.org/pub/babl/0.1/"
-    regex(/babl[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?babl[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/bibutils.rb
+++ b/Livecheckables/bibutils.rb
@@ -1,6 +1,6 @@
 class Bibutils
   livecheck do
-    url "sourceforge.net/projects/bibutils/files/"
-    regex(%r{/bibutils/files/bibutils[._-]v?(\d+(?:\.\d+)+)_src\.t}i)
+    url :stable
+    regex(%r{url=.*?/bibutils[._-]v?(\d+(?:\.\d+)+)[._-]src\.t}i)
   end
 end

--- a/Livecheckables/bonnie++.rb
+++ b/Livecheckables/bonnie++.rb
@@ -1,6 +1,6 @@
 class Bonniexx
   livecheck do
     url "https://www.coker.com.au/bonnie++/experimental/"
-    regex(/bonnie\+\+[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?bonnie\+\+[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/capnp.rb
+++ b/Livecheckables/capnp.rb
@@ -1,6 +1,6 @@
 class Capnp
   livecheck do
     url "https://capnproto.org/install.html"
-    regex(/capnproto-c\+\+[._-]v?(\d+(\.\d+)*)\.t/i)
+    regex(/href=.*?capnproto-c\+\+[._-]v?(\d+(\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/ccm.rb
+++ b/Livecheckables/ccm.rb
@@ -1,6 +1,6 @@
 class Ccm
   livecheck do
     url :stable
-    regex(%r{/ccm[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{href=.*?/ccm[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/clog.rb
+++ b/Livecheckables/clog.rb
@@ -1,6 +1,6 @@
 class Clog
   livecheck do
     url "https://gothenburgbitfactory.org"
-    regex(%r{gothenburgbitfactory.org/download/clog[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(/href=.*?clog[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/colordiff.rb
+++ b/Livecheckables/colordiff.rb
@@ -1,6 +1,6 @@
 class Colordiff
   livecheck do
     url :homepage
-    regex(/colordiff[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?colordiff[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/convmv.rb
+++ b/Livecheckables/convmv.rb
@@ -1,6 +1,6 @@
 class Convmv
   livecheck do
     url :homepage
-    regex(/convmv[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?convmv[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/cscope.rb
+++ b/Livecheckables/cscope.rb
@@ -1,6 +1,6 @@
 class Cscope
   livecheck do
-    url "https://sourceforge.net/projects/cscope/rss"
-    regex(/cscope[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+    url :stable
+    regex(%r{url=.*?/cscope[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end

--- a/Livecheckables/curl.rb
+++ b/Livecheckables/curl.rb
@@ -1,6 +1,6 @@
 class Curl
   livecheck do
     url "https://curl.haxx.se/download/"
-    regex(/curl[._-]v?(.*?)\.t/i)
+    regex(/href=.*?curl[._-]v?(.*?)\.t/i)
   end
 end

--- a/Livecheckables/dar.rb
+++ b/Livecheckables/dar.rb
@@ -1,6 +1,6 @@
 class Dar
   livecheck do
-    url "https://sourceforge.net/projects/dar/"
-    regex(%r{.*?/dar[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/dar[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/debianutils.rb
+++ b/Livecheckables/debianutils.rb
@@ -1,6 +1,6 @@
 class Debianutils
   livecheck do
     url "https://packages.qa.debian.org/d/debianutils.html"
-    regex(/debianutils[._-]v?(\d+(?:.\d+)+).dsc/i)
+    regex(/href=.*?debianutils[._-]v?(\d+(?:.\d+)+).dsc/i)
   end
 end

--- a/Livecheckables/deployer.rb
+++ b/Livecheckables/deployer.rb
@@ -1,6 +1,6 @@
 class Deployer
   livecheck do
     url "https://deployer.org/download"
-    regex(%r{/releases/v?(\d+(?:\.\d+)+)/deployer.phar}i)
+    regex(%r{href=.*?/releases/v?(\d+(?:\.\d+)+)/deployer.phar}i)
   end
 end

--- a/Livecheckables/djvulibre.rb
+++ b/Livecheckables/djvulibre.rb
@@ -1,6 +1,6 @@
 class Djvulibre
   livecheck do
-    url "https://sourceforge.net/projects/djvu/files/DjVuLibre/"
-    regex(/djvulibre[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(%r{url=.*?/djvulibre[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/dnsdist.rb
+++ b/Livecheckables/dnsdist.rb
@@ -1,6 +1,6 @@
 class Dnsdist
   livecheck do
     url "https://downloads.powerdns.com/releases/"
-    regex(/dnsdist[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?dnsdist[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/dnsperf.rb
+++ b/Livecheckables/dnsperf.rb
@@ -1,6 +1,6 @@
 class Dnsperf
   livecheck do
     url :homepage
-    regex(/dnsperf[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?dnsperf[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/duply.rb
+++ b/Livecheckables/duply.rb
@@ -1,6 +1,6 @@
 class Duply
   livecheck do
-    url :homepage
-    regex(%r{<title><!\[CDATA\[/duply \(simple duplicity\).*?duply[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/duply[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/dvdauthor.rb
+++ b/Livecheckables/dvdauthor.rb
@@ -1,6 +1,6 @@
 class Dvdauthor
   livecheck do
-    url "https://sourceforge.net/projects/dvdauthor/"
-    regex(%r{/dvdauthor[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/dvdauthor[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/e2fsprogs.rb
+++ b/Livecheckables/e2fsprogs.rb
@@ -1,6 +1,6 @@
 class E2fsprogs
   livecheck do
-    url "https://sourceforge.net/projects/e2fsprogs/"
-    regex(/e2fsprogs[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(%r{url=.*?/e2fsprogs[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/epsilon.rb
+++ b/Livecheckables/epsilon.rb
@@ -1,6 +1,6 @@
 class Epsilon
   livecheck do
     url :stable
-    regex(%r{/epsilon[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/epsilon[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/faac.rb
+++ b/Livecheckables/faac.rb
@@ -1,6 +1,6 @@
 class Faac
   livecheck do
-    url "https://sourceforge.net/projects/faac/files/faac-src/"
-    regex(/faac[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    url :stable
+    regex(%r{url=.*?/faac[._-]v?(\d+(?:\.\d+)*)\.t}i)
   end
 end

--- a/Livecheckables/fatsort.rb
+++ b/Livecheckables/fatsort.rb
@@ -1,6 +1,6 @@
 class Fatsort
   livecheck do
-    url "https://sourceforge.net/projects/fatsort/"
-    regex(/fatsort[._-]v?(\d+(?:\.\d+)+)\.[0-9]+\.t/i)
+    url :stable
+    regex(%r{url=.*?/fatsort[._-]v?(\d+(?:\.\d+)+)\.[0-9]+\.t}i)
   end
 end

--- a/Livecheckables/fb-client.rb
+++ b/Livecheckables/fb-client.rb
@@ -1,6 +1,6 @@
 class FbClient
   livecheck do
     url :homepage
-    regex(%r{Latest release:.*?/fb[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{Latest release:.*?href=.*?/fb[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/ffmpeg.rb
+++ b/Livecheckables/ffmpeg.rb
@@ -1,6 +1,6 @@
 class Ffmpeg
   livecheck do
     url "https://ffmpeg.org/download.html"
-    regex(/ffmpeg[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?ffmpeg[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ffmpeg@2.8.rb
+++ b/Livecheckables/ffmpeg@2.8.rb
@@ -1,6 +1,6 @@
 class FfmpegAT28
   livecheck do
     url "https://ffmpeg.org/download.html"
-    regex(/ffmpeg[._-]v?(2\.8(?:\.\d+)*)\.t/i)
+    regex(/href=.*?ffmpeg[._-]v?(2\.8(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/fig2dev.rb
+++ b/Livecheckables/fig2dev.rb
@@ -1,6 +1,6 @@
 class Fig2dev
   livecheck do
-    url "https://sourceforge.net/projects/mcj/"
-    regex(%r{.*?/fig2dev[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
+    url :stable
+    regex(%r{url=.*?/fig2dev[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 end

--- a/Livecheckables/fuse-emulator.rb
+++ b/Livecheckables/fuse-emulator.rb
@@ -1,6 +1,6 @@
 class FuseEmulator
   livecheck do
-    url "https://sourceforge.net/projects/fuse-emulator/"
-    regex(%r{/fuse/[0-9.]+/fuse[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/fuse[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/gdcm.rb
+++ b/Livecheckables/gdcm.rb
@@ -1,6 +1,6 @@
 class Gdcm
   livecheck do
     url :homepage
-    regex(%r{/gdcm[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/gdcm[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/gegl.rb
+++ b/Livecheckables/gegl.rb
@@ -1,6 +1,6 @@
 class Gegl
   livecheck do
     url "https://download.gimp.org/pub/gegl/0.4/"
-    regex(/gegl[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?gegl[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/getmail.rb
+++ b/Livecheckables/getmail.rb
@@ -1,6 +1,6 @@
 class Getmail
   livecheck do
     url :homepage
-    regex(/getmail[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?getmail[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/giflib.rb
+++ b/Livecheckables/giflib.rb
@@ -1,6 +1,6 @@
 class Giflib
   livecheck do
     url :stable
-    regex(%r{/giflib[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/giflib[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/git.rb
+++ b/Livecheckables/git.rb
@@ -1,6 +1,6 @@
 class Git
   livecheck do
     url "https://www.kernel.org/pub/software/scm/git/"
-    regex(/git[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?git[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gloox.rb
+++ b/Livecheckables/gloox.rb
@@ -1,6 +1,6 @@
 class Gloox
   livecheck do
     url :homepage
-    regex(%r{Latest stable version.*?/gloox[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(/Latest stable version.*?href=.*?gloox[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gmic.rb
+++ b/Livecheckables/gmic.rb
@@ -1,6 +1,6 @@
 class Gmic
   livecheck do
     url "https://gmic.eu/files/source/"
-    regex(/gmic[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?gmic[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gnupg.rb
+++ b/Livecheckables/gnupg.rb
@@ -1,6 +1,6 @@
 class Gnupg
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gnupg/"
-    regex(/gnupg[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?gnupg[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gnupg@1.4.rb
+++ b/Livecheckables/gnupg@1.4.rb
@@ -1,6 +1,6 @@
 class GnupgAT14
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gnupg/"
-    regex(/gnupg[._-]v?(1\.4(?:\.\d+)+)\.t/i)
+    regex(/href=.*?gnupg[._-]v?(1\.4(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gnutls.rb
+++ b/Livecheckables/gnutls.rb
@@ -1,6 +1,6 @@
 class Gnutls
   livecheck do
     url "https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/"
-    regex(/gnutls[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?gnutls[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/go.rb
+++ b/Livecheckables/go.rb
@@ -1,6 +1,6 @@
 class Go
   livecheck do
     url "https://golang.org/dl/"
-    regex(/gov?(\d+(?:\.\d+)+)\.src/i)
+    regex(/href=.*?gov?(\d+(?:\.\d+)+)\.src/i)
   end
 end

--- a/Livecheckables/gpgme.rb
+++ b/Livecheckables/gpgme.rb
@@ -1,6 +1,6 @@
 class Gpgme
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gpgme/"
-    regex(/gpgme[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?gpgme[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gphoto2.rb
+++ b/Livecheckables/gphoto2.rb
@@ -1,6 +1,6 @@
 class Gphoto2
   livecheck do
-    url "https://sourceforge.net/projects/gphoto/"
-    regex(%r{.*?/gphoto2[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/gphoto2[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/gpsim.rb
+++ b/Livecheckables/gpsim.rb
@@ -1,6 +1,6 @@
 class Gpsim
   livecheck do
-    url "https://sourceforge.net/projects/gpsim/"
-    regex(%r{/gpsim[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/gpsim[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/gputils.rb
+++ b/Livecheckables/gputils.rb
@@ -1,6 +1,6 @@
 class Gputils
   livecheck do
-    url "https://sourceforge.net/projects/gputils/"
-    regex(%r{/gputils[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)\.t}i)
+    url :stable
+    regex(%r{url=.*?/gputils[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/groovy.rb
+++ b/Livecheckables/groovy.rb
@@ -1,6 +1,6 @@
 class Groovy
   livecheck do
     url "https://dl.bintray.com/groovy/maven/"
-    regex(/groovy-binary[._-]v?([\d.]+)\.zip/i)
+    regex(/href=.*?groovy-binary[._-]v?([\d.]+)\.zip/i)
   end
 end

--- a/Livecheckables/groovysdk.rb
+++ b/Livecheckables/groovysdk.rb
@@ -1,6 +1,6 @@
 class Groovysdk
   livecheck do
     url "https://dl.bintray.com/groovy/maven/"
-    regex(/apache-groovy-sdk[._-]v?([\d.]+)\.zip/i)
+    regex(/href=.*?apache-groovy-sdk[._-]v?([\d.]+)\.zip/i)
   end
 end

--- a/Livecheckables/haproxy.rb
+++ b/Livecheckables/haproxy.rb
@@ -1,6 +1,6 @@
 class Haproxy
   livecheck do
     url :homepage
-    regex(/haproxy[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?haproxy[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/hdf5@1.8.rb
+++ b/Livecheckables/hdf5@1.8.rb
@@ -1,6 +1,6 @@
 class Hdf5AT18
   livecheck do
     url "https://support.hdfgroup.org/ftp/HDF5/current18/src/"
-    regex(/hdf5[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?hdf5[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/httrack.rb
+++ b/Livecheckables/httrack.rb
@@ -1,6 +1,6 @@
 class Httrack
   livecheck do
     url "https://mirror.httrack.com/historical/"
-    regex(/httrack[._-]v?(\d+(?:\.\d+)+)\./i)
+    regex(/href=.*?httrack[._-]v?(\d+(?:\.\d+)+)\./i)
   end
 end

--- a/Livecheckables/i2p.rb
+++ b/Livecheckables/i2p.rb
@@ -1,6 +1,6 @@
 class I2p
   livecheck do
     url "https://geti2p.net/en/download"
-    regex(/i2pinstall[._-]v?(\d+(?:\.\d+)+)\.jar/i)
+    regex(/href=.*?i2pinstall[._-]v?(\d+(?:\.\d+)+)\.jar/i)
   end
 end

--- a/Livecheckables/ipbt.rb
+++ b/Livecheckables/ipbt.rb
@@ -1,6 +1,6 @@
 class Ipbt
   livecheck do
     url :homepage
-    regex(/ipbt[._-]v?(\d+)(?:\.[\da-z]+)?\.t/i)
+    regex(/href=.*?ipbt[._-]v?(\d+)(?:\.[\da-z]+)?\.t/i)
   end
 end

--- a/Livecheckables/ircd-hybrid.rb
+++ b/Livecheckables/ircd-hybrid.rb
@@ -1,6 +1,6 @@
 class IrcdHybrid
   livecheck do
-    url "https://sourceforge.net/projects/ircd-hybrid/"
-    regex(/ircd-hybrid[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(%r{url=.*?/ircd-hybrid[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/isc-dhcp.rb
+++ b/Livecheckables/isc-dhcp.rb
@@ -1,6 +1,6 @@
 class IscDhcp
   livecheck do
     url "https://www.isc.org/downloads/"
-    regex(%r{/dhcp[._-]v?(\d+(?:\.\d+)+(?:-P\d+)?)\.t}i)
+    regex(%r{href=.*?/dhcp[._-]v?(\d+(?:\.\d+)+(?:-P\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/ivykis.rb
+++ b/Livecheckables/ivykis.rb
@@ -1,6 +1,6 @@
 class Ivykis
   livecheck do
     url :homepage
-    regex(%r{/ivykis[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/ivykis[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/joe.rb
+++ b/Livecheckables/joe.rb
@@ -1,6 +1,6 @@
 class Joe
   livecheck do
-    url "https://sourceforge.net/projects/joe-editor/"
-    regex(%r{/joe[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/joe[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/klavaro.rb
+++ b/Livecheckables/klavaro.rb
@@ -1,6 +1,6 @@
 class Klavaro
   livecheck do
-    url "https://sourceforge.net/projects/klavaro/"
-    regex(%r{/klavaro[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/klavaro[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/kpcli.rb
+++ b/Livecheckables/kpcli.rb
@@ -1,6 +1,6 @@
 class Kpcli
   livecheck do
-    url "https://sourceforge.net/projects/kpcli/"
-    regex(%r{.*?/kpcli[._-]v?(\d+(?:\.\d+)+)\.p}i)
+    url :stable
+    regex(%r{url=.*?/kpcli[._-]v?(\d+(?:\.\d+)+)\.p}i)
   end
 end

--- a/Livecheckables/ktoblzcheck.rb
+++ b/Livecheckables/ktoblzcheck.rb
@@ -1,6 +1,6 @@
 class Ktoblzcheck
   livecheck do
-    url "https://sourceforge.net/projects/ktoblzcheck/"
-    regex(%r{/ktoblzcheck[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/ktoblzcheck[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/lame.rb
+++ b/Livecheckables/lame.rb
@@ -1,6 +1,6 @@
 class Lame
   livecheck do
-    url "https://sourceforge.net/projects/lame/"
-    regex(%r{.*?/lame[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/lame[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/lft.rb
+++ b/Livecheckables/lft.rb
@@ -1,6 +1,6 @@
 class Lft
   livecheck do
     url :homepage
-    regex(/value="lft[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/value=.*?lft[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libarchive.rb
+++ b/Livecheckables/libarchive.rb
@@ -1,6 +1,6 @@
 class Libarchive
   livecheck do
     url "https://libarchive.org/downloads/"
-    regex(/libarchive[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?libarchive[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libassuan.rb
+++ b/Livecheckables/libassuan.rb
@@ -1,6 +1,6 @@
 class Libassuan
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libassuan/"
-    regex(/libassuan[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?libassuan[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libdsk.rb
+++ b/Livecheckables/libdsk.rb
@@ -1,6 +1,6 @@
 class Libdsk
   livecheck do
     url :homepage
-    regex(%r{Stable version.*?/libdsk[._-]v?(\d+(?:\.\d+)+)\.t}im)
+    regex(/Stable version.*?href=.*?libdsk[._-]v?(\d+(?:\.\d+)+)\.t/im)
   end
 end

--- a/Livecheckables/libev.rb
+++ b/Livecheckables/libev.rb
@@ -1,6 +1,6 @@
 class Libev
   livecheck do
     url "http://dist.schmorp.de/libev/"
-    regex(/libev[._-]v?([\d.]+)\./i)
+    regex(/href=.*?libev[._-]v?([\d.]+)\./i)
   end
 end

--- a/Livecheckables/libgpg-error.rb
+++ b/Livecheckables/libgpg-error.rb
@@ -1,6 +1,6 @@
 class LibgpgError
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libgpg-error/"
-    regex(/libgpg-error[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?libgpg-error[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libgphoto2.rb
+++ b/Livecheckables/libgphoto2.rb
@@ -1,6 +1,6 @@
 class Libgphoto2
   livecheck do
-    url "https://sourceforge.net/projects/gphoto/"
-    regex(%r{.*?/libgphoto2[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/libgphoto2[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libksba.rb
+++ b/Livecheckables/libksba.rb
@@ -1,6 +1,6 @@
 class Libksba
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libksba/"
-    regex(/libksba[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?libksba[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libmodplug.rb
+++ b/Livecheckables/libmodplug.rb
@@ -1,6 +1,6 @@
 class Libmodplug
   livecheck do
-    url "https://sourceforge.net/projects/modplug-xmms/"
-    regex(%r{/libmodplug[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/libmodplug[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libofx.rb
+++ b/Livecheckables/libofx.rb
@@ -1,6 +1,6 @@
 class Libofx
   livecheck do
-    url "https://sourceforge.net/projects/libofx/"
-    regex(%r{/libofx[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/libofx[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libpng.rb
+++ b/Livecheckables/libpng.rb
@@ -1,6 +1,6 @@
 class Libpng
   livecheck do
-    url "https://sourceforge.net/projects/libpng/"
-    regex(%r{/libpng[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/libpng[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libraw.rb
+++ b/Livecheckables/libraw.rb
@@ -1,6 +1,6 @@
 class Libraw
   livecheck do
     url "https://www.libraw.org/download/"
-    regex(/LibRaw[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?LibRaw[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/libsndfile.rb
+++ b/Livecheckables/libsndfile.rb
@@ -1,6 +1,6 @@
 class Libsndfile
   livecheck do
     url :homepage
-    regex(/libsndfile[._-]v?([\d.]+)\.t/i)
+    regex(/href=.*?libsndfile[._-]v?([\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/libsoxr.rb
+++ b/Livecheckables/libsoxr.rb
@@ -1,6 +1,6 @@
 class Libsoxr
   livecheck do
     url :stable
-    regex(%r{/soxr[._-]v?(\d+(?:\.\d+)+)(?:-Source)?\.t}i)
+    regex(%r{url=.*?/soxr[._-]v?(\d+(?:\.\d+)+)(?:-Source)?\.t}i)
   end
 end

--- a/Livecheckables/libspectrum.rb
+++ b/Livecheckables/libspectrum.rb
@@ -1,6 +1,6 @@
 class Libspectrum
   livecheck do
-    url "https://sourceforge.net/projects/fuse-emulator/"
-    regex(%r{/libspectrum/[0-9.]+/libspectrum[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/libspectrum[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libssh2.rb
+++ b/Livecheckables/libssh2.rb
@@ -1,6 +1,6 @@
 class Libssh2
   livecheck do
     url "https://libssh2.org/download/"
-    regex(/libssh2[._-]v?(\d+(?:\.\d+)+)\./i)
+    regex(/href=.*?libssh2[._-]v?(\d+(?:\.\d+)+)\./i)
   end
 end

--- a/Livecheckables/libu2f-host.rb
+++ b/Livecheckables/libu2f-host.rb
@@ -1,6 +1,6 @@
 class Libu2fHost
   livecheck do
     url "https://developers.yubico.com/libu2f-host/Releases/"
-    regex(/libu2f-host[._-]v?(\d+\.\d+\.\d+)\.t/i)
+    regex(/href=.*?libu2f-host[._-]v?(\d+\.\d+\.\d+)\.t/i)
   end
 end

--- a/Livecheckables/libusb-compat.rb
+++ b/Livecheckables/libusb-compat.rb
@@ -1,6 +1,6 @@
 class LibusbCompat
   livecheck do
     url :stable
-    regex(%r{/libusb-compat[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/libusb-compat[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libvirt-glib.rb
+++ b/Livecheckables/libvirt-glib.rb
@@ -1,6 +1,6 @@
 class LibvirtGlib
   livecheck do
     url "https://libvirt.org/sources/glib/"
-    regex(/libvirt-glib[._-]v?([\d.]+)\.t/i)
+    regex(/href=.*?libvirt-glib[._-]v?([\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/libvterm.rb
+++ b/Livecheckables/libvterm.rb
@@ -1,6 +1,6 @@
 class Libvterm
   livecheck do
     url :homepage
-    regex(/libvterm[._-]v?(\d+(?:\.\d+)+)\./i)
+    regex(/href=.*?libvterm[._-]v?(\d+(?:\.\d+)+)\./i)
   end
 end

--- a/Livecheckables/log4cplus.rb
+++ b/Livecheckables/log4cplus.rb
@@ -1,6 +1,6 @@
 class Log4cplus
   livecheck do
-    url "https://sourceforge.net/projects/log4cplus/"
-    regex(%r{/log4cplus-stable/.*?/log4cplus[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(/url=.*?log4cplus-stable.*?log4cplus[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/log4cpp.rb
+++ b/Livecheckables/log4cpp.rb
@@ -1,6 +1,6 @@
 class Log4cpp
   livecheck do
-    url "https://sourceforge.net/projects/log4cpp/files/log4cpp-1.1.x%20%28new%29/log4cpp-1.1/"
-    regex(/log4cpp[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(%r{url=.*?/log4cpp[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/logcheck.rb
+++ b/Livecheckables/logcheck.rb
@@ -1,6 +1,6 @@
 class Logcheck
   livecheck do
     url "https://packages.debian.org/unstable/logcheck"
-    regex(/logcheck[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?logcheck[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/lrzip.rb
+++ b/Livecheckables/lrzip.rb
@@ -1,6 +1,6 @@
 class Lrzip
   livecheck do
     url "http://ck.kolivas.org/apps/lrzip"
-    regex(/lrzip[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?lrzip[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/lzo.rb
+++ b/Livecheckables/lzo.rb
@@ -1,6 +1,6 @@
 class Lzo
   livecheck do
     url "https://www.oberhumer.com/opensource/lzo/download/"
-    regex(/lzo[._-]v?([\d.]+)\./i)
+    regex(/href=.*?lzo[._-]v?([\d.]+)\./i)
   end
 end

--- a/Livecheckables/mairix.rb
+++ b/Livecheckables/mairix.rb
@@ -1,6 +1,6 @@
 class Mairix
   livecheck do
-    url "https://sourceforge.net/projects/mairix/"
-    regex(%r{/mairix[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/mairix[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/maxima.rb
+++ b/Livecheckables/maxima.rb
@@ -1,6 +1,6 @@
 class Maxima
   livecheck do
-    url "https://sourceforge.net/projects/maxima/"
-    regex(%r{/maxima[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/maxima[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/memcached.rb
+++ b/Livecheckables/memcached.rb
@@ -1,6 +1,6 @@
 class Memcached
   livecheck do
     url :homepage
-    regex(/memcached[._-]v?(\d+(?:\.\d+){2,})\./i)
+    regex(/href=.*?memcached[._-]v?(\d+(?:\.\d+){2,})\./i)
   end
 end

--- a/Livecheckables/mk-configure.rb
+++ b/Livecheckables/mk-configure.rb
@@ -1,6 +1,6 @@
 class MkConfigure
   livecheck do
-    url "https://sourceforge.net/projects/mk-configure/"
-    regex(%r{.*?/mk-configure[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/mk-configure[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/mksh.rb
+++ b/Livecheckables/mksh.rb
@@ -1,6 +1,6 @@
 class Mksh
   livecheck do
     url "https://www.mirbsd.org/MirOS/dist/mir/mksh/"
-    regex(/mksh-R?(\d+[a-z]?)\.t/i)
+    regex(/href=.*?mksh-R?(\d+[a-z]?)\.t/i)
   end
 end

--- a/Livecheckables/modules.rb
+++ b/Livecheckables/modules.rb
@@ -1,6 +1,6 @@
 class Modules
   livecheck do
-    url "https://sourceforge.net/projects/modules/"
-    regex(%r{.*?/modules[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/modules[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/nagios.rb
+++ b/Livecheckables/nagios.rb
@@ -1,6 +1,6 @@
 class Nagios
   livecheck do
-    url "https://sourceforge.net/projects/nagios/"
-    regex(%r{/.*nagios-.*/nagios[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/nagios[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/nano.rb
+++ b/Livecheckables/nano.rb
@@ -1,6 +1,6 @@
 class Nano
   livecheck do
     url "https://www.nano-editor.org/download.php"
-    regex(/nano[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?nano[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/omniorb.rb
+++ b/Livecheckables/omniorb.rb
@@ -1,6 +1,6 @@
 class Omniorb
   livecheck do
-    url "https://sourceforge.net/projects/omniorb/"
-    regex(%r{/omniORB[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)\.t}i)
+    url :stable
+    regex(%r{url=.*?/omniORB[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/opencore-amr.rb
+++ b/Livecheckables/opencore-amr.rb
@@ -1,6 +1,6 @@
 class OpencoreAmr
   livecheck do
-    url "https://sourceforge.net/projects/opencore-amr/files/opencore-amr/"
-    regex(/>opencore-amr[._-]v?([\d.]+)\.t/i)
+    url :stable
+    regex(%r{url=.*?/opencore-amr[._-]v?([\d.]+)\.t}i)
   end
 end

--- a/Livecheckables/openldap.rb
+++ b/Livecheckables/openldap.rb
@@ -1,6 +1,6 @@
 class Openldap
   livecheck do
     url "https://www.openldap.org/software/download/OpenLDAP/openldap-release/"
-    regex(/openldap[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?openldap[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/paperkey.rb
+++ b/Livecheckables/paperkey.rb
@@ -1,6 +1,6 @@
 class Paperkey
   livecheck do
     url :homepage
-    regex(/paperkey[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?paperkey[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pcb.rb
+++ b/Livecheckables/pcb.rb
@@ -1,6 +1,6 @@
 class Pcb
   livecheck do
-    url "https://sourceforge.net/projects/pcb/"
-    regex(%r{.*?/pcb[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/pcb[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/pdns.rb
+++ b/Livecheckables/pdns.rb
@@ -1,6 +1,6 @@
 class Pdns
   livecheck do
     url "https://downloads.powerdns.com/releases/"
-    regex(/pdns[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?pdns[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/pdnsrec.rb
+++ b/Livecheckables/pdnsrec.rb
@@ -1,6 +1,6 @@
 class Pdnsrec
   livecheck do
     url "https://downloads.powerdns.com/releases/"
-    regex(/pdns-recursor[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?pdns-recursor[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/pgpool-ii.rb
+++ b/Livecheckables/pgpool-ii.rb
@@ -1,6 +1,6 @@
 class PgpoolIi
   livecheck do
     url "https://www.pgpool.net/mediawiki/index.php/Downloads"
-    regex(/download\.php\?f=pgpool-II[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?pgpool-II[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pinentry.rb
+++ b/Livecheckables/pinentry.rb
@@ -1,6 +1,6 @@
 class Pinentry
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/pinentry/"
-    regex(/pinentry[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?pinentry[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pipenv.rb
+++ b/Livecheckables/pipenv.rb
@@ -1,6 +1,6 @@
 class Pipenv
   livecheck do
     url :stable
-    regex(%r{/pipenv[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(/href=.*?pipenv[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pkg-config.rb
+++ b/Livecheckables/pkg-config.rb
@@ -1,6 +1,6 @@
 class PkgConfig
   livecheck do
     url "https://pkg-config.freedesktop.org/releases/"
-    regex(/pkg-config[._-]v?(\d+(?:\.\d+)+)\./i)
+    regex(/href=.*?pkg-config[._-]v?(\d+(?:\.\d+)+)\./i)
   end
 end

--- a/Livecheckables/plantuml.rb
+++ b/Livecheckables/plantuml.rb
@@ -1,6 +1,6 @@
 class Plantuml
   livecheck do
-    url "https://sourceforge.net/projects/plantuml/"
-    regex(%r{.*?/plantuml[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/plantuml[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/poppler.rb
+++ b/Livecheckables/poppler.rb
@@ -1,6 +1,6 @@
 class Poppler
   livecheck do
     url "https://poppler.freedesktop.org/releases.html"
-    regex(/poppler[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?poppler[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/potrace.rb
+++ b/Livecheckables/potrace.rb
@@ -1,6 +1,6 @@
 class Potrace
   livecheck do
     url "http://potrace.sourceforge.net/"
-    regex(/potrace[._-]v?(\d+(?:\.\d+)*)\.t/i)
+    regex(/href=.*?potrace[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/privoxy.rb
+++ b/Livecheckables/privoxy.rb
@@ -1,6 +1,6 @@
 class Privoxy
   livecheck do
-    url "https://www.privoxy.org/feeds/privoxy-releases.xml"
-    regex(/privoxy[._-]v?(\d+(?:\.\d+)+)-stable-src\./i)
+    url :stable
+    regex(%r{url=.*?/privoxy[._-]v?(\d+(?:\.\d+)+)[._-]stable[._-]src\.t}i)
   end
 end

--- a/Livecheckables/pv.rb
+++ b/Livecheckables/pv.rb
@@ -1,6 +1,6 @@
 class Pv
   livecheck do
     url :homepage
-    regex(/pv[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?pv[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/qjackctl.rb
+++ b/Livecheckables/qjackctl.rb
@@ -1,6 +1,6 @@
 class Qjackctl
   livecheck do
-    url "https://sourceforge.net/projects/qjackctl/"
-    regex(%r{.*?/qjackctl[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/qjackctl[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/quex.rb
+++ b/Livecheckables/quex.rb
@@ -1,6 +1,6 @@
 class Quex
   livecheck do
-    url "https://sourceforge.net/projects/quex/"
-    regex(%r{.*?/quex[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/quex[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/rakudo-star.rb
+++ b/Livecheckables/rakudo-star.rb
@@ -1,6 +1,6 @@
 class RakudoStar
   livecheck do
     url "https://rakudo.org/dl/star/"
-    regex(/rakudo-star[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/".*?rakudo-star[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/rtmpdump.rb
+++ b/Livecheckables/rtmpdump.rb
@@ -1,6 +1,6 @@
 class Rtmpdump
   livecheck do
     url "https://cdn-aws.deb.debian.org/debian/pool/main/r/rtmpdump/"
-    regex(/rtmpdump[._-]v?(\d.\d\+\d*).*.orig\.t/i)
+    regex(/href=.*?rtmpdump[._-]v?(\d.\d\+\d*).*.orig\.t/i)
   end
 end

--- a/Livecheckables/ruby.rb
+++ b/Livecheckables/ruby.rb
@@ -1,6 +1,6 @@
 class Ruby
   livecheck do
     url "https://www.ruby-lang.org/en/downloads/"
-    regex(/The current stable version is v?(\d+(?:\.\d+)+)\./i)
+    regex(/href=.*?ruby[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/sdl2_gfx.rb
+++ b/Livecheckables/sdl2_gfx.rb
@@ -1,6 +1,6 @@
 class Sdl2Gfx
   livecheck do
-    url "https://sourceforge.net/projects/sdl2gfx/"
-    regex(%r{.*?/SDL2_gfx[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :homepage
+    regex(/href=.*?SDL2_gfx[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ser2net.rb
+++ b/Livecheckables/ser2net.rb
@@ -1,6 +1,6 @@
 class Ser2net
   livecheck do
-    url "https://sourceforge.net/projects/ser2net/"
-    regex(%r{.*?/ser2net[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/ser2net[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/shmcat.rb
+++ b/Livecheckables/shmcat.rb
@@ -1,6 +1,6 @@
 class Shmcat
   livecheck do
-    url "https://sourceforge.net/projects/shmcat/"
-    regex(%r{.*?/shmcat[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/shmcat[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/sip.rb
+++ b/Livecheckables/sip.rb
@@ -1,6 +1,6 @@
 class Sip
   livecheck do
     url "https://riverbankcomputing.com/software/sip/download"
-    regex(/sip[._-]v?(\d+(\.\d+)+)\.t/i)
+    regex(/href=.*?sip[._-]v?(\d+(\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/socat.rb
+++ b/Livecheckables/socat.rb
@@ -1,6 +1,6 @@
 class Socat
   livecheck do
     url "http://www.dest-unreach.org/socat/download/"
-    regex(/socat[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?socat[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/sonarqube.rb
+++ b/Livecheckables/sonarqube.rb
@@ -1,6 +1,6 @@
 class Sonarqube
   livecheck do
     url "https://binaries.sonarsource.com/Distribution/sonarqube/"
-    regex(/sonarqube[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+    regex(/href=.*?sonarqube[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 end

--- a/Livecheckables/squid.rb
+++ b/Livecheckables/squid.rb
@@ -1,6 +1,6 @@
 class Squid
   livecheck do
     url "http://www.squid-cache.org/Versions/v4/"
-    regex(/squid[._-]v?(\d+(?:\.\d+)+)-RELEASENOTES\.html/i)
+    regex(/href=.*?squid[._-]v?(\d+(?:\.\d+)+)-RELEASENOTES\.html/i)
   end
 end

--- a/Livecheckables/stm32flash.rb
+++ b/Livecheckables/stm32flash.rb
@@ -1,6 +1,6 @@
 class Stm32flash
   livecheck do
-    url :homepage
-    regex(%r{.*?/stm32flash[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/stm32flash[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/suricata.rb
+++ b/Livecheckables/suricata.rb
@@ -1,6 +1,6 @@
 class Suricata
   livecheck do
     url "https://suricata-ids.org/download/"
-    regex(/suricata[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?suricata[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/swi-prolog.rb
+++ b/Livecheckables/swi-prolog.rb
@@ -1,6 +1,6 @@
 class SwiProlog
   livecheck do
     url "https://www.swi-prolog.org/download/stable/src"
-    regex(/swipl[._-]v?(\d+\.\d+\.\d+)\.t/i)
+    regex(/href=.*?swipl[._-]v?(\d+\.\d+\.\d+)\.t/i)
   end
 end

--- a/Livecheckables/tclap.rb
+++ b/Livecheckables/tclap.rb
@@ -1,6 +1,6 @@
 class Tclap
   livecheck do
-    url "https://sourceforge.net/projects/tclap/"
-    regex(%r{.*?/tclap[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/tclap[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/tor.rb
+++ b/Livecheckables/tor.rb
@@ -1,6 +1,6 @@
 class Tor
   livecheck do
     url "https://dist.torproject.org/"
-    regex(/tor[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?tor[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/tox.rb
+++ b/Livecheckables/tox.rb
@@ -1,6 +1,6 @@
 class Tox
   livecheck do
     url :stable
-    regex(%r{/tox[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(/href=.*?tox[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/tree.rb
+++ b/Livecheckables/tree.rb
@@ -1,6 +1,6 @@
 class Tree
   livecheck do
     url "http://mama.indstate.edu/users/ice/tree/src"
-    regex(/tree[._-]v?(.*?)\.t/i)
+    regex(/href=.*?tree[._-]v?(.*?)\.t/i)
   end
 end

--- a/Livecheckables/ucon64.rb
+++ b/Livecheckables/ucon64.rb
@@ -1,6 +1,6 @@
 class Ucon64
   livecheck do
-    url "https://sourceforge.net/projects/ucon64/"
-    regex(%r{.*?/ucon64[._-]v?(\d+(?:\.\d+)+)-src\.t}i)
+    url :stable
+    regex(%r{url=.*?/ucon64[._-]v?(\d+(?:\.\d+)+)-src\.t}i)
   end
 end

--- a/Livecheckables/uftp.rb
+++ b/Livecheckables/uftp.rb
@@ -1,6 +1,6 @@
 class Uftp
   livecheck do
-    url "https://sourceforge.net/projects/uftp-multicast/"
-    regex(%r{.*?/uftp[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/uftp[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/usbredir.rb
+++ b/Livecheckables/usbredir.rb
@@ -1,6 +1,6 @@
 class Usbredir
   livecheck do
     url "https://www.spice-space.org/download/usbredir/"
-    regex(/usbredir[._-]v?([\d.]+)\.t/i)
+    regex(/href=.*?usbredir[._-]v?([\d.]+)\.t/i)
   end
 end

--- a/Livecheckables/vde.rb
+++ b/Livecheckables/vde.rb
@@ -1,6 +1,6 @@
 class Vde
   livecheck do
     url :stable
-    regex(%r{/vde\d*?[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/vde\d*?[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/vice.rb
+++ b/Livecheckables/vice.rb
@@ -1,6 +1,6 @@
 class Vice
   livecheck do
-    url :homepage
-    regex(%r{.*?/vice[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/vice[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/vorbis-tools.rb
+++ b/Livecheckables/vorbis-tools.rb
@@ -1,6 +1,6 @@
 class VorbisTools
   livecheck do
     url "https://downloads.xiph.org/releases/vorbis/"
-    regex(/vorbis-tools[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?vorbis-tools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/writerperfect.rb
+++ b/Livecheckables/writerperfect.rb
@@ -1,6 +1,6 @@
 class Writerperfect
   livecheck do
-    url "https://sourceforge.net/projects/libwpd/"
-    regex(%r{.*?/writerperfect[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/writerperfect[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/wtf.rb
+++ b/Livecheckables/wtf.rb
@@ -1,6 +1,6 @@
 class Wtf
   livecheck do
-    url :homepage
-    regex(%r{.*?/wtf[._-]v?(\d{6,8})\.t}i)
+    url :stable
+    regex(%r{url=.*?/wtf[._-]v?(\d{6,8})\.t}i)
   end
 end

--- a/Livecheckables/xqilla.rb
+++ b/Livecheckables/xqilla.rb
@@ -1,6 +1,6 @@
 class Xqilla
   livecheck do
-    url "https://sourceforge.net/projects/xqilla/"
-    regex(%r{.*?/XQilla[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(%r{url=.*?/XQilla[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/yaf.rb
+++ b/Livecheckables/yaf.rb
@@ -1,6 +1,6 @@
 class Yaf
   livecheck do
     url "https://tools.netsa.cert.org/yaf/download.html"
-    regex(%r{/yaf[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(/".*?yaf[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/zbar.rb
+++ b/Livecheckables/zbar.rb
@@ -1,6 +1,6 @@
 class Zbar
   livecheck do
-    url "https://sourceforge.net/projects/zbar/"
-    regex(/zbar[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(%r{url=.*?/zbar[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/livecheck/livecheck_strategy/sourceforge.rb
+++ b/livecheck/livecheck_strategy/sourceforge.rb
@@ -9,13 +9,10 @@ module LivecheckStrategy
       /bashdb/
       /netpbm/
       bcrypt.sourceforge.net
-      e2fsprogs
       foremost.sourceforge.net
       liba52.sourceforge.net
       libwps
-      log4cpp
       mikmod
-      opencore-amr
       potrace
       remake
     ].freeze


### PR DESCRIPTION
The main purpose of this is to add a delimiter followed by `.*?` (e.g., `href=.*?`, `url=.*?`, `value=.*?`, `".*?`, etc.) before the file name in regexes. For example, `/aamath[._-]v?(\d+(?:\.\d+)+)\.t/i` becomes `/href=.*?aamath[._-]v?(\d+(?:\.\d+)+)\.t/i`.

I also addressed the following areas along the way:

* Use formula URL symbol instead of hardcoded SourceForge URLs, where possible.
* Prefer `:stable` URL over `:homepage`, where applicable.
* Reduce unnecessary specificity in file URL in regexes, where possible.

I've compared the strategy used and matched versions before/after the changes in this PR and the differences are all as I would expect.