### PR TITLE
Use stable for Haskell formulae

### DIFF
--- a/Livecheckables/allureofthestars.rb
+++ b/Livecheckables/allureofthestars.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class Allureofthestars
   livecheck do
     url :stable
   end

--- a/Livecheckables/bench.rb
+++ b/Livecheckables/bench.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class Bench
   livecheck do
     url :stable
   end

--- a/Livecheckables/cryptol.rb
+++ b/Livecheckables/cryptol.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class Cryptol
   livecheck do
     url :stable
   end

--- a/Livecheckables/darcs.rb
+++ b/Livecheckables/darcs.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class Darcs
   livecheck do
     url :stable
   end

--- a/Livecheckables/dhall-bash.rb
+++ b/Livecheckables/dhall-bash.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class DhallBash
   livecheck do
     url :stable
   end

--- a/Livecheckables/dhall-json.rb
+++ b/Livecheckables/dhall-json.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class DhallJson
   livecheck do
     url :stable
   end

--- a/Livecheckables/dhall-lsp-server.rb
+++ b/Livecheckables/dhall-lsp-server.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class DhallLspServer
   livecheck do
     url :stable
   end

--- a/Livecheckables/dhall-yaml.rb
+++ b/Livecheckables/dhall-yaml.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class DhallYaml
   livecheck do
     url :stable
   end

--- a/Livecheckables/dhall.rb
+++ b/Livecheckables/dhall.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class Dhall
   livecheck do
     url :stable
   end

--- a/Livecheckables/hledger.rb
+++ b/Livecheckables/hledger.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class Hledger
   livecheck do
     url :stable
   end

--- a/Livecheckables/hlint.rb
+++ b/Livecheckables/hlint.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class Hlint
   livecheck do
     url :stable
   end

--- a/Livecheckables/hopenpgp-tools.rb
+++ b/Livecheckables/hopenpgp-tools.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class HopenpgpTools
   livecheck do
     url :stable
   end

--- a/Livecheckables/mighttpd2.rb
+++ b/Livecheckables/mighttpd2.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class Mighttpd2
   livecheck do
     url :stable
   end

--- a/Livecheckables/pandoc-crossref.rb
+++ b/Livecheckables/pandoc-crossref.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class PandocCrossref
   livecheck do
     url :stable
   end

--- a/Livecheckables/pandoc-include-code.rb
+++ b/Livecheckables/pandoc-include-code.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class PandocIncludeCode
   livecheck do
     url :stable
   end

--- a/Livecheckables/pandoc.rb
+++ b/Livecheckables/pandoc.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class Pandoc
   livecheck do
     url :stable
   end

--- a/Livecheckables/purescript.rb
+++ b/Livecheckables/purescript.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class Purescript
   livecheck do
     url :stable
   end

--- a/Livecheckables/shelltestrunner.rb
+++ b/Livecheckables/shelltestrunner.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class Shelltestrunner
   livecheck do
     url :stable
   end

--- a/Livecheckables/texmath.rb
+++ b/Livecheckables/texmath.rb
@@ -1,4 +1,4 @@
-class CabalInstall
+class Texmath
   livecheck do
     url :stable
   end


### PR DESCRIPTION
Some of the Haskell formulae were checking the `head` Git repository in their formula and finding incorrect versions. Others were using the stable URL which uses `Hackage` strategy but we want to prevent this from breaking in the future if `head` is added to the formula.

In both of these cases, adding a livecheckable (or modifying an existing one) to simply use `url :stable` is appropriate.