### PR TITLE
clojure: update url and regex

### DIFF
--- a/Livecheckables/clojure.rb
+++ b/Livecheckables/clojure.rb
@@ -1,6 +1,6 @@
 class Clojure
   livecheck do
-    url "https://github.com/clojure/brew-install.git"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://clojure.org/guides/getting_started"
+    regex(/linux-install-v?(\d+(?:\.\d+)+)/i)
   end
 end

--- a/Livecheckables/clojure.rb
+++ b/Livecheckables/clojure.rb
@@ -1,6 +1,6 @@
 class Clojure
   livecheck do
-    url "https://clojure.org/guides/getting_started"
-    regex(/linux-install-v?(\d+(?:\.\d+)+)/i)
+    url "https://raw.githubusercontent.com/clojure/homebrew-tools/master/Formula/clojure.rb"
+    regex(/url ".*?clojure-tools-v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
The current livecheck is not quite right, see the comment in [here](https://github.com/Homebrew/homebrew-core/pull/59478#issue-466121012).

Updating to track down the official installation page rather than the `homebrew-tools` one

---

```
$ brew livecheck clojure
clojure : 1.10.1.645 ==> 1.10.1.561
```