### PR TITLE
hevea: update url and regex

### DIFF
--- a/Livecheckables/hevea.rb
+++ b/Livecheckables/hevea.rb
@@ -1,6 +1,6 @@
 class Hevea
   livecheck do
-    url :homepage
-    regex(/Current version is v?(\d+(?:\.\d+)+)\./i)
+    url "http://hevea.inria.fr/old/"
+    regex(/href=.*?hevea[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This updates the existing livecheckable for `hevea` to use the directory index page where the stable archive is located and brings the regex up to current standards.