### PR TITLE
Update livecheckables using a SourceForge URL

### DIFF
--- a/Livecheckables/astyle.rb
+++ b/Livecheckables/astyle.rb
@@ -1,6 +1,6 @@
 class Astyle
   livecheck do
-    url "https://sourceforge.net/projects/astyle/"
-    regex(%r{.*?/astyle[._-]v?(\d+(?:\.\d+)+)_}i)
+    url :stable
+    regex(%r{url=.*?/astyle[._-]v?(\d+(?:\.\d+)+)_}i)
   end
 end

--- a/Livecheckables/aview.rb
+++ b/Livecheckables/aview.rb
@@ -1,6 +1,6 @@
 class Aview
   livecheck do
-    url "https://sourceforge.net/projects/aa-project/rss"
+    url :stable
     regex(%r{url=.*?/aview[._-]v?(\d+(?:\.\d+)+(?:[a-z]+\d*)?)\.t}i)
   end
 end

--- a/Livecheckables/ctags.rb
+++ b/Livecheckables/ctags.rb
@@ -1,6 +1,6 @@
 class Ctags
   livecheck do
-    url "https://sourceforge.net/projects/ctags/"
+    url :stable
     regex(%r{url=.*?/ctags[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/dfu-programmer.rb
+++ b/Livecheckables/dfu-programmer.rb
@@ -1,6 +1,6 @@
 class DfuProgrammer
   livecheck do
-    url "https://sourceforge.net/projects/dfu-programmer/rss"
+    url :stable
     regex(%r{url=.*?/dfu-programmer[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/docbook2x.rb
+++ b/Livecheckables/docbook2x.rb
@@ -1,6 +1,6 @@
 class Docbook2x
   livecheck do
-    url "https://sourceforge.net/projects/docbook2x/rss"
+    url :stable
     regex(%r{url=.*?/docbook2X[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/expat.rb
+++ b/Livecheckables/expat.rb
@@ -1,5 +1,6 @@
 class Expat
   livecheck do
-    url "https://sourceforge.net/projects/expat/files/"
+    url "https://github.com/libexpat/libexpat/releases/latest"
+    regex(/href=.*?expat[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ffe.rb
+++ b/Livecheckables/ffe.rb
@@ -1,6 +1,6 @@
 class Ffe
   livecheck do
-    url "https://sourceforge.net/projects/ff-extractor/"
+    url :stable
     regex(%r{url=.*?/ffe[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/fpc.rb
+++ b/Livecheckables/fpc.rb
@@ -1,6 +1,9 @@
 class Fpc
+  # fpc releases involve so many files that the tarball is pushed out of the
+  # RSS feed and we can't rely on the SourceForge strategy.
   livecheck do
-    url "https://sourceforge.net/projects/freepascal/"
-    regex(%r{/Linux/v?(\d+(?:\.\d+)+)/readme.txt}i)
+    url "https://sourceforge.net/projects/freepascal/files/Source/"
+    strategy :page_match
+    regex(%r{href=(?:["']|.*?Source/)?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/freeciv.rb
+++ b/Livecheckables/freeciv.rb
@@ -1,6 +1,6 @@
 class Freeciv
   livecheck do
-    url "https://sourceforge.net/projects/freeciv/"
-    regex(%r{/freeciv[._-]v?(\d+(?:\.\d+)+)\.t.*?z.*?/}i)
+    url :stable
+    regex(%r{url=.*?/freeciv[._-]v?(\d+(?:\.\d+)+)\.(?:t|zip)/}i)
   end
 end

--- a/Livecheckables/ganglia.rb
+++ b/Livecheckables/ganglia.rb
@@ -1,6 +1,6 @@
 class Ganglia
   livecheck do
-    url "https://downloads.sourceforge.net/project/ganglia/"
+    url :stable
     regex(%r{url=.*?/ganglia[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/gauche.rb
+++ b/Livecheckables/gauche.rb
@@ -1,6 +1,6 @@
 class Gauche
   livecheck do
-    url "https://sourceforge.net/projects/gauche/rss"
+    url :stable
     regex(%r{url=.*?/Gauche[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/gerbv.rb
+++ b/Livecheckables/gerbv.rb
@@ -1,6 +1,6 @@
 class Gerbv
   livecheck do
-    url "https://sourceforge.net/projects/gerbv/"
+    url :stable
     regex(%r{/gerbv/gerbv[._-]v?(\d+(?:\.\d+)+)/}i)
   end
 end

--- a/Livecheckables/harbour.rb
+++ b/Livecheckables/harbour.rb
@@ -1,6 +1,6 @@
 class Harbour
   livecheck do
-    url "https://sourceforge.net/projects/harbour-project/rss"
+    url :stable
     regex(%r{url=.*?/harbour[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/irrlicht.rb
+++ b/Livecheckables/irrlicht.rb
@@ -1,6 +1,6 @@
 class Irrlicht
   livecheck do
-    url "https://sourceforge.net/projects/irrlicht/rss"
+    url :stable
     regex(%r{url=.*?/irrlicht[._-]v?(\d+(?:\.\d+)+)\.(?:t|z)}i)
   end
 end

--- a/Livecheckables/itpp.rb
+++ b/Livecheckables/itpp.rb
@@ -1,6 +1,6 @@
 class Itpp
   livecheck do
-    url "https://sourceforge.net/projects/itpp/rss"
+    url :stable
     regex(%r{url=.*?/itpp[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libmaa.rb
+++ b/Livecheckables/libmaa.rb
@@ -1,6 +1,6 @@
 class Libmaa
   livecheck do
-    url "https://sourceforge.net/projects/dict/"
+    url :stable
     regex(%r{url=.*?/libmaa[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/libngspice.rb
+++ b/Livecheckables/libngspice.rb
@@ -1,6 +1,6 @@
 class Libngspice
   livecheck do
-    url "https://sourceforge.net/projects/ngspice/rss"
+    url :stable
     regex(%r{url=.*?/ngspice[._-]v?(\d+(?:\.\d+)*)\.t}i)
   end
 end

--- a/Livecheckables/libvo-aacenc.rb
+++ b/Livecheckables/libvo-aacenc.rb
@@ -1,6 +1,6 @@
 class LibvoAacenc
   livecheck do
-    url "https://sourceforge.net/projects/opencore-amr/rss"
+    url :stable
     regex(%r{url=.*?/vo-aacenc[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/minidjvu.rb
+++ b/Livecheckables/minidjvu.rb
@@ -1,6 +1,6 @@
 class Minidjvu
   livecheck do
-    url "https://sourceforge.net/projects/minidjvu/"
+    url :stable
     regex(%r{url=.*?/minidjvu[._-]v?((?!0\.33)\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/mpg123.rb
+++ b/Livecheckables/mpg123.rb
@@ -1,6 +1,6 @@
 class Mpg123
   livecheck do
-    url "https://sourceforge.net/projects/mpg123/rss"
-    regex(%r{url=.*?/mpg123[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url "https://www.mpg123.de/download/"
+    regex(/href=.*?mpg123[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/nco.rb
+++ b/Livecheckables/nco.rb
@@ -1,6 +1,6 @@
 class Nco
   livecheck do
-    url "https://sourceforge.net/projects/nco/"
-    regex(%r{/nco[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url "https://github.com/nco/nco/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/net-snmp.rb
+++ b/Livecheckables/net-snmp.rb
@@ -1,6 +1,6 @@
 class NetSnmp
   livecheck do
-    url "https://sourceforge.net/projects/net-snmp/"
+    url :stable
     regex(%r{url=.*?/net-snmp[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/ngspice.rb
+++ b/Livecheckables/ngspice.rb
@@ -1,6 +1,6 @@
 class Ngspice
   livecheck do
-    url "https://sourceforge.net/projects/ngspice/rss"
+    url :stable
     regex(%r{url=.*?/ngspice[._-]v?(\d+(?:\.\d+)*)\.t}i)
   end
 end

--- a/Livecheckables/qmmp.rb
+++ b/Livecheckables/qmmp.rb
@@ -1,6 +1,6 @@
 class Qmmp
   livecheck do
-    url "https://sourceforge.net/projects/qmmp-dev/rss"
+    url :stable
     regex(%r{url=.*?/qmmp[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/sdcc.rb
+++ b/Livecheckables/sdcc.rb
@@ -1,6 +1,6 @@
 class Sdcc
   livecheck do
-    url "https://sourceforge.net/projects/sdcc/rss"
+    url :stable
     regex(%r{url=.*?/sdcc-src[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/sfk.rb
+++ b/Livecheckables/sfk.rb
@@ -1,6 +1,6 @@
 class Sfk
   livecheck do
-    url "https://sourceforge.net/projects/swissfileknife/"
-    regex(%r{swissfileknife/v?(\d+(?:\.\d+)+)/}i)
+    url :stable
+    regex(%r{url.*?swissfileknife/v?(\d+(?:\.\d+)+)/}i)
   end
 end

--- a/Livecheckables/simutrans.rb
+++ b/Livecheckables/simutrans.rb
@@ -1,6 +1,6 @@
 class Simutrans
   livecheck do
-    url "https://sourceforge.net/projects/simutrans/rss"
-    regex(%r{url=.*?/simutrans-src[._-]v?(\d+(?:[-_.]\d+)+)\.(?:t|z)}i)
+    url :stable
+    regex(%r{url=.*?/simutrans-src[._-]v?(\d+(?:[-_.]\d+)+)\.(?:t|zip)}i)
   end
 end

--- a/Livecheckables/synfig.rb
+++ b/Livecheckables/synfig.rb
@@ -1,6 +1,6 @@
 class Synfig
   livecheck do
-    url "https://sourceforge.net/projects/synfig/"
+    url :stable
     regex(%r{url=.*?/synfig[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/tcl-tk.rb
+++ b/Livecheckables/tcl-tk.rb
@@ -1,6 +1,6 @@
 class TclTk
   livecheck do
-    url "https://sourceforge.net/projects/tcl/rss"
-    regex(%r{url=.*?/(?:tcl|tk).?v?(\d+(?:\.\d+)+)-src\.t}i)
+    url :stable
+    regex(%r{url=.*?/(?:tcl|tk).?v?(\d+(?:\.\d+)+)[._-]src\.t}i)
   end
 end

--- a/Livecheckables/tintin.rb
+++ b/Livecheckables/tintin.rb
@@ -1,6 +1,6 @@
 class Tintin
   livecheck do
-    url "https://sourceforge.net/projects/tintin/"
-    regex(%r{.*?/tintin[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url "https://github.com/scandum/tintin/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end

--- a/Livecheckables/ttf2pt1.rb
+++ b/Livecheckables/ttf2pt1.rb
@@ -1,6 +1,6 @@
 class Ttf2pt1
   livecheck do
-    url "https://sourceforge.net/projects/ttf2pt1/rss"
+    url :stable
     regex(%r{url=.*?/ttf2pt1[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/udis86.rb
+++ b/Livecheckables/udis86.rb
@@ -1,6 +1,6 @@
 class Udis86
   livecheck do
-    url "https://sourceforge.net/projects/udis86/rss"
+    url :stable
     regex(%r{url=.*?/udis86[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/w3m.rb
+++ b/Livecheckables/w3m.rb
@@ -1,6 +1,6 @@
 class W3m
   livecheck do
-    url "https://sourceforge.net/projects/w3m/rss"
+    url :stable
     regex(%r{url=.*?/w3m[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/zint.rb
+++ b/Livecheckables/zint.rb
@@ -1,6 +1,6 @@
 class Zint
   livecheck do
-    url "https://sourceforge.net/projects/zint/rss"
+    url :stable
     regex(%r{url=.*?/zint[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end


### PR DESCRIPTION
This primarily modifies livecheckables that are 1) using a SourceForge URL, 2) using the `Sourceforge` strategy, and 3) have a downloads.sourceforge.net `stable` URL to use `strategy :stable`. Some of the regexes were also updated to bring them up to our current standards.

Besides that, this also addresses the following:

* Updates `expat`, `nco`, and `tintin` to check the "latest" release on GitHub, since the `stable` archive comes from the GitHub repository.
* Updates `fpc` to check the SourceForge project's `Source` folder page, since releases involve so many files that the tarball we're interested in can be pushed out of the RSS feed.
* Updates `mpg123` to use the [first-party `download` directory listing page](https://www.mpg123.de/download/), where the stable archive is found.