### PR TITLE
Use stable for Launchpad formulae

### DIFF
--- a/Livecheckables/bazaar.rb
+++ b/Livecheckables/bazaar.rb
@@ -1,0 +1,5 @@
+class Bazaar
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/byobu.rb
+++ b/Livecheckables/byobu.rb
@@ -1,0 +1,5 @@
+class Byobu
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bzr-builder.rb
+++ b/Livecheckables/bzr-builder.rb
@@ -1,0 +1,5 @@
+class BzrBuilder
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bzr-colo.rb
+++ b/Livecheckables/bzr-colo.rb
@@ -1,0 +1,5 @@
+class BzrColo
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bzr-externals.rb
+++ b/Livecheckables/bzr-externals.rb
@@ -1,0 +1,5 @@
+class BzrExternals
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bzr-extmerge.rb
+++ b/Livecheckables/bzr-extmerge.rb
@@ -1,0 +1,5 @@
+class BzrExtmerge
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bzr-rewrite.rb
+++ b/Livecheckables/bzr-rewrite.rb
@@ -1,0 +1,5 @@
+class BzrRewrite
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bzr-upload.rb
+++ b/Livecheckables/bzr-upload.rb
@@ -1,0 +1,5 @@
+class BzrUpload
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bzr-xmloutput.rb
+++ b/Livecheckables/bzr-xmloutput.rb
@@ -1,0 +1,5 @@
+class BzrXmloutput
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/duplicity.rb
+++ b/Livecheckables/duplicity.rb
@@ -1,0 +1,5 @@
+class Duplicity
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/flowgrind.rb
+++ b/Livecheckables/flowgrind.rb
@@ -1,6 +1,6 @@
 class Flowgrind
   livecheck do
-    url :homepage
-    regex(/Latest version is flowgrind[._-]v?(\d+(?:\.\d+)+)/i)
+    url :stable
+    regex(%r{<div class="version">\s*Latest version is flowgrind[._-]v?(\d+(?:\.\d+)+)\s*</div>})
   end
 end

--- a/Livecheckables/intltool.rb
+++ b/Livecheckables/intltool.rb
@@ -1,0 +1,5 @@
+class Intltool
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libmemcached.rb
+++ b/Livecheckables/libmemcached.rb
@@ -1,0 +1,5 @@
+class Libmemcached
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pastebinit.rb
+++ b/Livecheckables/pastebinit.rb
@@ -1,0 +1,5 @@
+class Pastebinit
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pbzip2.rb
+++ b/Livecheckables/pbzip2.rb
@@ -1,0 +1,5 @@
+class Pbzip2
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pipemeter.rb
+++ b/Livecheckables/pipemeter.rb
@@ -1,0 +1,5 @@
+class Pipemeter
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/schroedinger.rb
+++ b/Livecheckables/schroedinger.rb
@@ -1,0 +1,5 @@
+class Schroedinger
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/utimer.rb
+++ b/Livecheckables/utimer.rb
@@ -1,0 +1,5 @@
+class Utimer
+  livecheck do
+    url :stable
+  end
+end


### PR DESCRIPTION
All of the formulae that are using a launchpad.net `stable` URL are currently using the `Launchpad` strategy but this formalizes this in livecheckables using `url :stable`. This prevents the checks from breaking or giving an incorrect result if `head` is added to these formula in the future.