### PR TITLE
Apache: update regex to current standards

### DIFF
--- a/livecheck/livecheck_strategy/apache.rb
+++ b/livecheck/livecheck_strategy/apache.rb
@@ -9,8 +9,11 @@ module LivecheckStrategy
     def self.find_versions(url, regex = nil)
       path, prefix, suffix = url.match(%r{path=(.+?)/([^/]*?)\d+(?:\.\d+)+(/|[^/]*)})[1, 3]
 
+      # Use `\.t` instead of specific tarball extensions (e.g., .tar.gz)
+      suffix.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/, "\.t")
+
       page_url = "https://archive.apache.org/dist/#{path}/"
-      regex ||= /href="#{Regexp.escape(prefix)}(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/
+      regex ||= /href=["']?#{Regexp.escape(prefix)}v?(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/
 
       PageMatch.find_versions(page_url, regex)
     end


### PR DESCRIPTION
This brings the default regex for the Apache strategy up to date with some of our current standards.

* Use `\.t` instead of specific tarball extensions (e.g., .tar.gz)
* Use `href=["']?` instead of `href="`
* Use `v?` before the numeric version matching snippet

It's worth noting that we're using `href=["']?` here as it's less explicit than `href="`. We can't use the usual `href=.*?` snippet, as it ends up matching more than it should when it comes to directory names.