### PR TITLE
widelands: add livecheckable

### DIFF
--- a/Livecheckables/widelands.rb
+++ b/Livecheckables/widelands.rb
@@ -1,0 +1,6 @@
+class Widelands
+  livecheck do
+    url :stable
+    regex(%r{<div class="version">\s*Latest version is [^<]*?v?(\d+(?:\.\d+)*)\s*</div>}i)
+  end
+end


### PR DESCRIPTION
The default check for `widelands` returns a version like `build21` whereas the formula uses a version of `21`. This adds a livecheckable that uses a modified version the `Launchpad` strategy regex where we only capture the numeric version.

I considered updating the `Launchpad` strategy's default regex to account for this but I figured it may cause problems in the future if we encounter stable versions with some trailing non-digit content (e.g., `1.2.3a`). I may revisit this in the future but I'm holding off for the moment.