### PR TITLE
poppler: update url

### DIFF
--- a/Livecheckables/poppler.rb
+++ b/Livecheckables/poppler.rb
@@ -1,6 +1,6 @@
 class Poppler
   livecheck do
-    url "https://poppler.freedesktop.org/releases.html"
+    url :homepage
     regex(/href=.*?poppler[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 end


### PR DESCRIPTION
The [`poppler` homepage](https://poppler.freedesktop.org) is sufficient to find the latest version and is only around 2 KB gzipped, whereas the [`releases.html` page](https://poppler.freedesktop.org/releases.html) is around 46 KB gzipped. It never hurts to save a little data, especially when we're checking thousands of formulae.