### PR TITLE
Hackage: handle downloads.haskell.org URLs

### DIFF
--- a/Livecheckables/ghc.rb
+++ b/Livecheckables/ghc.rb
@@ -1,6 +1,5 @@
 class Ghc
   livecheck do
-    url "https://downloads.haskell.org/~ghc/"
-    regex(%r{href=.*?v?(\d+(?:\.\d{1,4})+)/?["' >]}i)
+    url :stable
   end
 end

--- a/livecheck/livecheck_strategy/hackage.rb
+++ b/livecheck/livecheck_strategy/hackage.rb
@@ -3,11 +3,11 @@
 module LivecheckStrategy
   class Hackage
     def self.match?(url)
-      /hackage\.haskell\.org/.match?(url)
+      /(?:downloads|hackage)\.haskell\.org/i.match?(url)
     end
 
     def self.find_versions(url, regex = nil)
-      package_name = ((url.split("/")[4]).split("-")[0..-2]).join("-")
+      /^(?<package_name>.+?)-\d+/i =~ File.basename(url)
 
       page_url = "https://hackage.haskell.org/package/#{package_name}/src"
       regex ||= %r{<h3>#{package_name}-(.*?)/?</h3>}i


### PR DESCRIPTION
This updates the `Hackage` strategy to also handle `downloads.haskell.org` URLs, which allows us to use it for `ghc`.

This also updates the way in which we identify the `package_name` to support file names like `ghc-8.10.1-src.tar.xz`. Before, we only supported file names like `Agda-2.6.1.tar.gz`, where the last hyphen we encounter is after the package name (i.e., there's no trailing `-src` after the numeric version).