### PR TITLE
libmetalink: update regex

### DIFF
--- a/Livecheckables/libmetalink.rb
+++ b/Livecheckables/libmetalink.rb
@@ -1,6 +1,6 @@
 class Libmetalink
   livecheck do
     url :stable
-    regex(/libmetalink[._-]v?(\d+(?:\.\d+)+)$/i)
+    regex(%r{<div class="version">\s*Latest version is libmetalink[._-]v?(\d+(?:\.\d+)+)\s*</div>}i)
   end
 end


### PR DESCRIPTION
This brings the regex in the existing livecheckable for `libmetalink` up to date with the default regex for the `Launchpad` strategy.