### PR TITLE
Pypi: replace spaces in package_name with hyphens

### DIFF
--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -10,6 +10,7 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex = nil)
       package_name = url[%r{https://files.pythonhosted.org/packages/.*/.*/(.*)-.*}, 1]
+      package_name.gsub!("%20", "-")
 
       page_url = "https://pypi.org/project/#{package_name}"
       regex ||= /#{package_name} ([0-9.]+)/


### PR DESCRIPTION
This modifies the `Pypi` strategy to replace URL-encoded spaces (i.e., `%20`) in the `package_name` string with hyphens. This only affects one formula at the moment, which is `gimme-aws-creds`.

The file name in the stable URL of the `gimme-aws-creds` formula is like `gimme%20aws%20creds-2.3.4.tar.gz`, so the `package_name` string is `gimme%20aws%20creds`. This is a problem because it's used in the URL (and regex), leading to a 404 because this part of the URL should be `gimme-aws-creds`. The changes here resolve this situation and fix the broken check.

As usual, I did a comparison of the output without and with this change and the only affected formula was `gimme-aws-creds`, as described above.