### PR TITLE
Remove Sourceforge strategy SPECIAL_CASES

### DIFF
--- a/Livecheckables/a52dec.rb
+++ b/Livecheckables/a52dec.rb
@@ -1,6 +1,7 @@
 class A52dec
   livecheck do
     url "http://liba52.sourceforge.net/downloads.html"
+    strategy :page_match
     regex(/href=.*?a52dec[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/avfs.rb
+++ b/Livecheckables/avfs.rb
@@ -1,6 +1,6 @@
 class Avfs
   livecheck do
-    url "https://sourceforge.net/projects/avf/rss"
+    url :stable
     regex(%r{url=.*?/avfs[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/bashdb.rb
+++ b/Livecheckables/bashdb.rb
@@ -1,6 +1,7 @@
 class Bashdb
   livecheck do
     url "https://sourceforge.net/projects/bashdb/files/bashdb/"
+    strategy :page_match
     regex(%r{href=(?:["']|.*?bashdb/)?v?(\d+(?:[.-]\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/bcrypt.rb
+++ b/Livecheckables/bcrypt.rb
@@ -1,6 +1,7 @@
 class Bcrypt
   livecheck do
     url "http://bcrypt.sourceforge.net"
+    strategy :page_match
     regex(/href=.*?bcrypt[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/foremost.rb
+++ b/Livecheckables/foremost.rb
@@ -1,6 +1,7 @@
 class Foremost
   livecheck do
     url "http://foremost.sourceforge.net/"
+    strategy :page_match
     regex(/href=.*?foremost[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libmikmod.rb
+++ b/Livecheckables/libmikmod.rb
@@ -1,6 +1,6 @@
 class Libmikmod
   livecheck do
-    url "http://mikmod.sourceforge.net/"
-    regex(/href=.*?libmikmod[._-](\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(%r{url=.*?/libmikmod[._-](\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libwps.rb
+++ b/Livecheckables/libwps.rb
@@ -1,6 +1,6 @@
 class Libwps
   livecheck do
-    url "https://sourceforge.net/projects/libwps/files/libwps/"
-    regex(%r{href=.*?libwps(?:/|[._-])v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url :stable
+    regex(%r{url=.*?/libwps(?:/|[._-])v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/mikmod.rb
+++ b/Livecheckables/mikmod.rb
@@ -1,6 +1,6 @@
 class Mikmod
   livecheck do
-    url "http://mikmod.sourceforge.net/"
-    regex(/href=.*?[^b]mikmod[._-](\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(%r{url=.*?/mikmod[._-](\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/netpbm.rb
+++ b/Livecheckables/netpbm.rb
@@ -1,6 +1,7 @@
 class Netpbm
   livecheck do
     url "https://sourceforge.net/p/netpbm/code/HEAD/tree/stable/"
+    strategy :page_match
     regex(/Release v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/potrace.rb
+++ b/Livecheckables/potrace.rb
@@ -1,6 +1,7 @@
 class Potrace
   livecheck do
     url "http://potrace.sourceforge.net/"
+    strategy :page_match
     regex(/href=.*?potrace[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end

--- a/Livecheckables/remake.rb
+++ b/Livecheckables/remake.rb
@@ -1,6 +1,7 @@
 class Remake
   livecheck do
     url "https://sourceforge.net/projects/bashdb/files/remake/"
+    strategy :page_match
     regex(%r{href=.*?remake/v?(\d+(?:\.\d+)+(?:(?:%2Bdbg)?[._-]\d+(?:\.\d+)+)?)/?["' >]}i)
   end
 end

--- a/Livecheckables/zshdb.rb
+++ b/Livecheckables/zshdb.rb
@@ -1,0 +1,7 @@
+class Zshdb
+  livecheck do
+    url "https://sourceforge.net/projects/bashdb/files/zshdb/"
+    strategy :page_match
+    regex(%r{href=(?:["']|.*?zshdb/)?v?(\d+(?:[.-]\d+)+)/?["' >]}i)
+  end
+end

--- a/livecheck/livecheck_strategy/sourceforge.rb
+++ b/livecheck/livecheck_strategy/sourceforge.rb
@@ -4,23 +4,8 @@ module LivecheckStrategy
   class Sourceforge
     NICE_NAME = "SourceForge"
 
-    SPECIAL_CASES = %w[
-      /avf/
-      /bashdb/
-      /netpbm/
-      bcrypt.sourceforge.net
-      foremost.sourceforge.net
-      liba52.sourceforge.net
-      libwps
-      mikmod
-      potrace
-      remake
-    ].freeze
-    private_constant :SPECIAL_CASES
-
     def self.match?(url)
-      /(sourceforge|sf)\.net/.match?(url) &&
-        SPECIAL_CASES.none? { |sc| url.include? sc }
+      /(sourceforge|sf)\.net/.match?(url)
     end
 
     def self.find_versions(url, regex = nil)


### PR DESCRIPTION
The `Sourceforge` strategy's `SPECIAL_CASES` array is no longer necessary now that we can manually specify the strategy to use in the `livecheck` block.

This modifies/adds related checks and removes the `SPECIAL_CASES` array. Some of these simply needed `strategy :page_match` in the `livecheck` block and others were seemingly fine to use the `Sourceforge` strategy at this point.