### PR TITLE
Use stable for PyPI formulae

### DIFF
--- a/Livecheckables/airshare.rb
+++ b/Livecheckables/airshare.rb
@@ -1,0 +1,5 @@
+class Airshare
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/anime-downloader.rb
+++ b/Livecheckables/anime-downloader.rb
@@ -1,0 +1,5 @@
+class AnimeDownloader
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ansible-lint.rb
+++ b/Livecheckables/ansible-lint.rb
@@ -1,6 +1,5 @@
 class AnsibleLint
   livecheck do
     url :stable
-    regex(/href=.*?ansible-lint[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/asciinema.rb
+++ b/Livecheckables/asciinema.rb
@@ -1,0 +1,5 @@
+class Asciinema
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/atdtool.rb
+++ b/Livecheckables/atdtool.rb
@@ -1,0 +1,5 @@
+class Atdtool
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/athenacli.rb
+++ b/Livecheckables/athenacli.rb
@@ -1,0 +1,5 @@
+class Athenacli
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/autopep8.rb
+++ b/Livecheckables/autopep8.rb
@@ -1,0 +1,5 @@
+class Autopep8
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/aws-elasticbeanstalk.rb
+++ b/Livecheckables/aws-elasticbeanstalk.rb
@@ -1,6 +1,5 @@
 class AwsElasticbeanstalk
   livecheck do
     url :stable
-    regex(/href=.*?awsebcli[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/aws-shell.rb
+++ b/Livecheckables/aws-shell.rb
@@ -1,0 +1,5 @@
+class AwsShell
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/awslogs.rb
+++ b/Livecheckables/awslogs.rb
@@ -1,0 +1,5 @@
+class Awslogs
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bagit.rb
+++ b/Livecheckables/bagit.rb
@@ -1,0 +1,5 @@
+class Bagit
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/beancount.rb
+++ b/Livecheckables/beancount.rb
@@ -1,0 +1,5 @@
+class Beancount
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/black.rb
+++ b/Livecheckables/black.rb
@@ -1,6 +1,6 @@
 class Black
   livecheck do
     url :stable
-    regex(/black (\d+\.\d+(b\d+)?)/i)
+    regex(%r{href=.*?/packages.*?/black[._-]v?(\d+(?:\.\d+)*(?:[a-z]\d+)?)\.t}i)
   end
 end

--- a/Livecheckables/borgmatic.rb
+++ b/Livecheckables/borgmatic.rb
@@ -1,0 +1,5 @@
+class Borgmatic
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/breezy.rb
+++ b/Livecheckables/breezy.rb
@@ -1,0 +1,5 @@
+class Breezy
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bzt.rb
+++ b/Livecheckables/bzt.rb
@@ -1,6 +1,5 @@
 class Bzt
   livecheck do
     url :stable
-    regex(/href=.*?bzt[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/ccm.rb
+++ b/Livecheckables/ccm.rb
@@ -1,6 +1,5 @@
 class Ccm
   livecheck do
     url :stable
-    regex(%r{href=.*?/ccm[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/cfn-lint.rb
+++ b/Livecheckables/cfn-lint.rb
@@ -1,0 +1,5 @@
+class CfnLint
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/charm-tools.rb
+++ b/Livecheckables/charm-tools.rb
@@ -1,6 +1,5 @@
 class CharmTools
   livecheck do
     url :stable
-    regex(/href=.*?charm-tools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/cloudformation-cli.rb
+++ b/Livecheckables/cloudformation-cli.rb
@@ -1,0 +1,5 @@
+class CloudformationCli
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/coconut.rb
+++ b/Livecheckables/coconut.rb
@@ -1,0 +1,5 @@
+class Coconut
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/codemod.rb
+++ b/Livecheckables/codemod.rb
@@ -1,6 +1,5 @@
 class Codemod
   livecheck do
     url :stable
-    regex(/href=.*?codemod[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/codespell.rb
+++ b/Livecheckables/codespell.rb
@@ -1,0 +1,5 @@
+class Codespell
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/cppman.rb
+++ b/Livecheckables/cppman.rb
@@ -1,0 +1,5 @@
+class Cppman
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/csvkit.rb
+++ b/Livecheckables/csvkit.rb
@@ -1,6 +1,5 @@
 class Csvkit
   livecheck do
     url :stable
-    regex(/href=.*?csvkit[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/csvtomd.rb
+++ b/Livecheckables/csvtomd.rb
@@ -1,0 +1,5 @@
+class Csvtomd
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/cython.rb
+++ b/Livecheckables/cython.rb
@@ -1,6 +1,5 @@
 class Cython
   livecheck do
     url :stable
-    regex(/href=.*?Cython[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/datasette.rb
+++ b/Livecheckables/datasette.rb
@@ -1,0 +1,5 @@
+class Datasette
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/diffoscope.rb
+++ b/Livecheckables/diffoscope.rb
@@ -1,0 +1,5 @@
+class Diffoscope
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dnsviz.rb
+++ b/Livecheckables/dnsviz.rb
@@ -1,0 +1,5 @@
+class Dnsviz
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/docker-squash.rb
+++ b/Livecheckables/docker-squash.rb
@@ -1,0 +1,5 @@
+class DockerSquash
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/doitlive.rb
+++ b/Livecheckables/doitlive.rb
@@ -1,6 +1,5 @@
 class Doitlive
   livecheck do
     url :stable
-    regex(/href=.*?doitlive[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dxpy.rb
+++ b/Livecheckables/dxpy.rb
@@ -1,6 +1,5 @@
 class Dxpy
   livecheck do
     url :stable
-    regex(/href=.*?dxpy[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/eg-examples.rb
+++ b/Livecheckables/eg-examples.rb
@@ -1,0 +1,5 @@
+class EgExamples
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/eralchemy.rb
+++ b/Livecheckables/eralchemy.rb
@@ -1,6 +1,5 @@
 class Eralchemy
   livecheck do
     url :stable
-    regex(/href=.*?ERAlchemy[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/fades.rb
+++ b/Livecheckables/fades.rb
@@ -1,0 +1,5 @@
+class Fades
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/fava.rb
+++ b/Livecheckables/fava.rb
@@ -1,0 +1,5 @@
+class Fava
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/fdroidserver.rb
+++ b/Livecheckables/fdroidserver.rb
@@ -1,5 +1,5 @@
 class Fdroidserver
   livecheck do
-    url "https://gitlab.com/fdroid/fdroidserver.git"
+    url :stable
   end
 end

--- a/Livecheckables/flintrock.rb
+++ b/Livecheckables/flintrock.rb
@@ -1,0 +1,5 @@
+class Flintrock
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/fobis.rb
+++ b/Livecheckables/fobis.rb
@@ -1,0 +1,5 @@
+class Fobis
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gandi.cli.rb
+++ b/Livecheckables/gandi.cli.rb
@@ -1,0 +1,5 @@
+class GandiCli
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gdbgui.rb
+++ b/Livecheckables/gdbgui.rb
@@ -1,0 +1,5 @@
+class Gdbgui
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gimme-aws-creds.rb
+++ b/Livecheckables/gimme-aws-creds.rb
@@ -1,0 +1,5 @@
+class GimmeAwsCreds
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/git-review.rb
+++ b/Livecheckables/git-review.rb
@@ -1,0 +1,5 @@
+class GitReview
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/goolabs.rb
+++ b/Livecheckables/goolabs.rb
@@ -1,0 +1,5 @@
+class Goolabs
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gprof2dot.rb
+++ b/Livecheckables/gprof2dot.rb
@@ -1,0 +1,5 @@
+class Gprof2dot
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/grip.rb
+++ b/Livecheckables/grip.rb
@@ -1,0 +1,5 @@
+class Grip
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/homeassistant-cli.rb
+++ b/Livecheckables/homeassistant-cli.rb
@@ -1,6 +1,5 @@
 class HomeassistantCli
   livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url :stable
   end
 end

--- a/Livecheckables/howdoi.rb
+++ b/Livecheckables/howdoi.rb
@@ -1,0 +1,5 @@
+class Howdoi
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/httpie.rb
+++ b/Livecheckables/httpie.rb
@@ -1,0 +1,5 @@
+class Httpie
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/hy.rb
+++ b/Livecheckables/hy.rb
@@ -1,0 +1,5 @@
+class Hy
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/instalooter.rb
+++ b/Livecheckables/instalooter.rb
@@ -1,0 +1,5 @@
+class Instalooter
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/internetarchive.rb
+++ b/Livecheckables/internetarchive.rb
@@ -1,0 +1,5 @@
+class Internetarchive
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ipython.rb
+++ b/Livecheckables/ipython.rb
@@ -1,0 +1,5 @@
+class Ipython
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/jc.rb
+++ b/Livecheckables/jc.rb
@@ -1,0 +1,5 @@
+class Jc
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/jenkins-job-builder.rb
+++ b/Livecheckables/jenkins-job-builder.rb
@@ -1,6 +1,5 @@
 class JenkinsJobBuilder
   livecheck do
     url :stable
-    regex(/href=.*?jenkins-job-builder[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/jinja2-cli.rb
+++ b/Livecheckables/jinja2-cli.rb
@@ -1,0 +1,5 @@
+class Jinja2Cli
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/jrnl.rb
+++ b/Livecheckables/jrnl.rb
@@ -1,0 +1,5 @@
+class Jrnl
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/juju-wait.rb
+++ b/Livecheckables/juju-wait.rb
@@ -1,0 +1,5 @@
+class JujuWait
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/jupyterlab.rb
+++ b/Livecheckables/jupyterlab.rb
@@ -1,0 +1,5 @@
+class Jupyterlab
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/keepassc.rb
+++ b/Livecheckables/keepassc.rb
@@ -1,6 +1,5 @@
 class Keepassc
   livecheck do
     url :stable
-    regex(/href=.*?keepassc[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/keepkey-agent.rb
+++ b/Livecheckables/keepkey-agent.rb
@@ -1,6 +1,5 @@
 class KeepkeyAgent
   livecheck do
     url :stable
-    regex(/href=.*?keepkey_agent[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/khal.rb
+++ b/Livecheckables/khal.rb
@@ -1,0 +1,5 @@
+class Khal
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/khard.rb
+++ b/Livecheckables/khard.rb
@@ -1,0 +1,5 @@
+class Khard
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/legit.rb
+++ b/Livecheckables/legit.rb
@@ -1,0 +1,6 @@
+class Legit
+  livecheck do
+    url :stable
+    regex(%r{href=.*?/packages.*?/legit[._-]v?(\d+(?:\.\d+)*(?:[._-]?post\d+)?)\.t}i)
+  end
+end

--- a/Livecheckables/liquidctl.rb
+++ b/Livecheckables/liquidctl.rb
@@ -1,0 +1,5 @@
+class Liquidctl
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/litecli.rb
+++ b/Livecheckables/litecli.rb
@@ -1,0 +1,5 @@
+class Litecli
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/livestreamer.rb
+++ b/Livecheckables/livestreamer.rb
@@ -1,0 +1,5 @@
+class Livestreamer
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/lizard-analyzer.rb
+++ b/Livecheckables/lizard-analyzer.rb
@@ -1,0 +1,5 @@
+class LizardAnalyzer
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/magic-wormhole.rb
+++ b/Livecheckables/magic-wormhole.rb
@@ -1,0 +1,5 @@
+class MagicWormhole
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mdv.rb
+++ b/Livecheckables/mdv.rb
@@ -1,0 +1,5 @@
+class Mdv
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mkdocs.rb
+++ b/Livecheckables/mkdocs.rb
@@ -1,0 +1,5 @@
+class Mkdocs
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/molecule.rb
+++ b/Livecheckables/molecule.rb
@@ -1,0 +1,5 @@
+class Molecule
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mongo-orchestration.rb
+++ b/Livecheckables/mongo-orchestration.rb
@@ -1,0 +1,5 @@
+class MongoOrchestration
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mycli.rb
+++ b/Livecheckables/mycli.rb
@@ -1,0 +1,5 @@
+class Mycli
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/nbdime.rb
+++ b/Livecheckables/nbdime.rb
@@ -1,0 +1,5 @@
+class Nbdime
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/notifiers.rb
+++ b/Livecheckables/notifiers.rb
@@ -1,0 +1,5 @@
+class Notifiers
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/numpy.rb
+++ b/Livecheckables/numpy.rb
@@ -1,0 +1,5 @@
+class Numpy
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/nyx.rb
+++ b/Livecheckables/nyx.rb
@@ -1,0 +1,5 @@
+class Nyx
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ocrmypdf.rb
+++ b/Livecheckables/ocrmypdf.rb
@@ -1,6 +1,5 @@
 class Ocrmypdf
   livecheck do
     url :stable
-    regex(/href=.*?ocrmypdf[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/offlineimap.rb
+++ b/Livecheckables/offlineimap.rb
@@ -1,0 +1,5 @@
+class Offlineimap
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ooniprobe.rb
+++ b/Livecheckables/ooniprobe.rb
@@ -1,0 +1,5 @@
+class Ooniprobe
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/openstackclient.rb
+++ b/Livecheckables/openstackclient.rb
@@ -1,0 +1,5 @@
+class Openstackclient
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/passpie.rb
+++ b/Livecheckables/passpie.rb
@@ -1,0 +1,5 @@
+class Passpie
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/peru.rb
+++ b/Livecheckables/peru.rb
@@ -1,0 +1,5 @@
+class Peru
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pgcli.rb
+++ b/Livecheckables/pgcli.rb
@@ -1,6 +1,5 @@
 class Pgcli
   livecheck do
     url :stable
-    regex(/href=.*?pgcli[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pipenv.rb
+++ b/Livecheckables/pipenv.rb
@@ -1,6 +1,5 @@
 class Pipenv
   livecheck do
     url :stable
-    regex(/href=.*?pipenv[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/pipgrip.rb
+++ b/Livecheckables/pipgrip.rb
@@ -1,0 +1,5 @@
+class Pipgrip
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pipx.rb
+++ b/Livecheckables/pipx.rb
@@ -1,0 +1,5 @@
+class Pipx
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/platformio.rb
+++ b/Livecheckables/platformio.rb
@@ -1,0 +1,5 @@
+class Platformio
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/poetry.rb
+++ b/Livecheckables/poetry.rb
@@ -1,0 +1,5 @@
+class Poetry
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/proselint.rb
+++ b/Livecheckables/proselint.rb
@@ -1,0 +1,5 @@
+class Proselint
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pwntools.rb
+++ b/Livecheckables/pwntools.rb
@@ -1,0 +1,5 @@
+class Pwntools
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pygitup.rb
+++ b/Livecheckables/pygitup.rb
@@ -1,0 +1,5 @@
+class Pygitup
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pygments.rb
+++ b/Livecheckables/pygments.rb
@@ -1,0 +1,5 @@
+class Pygments
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pyinstaller.rb
+++ b/Livecheckables/pyinstaller.rb
@@ -1,0 +1,5 @@
+class Pyinstaller
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pylint.rb
+++ b/Livecheckables/pylint.rb
@@ -1,0 +1,5 @@
+class Pylint
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pympress.rb
+++ b/Livecheckables/pympress.rb
@@ -1,0 +1,5 @@
+class Pympress
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pyqt.rb
+++ b/Livecheckables/pyqt.rb
@@ -1,0 +1,5 @@
+class Pyqt
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/python-markdown.rb
+++ b/Livecheckables/python-markdown.rb
@@ -1,0 +1,5 @@
+class PythonMarkdown
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/python-yq.rb
+++ b/Livecheckables/python-yq.rb
@@ -1,0 +1,5 @@
+class PythonYq
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pyvim.rb
+++ b/Livecheckables/pyvim.rb
@@ -1,0 +1,5 @@
+class Pyvim
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/rbtools.rb
+++ b/Livecheckables/rbtools.rb
@@ -1,0 +1,5 @@
+class Rbtools
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/remarshal.rb
+++ b/Livecheckables/remarshal.rb
@@ -1,0 +1,5 @@
+class Remarshal
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/s3cmd.rb
+++ b/Livecheckables/s3cmd.rb
@@ -1,0 +1,5 @@
+class S3cmd
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/salt.rb
+++ b/Livecheckables/salt.rb
@@ -1,0 +1,5 @@
+class Salt
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/sceptre.rb
+++ b/Livecheckables/sceptre.rb
@@ -1,0 +1,5 @@
+class Sceptre
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/scipy.rb
+++ b/Livecheckables/scipy.rb
@@ -1,0 +1,5 @@
+class Scipy
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/scons.rb
+++ b/Livecheckables/scons.rb
@@ -1,0 +1,5 @@
+class Scons
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/shyaml.rb
+++ b/Livecheckables/shyaml.rb
@@ -1,0 +1,5 @@
+class Shyaml
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/snakemake.rb
+++ b/Livecheckables/snakemake.rb
@@ -1,0 +1,5 @@
+class Snakemake
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/sphinx-doc.rb
+++ b/Livecheckables/sphinx-doc.rb
@@ -1,0 +1,5 @@
+class SphinxDoc
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/spoof-mac.rb
+++ b/Livecheckables/spoof-mac.rb
@@ -1,0 +1,5 @@
+class SpoofMac
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/sqlparse.rb
+++ b/Livecheckables/sqlparse.rb
@@ -1,0 +1,5 @@
+class Sqlparse
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/stormssh.rb
+++ b/Livecheckables/stormssh.rb
@@ -1,0 +1,5 @@
+class Stormssh
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/subliminal.rb
+++ b/Livecheckables/subliminal.rb
@@ -1,0 +1,5 @@
+class Subliminal
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/svtplay-dl.rb
+++ b/Livecheckables/svtplay-dl.rb
@@ -1,0 +1,5 @@
+class SvtplayDl
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/thefuck.rb
+++ b/Livecheckables/thefuck.rb
@@ -1,0 +1,5 @@
+class Thefuck
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/todoman.rb
+++ b/Livecheckables/todoman.rb
@@ -1,0 +1,5 @@
+class Todoman
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/tox.rb
+++ b/Livecheckables/tox.rb
@@ -1,6 +1,5 @@
 class Tox
   livecheck do
     url :stable
-    regex(/href=.*?tox[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/tvnamer.rb
+++ b/Livecheckables/tvnamer.rb
@@ -1,0 +1,5 @@
+class Tvnamer
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/twarc.rb
+++ b/Livecheckables/twarc.rb
@@ -1,0 +1,5 @@
+class Twarc
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/twine-pypi.rb
+++ b/Livecheckables/twine-pypi.rb
@@ -1,0 +1,5 @@
+class TwinePypi
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/txt2tags.rb
+++ b/Livecheckables/txt2tags.rb
@@ -1,0 +1,5 @@
+class Txt2tags
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/unoconv.rb
+++ b/Livecheckables/unoconv.rb
@@ -1,0 +1,5 @@
+class Unoconv
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/urh.rb
+++ b/Livecheckables/urh.rb
@@ -1,0 +1,5 @@
+class Urh
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/vsts-cli.rb
+++ b/Livecheckables/vsts-cli.rb
@@ -1,0 +1,5 @@
+class VstsCli
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/wakatime-cli.rb
+++ b/Livecheckables/wakatime-cli.rb
@@ -1,0 +1,5 @@
+class WakatimeCli
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/watson.rb
+++ b/Livecheckables/watson.rb
@@ -1,0 +1,5 @@
+class Watson
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/wxpython.rb
+++ b/Livecheckables/wxpython.rb
@@ -1,0 +1,6 @@
+class Wxpython
+  livecheck do
+    url :stable
+    regex(%r{href=.*?/packages.*?/wxpython[._-]v?(\d+(?:\.\d+)*(?:[._-]?post\d+)?)\.t}i)
+  end
+end

--- a/Livecheckables/xdot.rb
+++ b/Livecheckables/xdot.rb
@@ -1,0 +1,5 @@
+class Xdot
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/xxh.rb
+++ b/Livecheckables/xxh.rb
@@ -1,0 +1,5 @@
+class Xxh
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/yapf.rb
+++ b/Livecheckables/yapf.rb
@@ -1,0 +1,5 @@
+class Yapf
+  livecheck do
+    url :stable
+  end
+end


### PR DESCRIPTION
A number of the formulae with a files.pythonhosted.org `stable` URL were checking `head` URLs by default. 

Other formulae without a livecheckable or `head` URL were using the `stable` URL, which uses the `Pypi` strategy. However, we don't want these to break (or return an incorrect version as newest) if `head` is added to the formula in the future.

In both of these cases, adding a livecheckable (or modifying an existing one) to use `url :stable` is appropriate. In some of the existing livecheckables, the regex wasn't necessary and could be removed. In others, it was necessary to add a regex to match an unusual version format.

There are a few other formulae (`git-plus`, `pwncat`, `trezor-agent`) that need this treatment but I'll be handling these in a follow-up PR that modifies the `Pypi` strategy's default regex. These particular formulae need the regex changes to be able to make a proper match and couldn't be included here.