### PR TITLE
bzrtools: add livecheckable

### DIFF
--- a/Livecheckables/bzrtools.rb
+++ b/Livecheckables/bzrtools.rb
@@ -1,0 +1,11 @@
+class Bzrtools
+  # https://launchpad.net/bzrtools/ doesn't provide the latest version, so we
+  # can't currently use the `Launchpad` strategy for this. Instead, we have to
+  # replicate the behavior of the Launchpad strategy here while checking the
+  # `/stable/` page.
+  livecheck do
+    url "https://launchpad.net/bzrtools/stable/"
+    strategy :page_match
+    regex(%r{<div class="version">\s*Latest version is (.+)\s*</div>}i)
+  end
+end


### PR DESCRIPTION
The `Launchpad` strategy doesn't work properly for `bzrtools` by default, since https://launchpad.net/bzrtools/ lists the latest version as `2.3.0` whereas the latest version on the https://launchpad.net/bzrtools/stable/ page is `2.6.0`. The formula uses a release from `/bzrtools/stable/`, so it's necessary to check that page to find the latest version.

It may be that we can modify the `Launchpad` strategy in some way to deal with this kind of situation but this livecheckable will work for now.