### PR TITLE
fontconfig: update url and regex

### DIFF
--- a/Livecheckables/fontconfig.rb
+++ b/Livecheckables/fontconfig.rb
@@ -1,6 +1,6 @@
 class Fontconfig
   livecheck do
-    url :homepage
-    regex(/current stable.*? v?(\d+(?:\.\d+)+)\./i)
+    url :stable
+    regex(/href=.*?fontconfig[._-]v?(\d+\.\d+\.(?:\d|[0-8]\d+))\.t/i)
   end
 end


### PR DESCRIPTION
This updates the existing livecheckable for `fontconfig` to use the `stable` formula URL instead of the `homepage` and brings the regex up to current standards.