### PR TITLE
Gnu: don't match Savannah URLs, update regex

### DIFF
--- a/Livecheckables/clzip.rb
+++ b/Livecheckables/clzip.rb
@@ -1,0 +1,6 @@
+class Clzip
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/lzip/clzip/"
+    regex(/href=.*?clzip[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/flvstreamer.rb
+++ b/Livecheckables/flvstreamer.rb
@@ -1,0 +1,6 @@
+class Flvstreamer
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/flvstreamer/source/"
+    regex(/href=.*?flvstreamer[._-]v?(\d+(?:\.\d+)+(?:[a-z]\d*)?)\.t/i)
+  end
+end

--- a/Livecheckables/gpsd.rb
+++ b/Livecheckables/gpsd.rb
@@ -1,0 +1,6 @@
+class Gpsd
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/gpsd/"
+    regex(/href=.*?gpsd[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/jcal.rb
+++ b/Livecheckables/jcal.rb
@@ -1,0 +1,6 @@
+class Jcal
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/jcal/"
+    regex(/href=.*?jcal[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/kimwitu++.rb
+++ b/Livecheckables/kimwitu++.rb
@@ -1,0 +1,6 @@
+class Kimwituxx
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/kimwitu-pp/"
+    regex(/href=.*?kimwitu\+\+[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/libexosip.rb
+++ b/Livecheckables/libexosip.rb
@@ -1,0 +1,6 @@
+class Libexosip
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/exosip/"
+    regex(/href=.*?libexosip2[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/lout.rb
+++ b/Livecheckables/lout.rb
@@ -1,0 +1,6 @@
+class Lout
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/lout/"
+    regex(/href=.*?lout[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/m2c.rb
+++ b/Livecheckables/m2c.rb
@@ -1,0 +1,6 @@
+class M2c
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/m2c/"
+    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+end

--- a/Livecheckables/man-db.rb
+++ b/Livecheckables/man-db.rb
@@ -1,0 +1,6 @@
+class ManDb
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/man-db/"
+    regex(/href=.*?man-db[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/nmh.rb
+++ b/Livecheckables/nmh.rb
@@ -1,0 +1,6 @@
+class Nmh
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/nmh/"
+    regex(/href=.*?nmh[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/oath-toolkit.rb
+++ b/Livecheckables/oath-toolkit.rb
@@ -1,7 +1,6 @@
 class OathToolkit
   livecheck do
-    url "http://download.savannah.nongnu.org/releases/oath-toolkit/"
-    strategy :page_match
+    url "https://download.savannah.gnu.org/releases/oath-toolkit/"
     regex(/href=.*?oath-toolkit[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/png++.rb
+++ b/Livecheckables/png++.rb
@@ -1,0 +1,6 @@
+class Pngxx
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/pngpp/"
+    regex(/href=.*?png\+\+[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/quilt.rb
+++ b/Livecheckables/quilt.rb
@@ -1,0 +1,6 @@
+class Quilt
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/quilt/"
+    regex(/href=.*?quilt[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/renameutils.rb
+++ b/Livecheckables/renameutils.rb
@@ -1,0 +1,6 @@
+class Renameutils
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/renameutils/"
+    regex(/href=.*?renameutils[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/treecc.rb
+++ b/Livecheckables/treecc.rb
@@ -1,0 +1,6 @@
+class Treecc
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/dotgnu-pnet/"
+    regex(/href=.*?treecc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/z80asm.rb
+++ b/Livecheckables/z80asm.rb
@@ -1,0 +1,6 @@
+class Z80asm
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/z80asm/"
+    regex(/href=.*?z80asm[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -5,13 +5,14 @@ module LivecheckStrategy
     NICE_NAME = "GNU"
 
     PROJECT_NAME_REGEXES = [
-      %r{/(?:software|gnu)/(.*?)/},
-      %r{//(.*?)\.gnu\.org(?:/)?$},
+      %r{/(?:gnu|software)/(.+?)/},
+      %r{//(.+?)\.gnu\.org(?:/)?$},
     ].freeze
     private_constant :PROJECT_NAME_REGEXES
 
     def self.match?(url)
-      url.include?("gnu.org")
+      url.match?(%r{//.+?\.gnu\.org|gnu\.org/(?:gnu|software)/}i) &&
+        !url.include?("savannah.")
     end
 
     def self.find_versions(url, regex = nil)
@@ -23,7 +24,7 @@ module LivecheckStrategy
       project_name = match_list[0][1]
 
       page_url = "http://ftp.gnu.org/gnu/#{project_name}/?C=M&O=D"
-      regex ||= /#{project_name}-(\d+(?:\.\d+)*)/
+      regex ||= %r{href=.*?#{project_name}[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i
 
       PageMatch.find_versions(page_url, regex)
     end


### PR DESCRIPTION
The `Gnu` strategy was matching Savannah GNU URLs like `https://download.savannah.gnu.org/releases/avrdude/avrdude-6.3.tar.gz` but these URLs aren't compatible with the strategy.

I worked on expanding the `Gnu` strategy to account for this but it wasn't as straightforward as the existing supported URLs. For the moment, I've simply added livecheckables for all the related formulae.

I've also updated the default regex for the `Gnu` strategy, as it was matching some files that it shouldn't (diffs, patches) and giving incorrect results. The changes here bring it more in line with our current standards as well.