### PR TITLE
Use stable for npm formulae

### DIFF
--- a/Livecheckables/angular-cli.rb
+++ b/Livecheckables/angular-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class AngularCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/apollo-cli.rb
+++ b/Livecheckables/apollo-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class ApolloCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/appium.rb
+++ b/Livecheckables/appium.rb
@@ -1,4 +1,4 @@
-class Insect
+class Appium
   livecheck do
     url :stable
   end

--- a/Livecheckables/ask-cli.rb
+++ b/Livecheckables/ask-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class AskCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/atomist-cli.rb
+++ b/Livecheckables/atomist-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class AtomistCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/autocode.rb
+++ b/Livecheckables/autocode.rb
@@ -1,4 +1,4 @@
-class Insect
+class Autocode
   livecheck do
     url :stable
   end

--- a/Livecheckables/autorest.rb
+++ b/Livecheckables/autorest.rb
@@ -1,4 +1,4 @@
-class Insect
+class Autorest
   livecheck do
     url :stable
   end

--- a/Livecheckables/aws-cdk.rb
+++ b/Livecheckables/aws-cdk.rb
@@ -1,4 +1,4 @@
-class Insect
+class AwsCdk
   livecheck do
     url :stable
   end

--- a/Livecheckables/babel.rb
+++ b/Livecheckables/babel.rb
@@ -1,4 +1,4 @@
-class Insect
+class Babel
   livecheck do
     url :stable
   end

--- a/Livecheckables/balena-cli.rb
+++ b/Livecheckables/balena-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class BalenaCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/bit.rb
+++ b/Livecheckables/bit.rb
@@ -1,4 +1,4 @@
-class Insect
+class Bit
   livecheck do
     url :stable
   end

--- a/Livecheckables/bitwarden-cli.rb
+++ b/Livecheckables/bitwarden-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class BitwardenCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/cash-cli.rb
+++ b/Livecheckables/cash-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class CashCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/cdk8s.rb
+++ b/Livecheckables/cdk8s.rb
@@ -1,4 +1,4 @@
-class Insect
+class Cdk8s
   livecheck do
     url :stable
   end

--- a/Livecheckables/chalk-cli.rb
+++ b/Livecheckables/chalk-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class ChalkCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/charge.rb
+++ b/Livecheckables/charge.rb
@@ -1,4 +1,4 @@
-class Insect
+class Charge
   livecheck do
     url :stable
   end

--- a/Livecheckables/code-server.rb
+++ b/Livecheckables/code-server.rb
@@ -1,4 +1,4 @@
-class Insect
+class CodeServer
   livecheck do
     url :stable
   end

--- a/Livecheckables/coffeescript.rb
+++ b/Livecheckables/coffeescript.rb
@@ -1,4 +1,4 @@
-class Insect
+class Coffeescript
   livecheck do
     url :stable
   end

--- a/Livecheckables/contentful-cli.rb
+++ b/Livecheckables/contentful-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class ContentfulCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/cubejs-cli.rb
+++ b/Livecheckables/cubejs-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class CubejsCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/eleventy.rb
+++ b/Livecheckables/eleventy.rb
@@ -1,4 +1,4 @@
-class Insect
+class Eleventy
   livecheck do
     url :stable
   end

--- a/Livecheckables/eslint.rb
+++ b/Livecheckables/eslint.rb
@@ -1,4 +1,4 @@
-class Insect
+class Eslint
   livecheck do
     url :stable
   end

--- a/Livecheckables/fauna-shell.rb
+++ b/Livecheckables/fauna-shell.rb
@@ -1,4 +1,4 @@
-class Insect
+class FaunaShell
   livecheck do
     url :stable
   end

--- a/Livecheckables/firebase-cli.rb
+++ b/Livecheckables/firebase-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class FirebaseCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/fx.rb
+++ b/Livecheckables/fx.rb
@@ -1,4 +1,4 @@
-class Insect
+class Fx
   livecheck do
     url :stable
   end

--- a/Livecheckables/gatsby-cli.rb
+++ b/Livecheckables/gatsby-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class GatsbyCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/generate-json-schema.rb
+++ b/Livecheckables/generate-json-schema.rb
@@ -1,4 +1,4 @@
-class Insect
+class GenerateJsonSchema
   livecheck do
     url :stable
   end

--- a/Livecheckables/gitmoji.rb
+++ b/Livecheckables/gitmoji.rb
@@ -1,4 +1,4 @@
-class Insect
+class Gitmoji
   livecheck do
     url :stable
   end

--- a/Livecheckables/graphql-cli.rb
+++ b/Livecheckables/graphql-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class GraphqlCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/grunt-cli.rb
+++ b/Livecheckables/grunt-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class GruntCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/gulp-cli.rb
+++ b/Livecheckables/gulp-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class GulpCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/http-server.rb
+++ b/Livecheckables/http-server.rb
@@ -1,4 +1,4 @@
-class Insect
+class HttpServer
   livecheck do
     url :stable
   end

--- a/Livecheckables/jhipster.rb
+++ b/Livecheckables/jhipster.rb
@@ -1,4 +1,4 @@
-class Insect
+class Jhipster
   livecheck do
     url :stable
   end

