### PR TITLE
Remove Gnu strategy SPECIAL_CASES

### DIFF
--- a/Livecheckables/avrdude.rb
+++ b/Livecheckables/avrdude.rb
@@ -1,6 +1,7 @@
 class Avrdude
   livecheck do
     url "https://download.savannah.gnu.org/releases/avrdude/"
+    strategy :page_match
     regex(/href=.*?avrdude[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/clisp.rb
+++ b/Livecheckables/clisp.rb
@@ -1,6 +1,7 @@
 class Clisp
   livecheck do
     url "https://ftp.gnu.org/gnu/clisp/release/?C=M&O=D"
+    strategy :page_match
     regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/cvs.rb
+++ b/Livecheckables/cvs.rb
@@ -1,6 +1,7 @@
 class Cvs
   livecheck do
     url "https://ftp.gnu.org/non-gnu/cvs/source/feature/"
+    strategy :page_match
     regex(%r{href=.*?v?(\d+(?:\.\d+)+)/}i)
   end
 end

--- a/Livecheckables/dvdrtools.rb
+++ b/Livecheckables/dvdrtools.rb
@@ -1,6 +1,7 @@
 class Dvdrtools
   livecheck do
     url "https://download.savannah.gnu.org/releases/dvdrtools/"
+    strategy :page_match
     regex(/href=.*?dvdrtools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/icoutils.rb
+++ b/Livecheckables/icoutils.rb
@@ -1,6 +1,7 @@
 class Icoutils
   livecheck do
     url "https://download.savannah.gnu.org/releases/icoutils/"
+    strategy :page_match
     regex(/href=.*?icoutils[._-](\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/kawa.rb
+++ b/Livecheckables/kawa.rb
@@ -1,6 +1,7 @@
 class Kawa
   livecheck do
     url "https://ftp.gnu.org/gnu/kawa"
+    strategy :page_match
     regex(/href=.*?kawa[._-]v?(\d+\.\d+(\.\d+)?)\.zip/i)
   end
 end

--- a/Livecheckables/lzip.rb
+++ b/Livecheckables/lzip.rb
@@ -1,6 +1,7 @@
 class Lzip
   livecheck do
     url "https://download.savannah.gnu.org/releases/lzip/"
+    strategy :page_match
     regex(/href=.*?lzip[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/mit-scheme.rb
+++ b/Livecheckables/mit-scheme.rb
@@ -1,6 +1,7 @@
 class MitScheme
   livecheck do
     url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/?C=M&O=D"
+    strategy :page_match
     regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/oath-toolkit.rb
+++ b/Livecheckables/oath-toolkit.rb
@@ -1,6 +1,7 @@
 class OathToolkit
   livecheck do
     url "http://download.savannah.nongnu.org/releases/oath-toolkit/"
+    strategy :page_match
     regex(/href=.*?oath-toolkit[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -10,22 +10,8 @@ module LivecheckStrategy
     ].freeze
     private_constant :PROJECT_NAME_REGEXES
 
-    SPECIAL_CASES = %w[
-      avrdude
-      clisp
-      cvs
-      dvdrtools
-      icoutils
-      kawa
-      lzip
-      mit-scheme
-      numdiff
-      oath-toolkit
-    ].freeze
-    private_constant :SPECIAL_CASES
-
     def self.match?(url)
-      url.include?("gnu.org") && SPECIAL_CASES.none? { |sc| url.include? sc }
+      url.include?("gnu.org")
     end
 
     def self.find_versions(url, regex = nil)


### PR DESCRIPTION
The `Gnu` strategy's `SPECIAL_CASES` array is no longer necessary now that we can manually specify the strategy to use in the `livecheck` block.

This modifies related checks to add `strategy :page_match` to the `livecheck` block and removes the `SPECIAL_CASES` array.