### PR TITLE
Gnu: update regex in match?

### DIFF
--- a/Livecheckables/cvs.rb
+++ b/Livecheckables/cvs.rb
@@ -1,7 +1,6 @@
 class Cvs
   livecheck do
     url "https://ftp.gnu.org/non-gnu/cvs/source/feature/"
-    strategy :page_match
     regex(%r{href=.*?v?(\d+(?:\.\d+)+)/}i)
   end
 end

--- a/Livecheckables/podiff.rb
+++ b/Livecheckables/podiff.rb
@@ -1,0 +1,6 @@
+class Podiff
+  livecheck do
+    url "https://download.gnu.org.ua/pub/release/podiff/"
+    regex(/href=.*?podiff[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -11,7 +11,7 @@ module LivecheckStrategy
     private_constant :PROJECT_NAME_REGEXES
 
     def self.match?(url)
-      url.match?(%r{//.+?\.gnu\.org|gnu\.org/(?:gnu|software)/}i) &&
+      url.match?(%r{//.+?\.gnu\.org$|gnu\.org/(?:gnu|software)/}i) &&
         !url.include?("savannah.")
     end
 


### PR DESCRIPTION
In updating the `Gnu` strategy's `#match?` method  in #1257, I overlooked the fact that one of the `PROJECT_NAME_REGEXES` had a trailing `$` delimiter. This is an important detail, so I've incorporated it here. This causes the `Gnu` strategy to no longer match the `cvs` and `podiff` formulae, which is a desirable change.

Before, the default check for `podiff` was trying the `Gnu` strategy but this URL isn't compatible, so it gave a `404 Not Found` error. This also adds a livecheckable for `podiff` to establish a working check.