### PR TITLE
weboob: add livecheckable

### DIFF
--- a/Livecheckables/weboob.rb
+++ b/Livecheckables/weboob.rb
@@ -1,0 +1,6 @@
+class Weboob
+  livecheck do
+    url "https://git.weboob.org/weboob/weboob.git"
+    regex(/^v?(\d+(?:\.(?:\d+|[a-z])+))$/i)
+  end
+end


### PR DESCRIPTION
Livecheck can't identify versions for `weboob` by default, so this adds a livecheckable which checks the upstream Git repository (where the stable archive comes from).