--- a/Livecheckables/joplin.rb
+++ b/Livecheckables/joplin.rb
@@ -1,4 +1,4 @@
-class Insect
+class Joplin
   livecheck do
     url :stable
   end

--- a/Livecheckables/jsdoc3.rb
+++ b/Livecheckables/jsdoc3.rb
@@ -1,4 +1,4 @@
-class Insect
+class Jsdoc3
   livecheck do
     url :stable
   end

--- a/Livecheckables/lerna.rb
+++ b/Livecheckables/lerna.rb
@@ -1,4 +1,4 @@
-class Insect
+class Lerna
   livecheck do
     url :stable
   end

--- a/Livecheckables/marked.rb
+++ b/Livecheckables/marked.rb
@@ -1,4 +1,4 @@
-class Insect
+class Marked
   livecheck do
     url :stable
   end

--- a/Livecheckables/nativefier.rb
+++ b/Livecheckables/nativefier.rb
@@ -1,4 +1,4 @@
-class Insect
+class Nativefier
   livecheck do
     url :stable
   end

--- a/Livecheckables/netlify-cli.rb
+++ b/Livecheckables/netlify-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class NetlifyCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/newman.rb
+++ b/Livecheckables/newman.rb
@@ -1,4 +1,4 @@
-class Insect
+class Newman
   livecheck do
     url :stable
   end

--- a/Livecheckables/node-sass.rb
+++ b/Livecheckables/node-sass.rb
@@ -1,4 +1,4 @@
-class Insect
+class NodeSass
   livecheck do
     url :stable
   end

--- a/Livecheckables/now-cli.rb
+++ b/Livecheckables/now-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class NowCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/pnpm.rb
+++ b/Livecheckables/pnpm.rb
@@ -1,4 +1,4 @@
-class Insect
+class Pnpm
   livecheck do
     url :stable
   end

--- a/Livecheckables/prettier.rb
+++ b/Livecheckables/prettier.rb
@@ -1,4 +1,4 @@
-class Insect
+class Prettier
   livecheck do
     url :stable
   end

--- a/Livecheckables/pulp.rb
+++ b/Livecheckables/pulp.rb
@@ -1,4 +1,4 @@
-class Insect
+class Pulp
   livecheck do
     url :stable
   end

--- a/Livecheckables/quicktype.rb
+++ b/Livecheckables/quicktype.rb
@@ -1,4 +1,4 @@
-class Insect
+class Quicktype
   livecheck do
     url :stable
   end

--- a/Livecheckables/react-native-cli.rb
+++ b/Livecheckables/react-native-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class ReactNativeCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/sloc.rb
+++ b/Livecheckables/sloc.rb
@@ -1,4 +1,4 @@
-class Insect
+class Sloc
   livecheck do
     url :stable
   end

--- a/Livecheckables/tdkjs.rb
+++ b/Livecheckables/tdkjs.rb
@@ -1,4 +1,4 @@
-class Insect
+class Tdkjs
   livecheck do
     url :stable
   end

--- a/Livecheckables/terrahub.rb
+++ b/Livecheckables/terrahub.rb
@@ -1,4 +1,4 @@
-class Insect
+class Terrahub
   livecheck do
     url :stable
   end

--- a/Livecheckables/triton.rb
+++ b/Livecheckables/triton.rb
@@ -1,4 +1,4 @@
-class Insect
+class Triton
   livecheck do
     url :stable
   end

--- a/Livecheckables/typescript.rb
+++ b/Livecheckables/typescript.rb
@@ -1,4 +1,4 @@
-class Insect
+class Typescript
   livecheck do
     url :stable
   end

--- a/Livecheckables/ungit.rb
+++ b/Livecheckables/ungit.rb
@@ -1,4 +1,4 @@
-class Insect
+class Ungit
   livecheck do
     url :stable
   end

--- a/Livecheckables/webpack.rb
+++ b/Livecheckables/webpack.rb
@@ -1,4 +1,4 @@
-class Insect
+class Webpack
   livecheck do
     url :stable
   end

--- a/Livecheckables/webtorrent-cli.rb
+++ b/Livecheckables/webtorrent-cli.rb
@@ -1,4 +1,4 @@
-class Insect
+class WebtorrentCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/whistle.rb
+++ b/Livecheckables/whistle.rb
@@ -1,4 +1,4 @@
-class Insect
+class Whistle
   livecheck do
     url :stable
   end

--- a/Livecheckables/write-good.rb
+++ b/Livecheckables/write-good.rb
@@ -1,4 +1,4 @@
-class Insect
+class WriteGood
   livecheck do
     url :stable
   end


### PR DESCRIPTION
A number of the formulae with an npm.org `stable` URL were checking `head` URLs by default. In one case (`quicktype`), the newest version reported by livecheck was older than the actual newest version (on npm).

Other formulae without a livecheckable or `head` URL were using the `stable` URL, which uses the `Npm` strategy. However, we don't want these to break (or return an incorrect version as newest) if `head` is added to the formula in the future.

In both of these cases, adding a livecheckable (or modifying an existing one) to simply use `url :stable` is appropriate.