### PR TITLE
Pypi: update page_url and regex creation

### DIFF
--- a/Livecheckables/git-plus.rb
+++ b/Livecheckables/git-plus.rb
@@ -1,0 +1,5 @@
+class GitPlus
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pwncat.rb
+++ b/Livecheckables/pwncat.rb
@@ -1,6 +1,5 @@
 class Pwncat
   livecheck do
     url :stable
-    regex(/href=.*?pwncat[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/trezor-agent.rb
+++ b/Livecheckables/trezor-agent.rb
@@ -1,0 +1,5 @@
+class TrezorAgent
+  livecheck do
+    url :stable
+  end
+end

--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -9,11 +9,14 @@ module LivecheckStrategy
     end
 
     def self.find_versions(url, regex = nil)
-      package_name = url[%r{https://files.pythonhosted.org/packages/.*/.*/(.*)-.*}, 1]
-      package_name.gsub!(/%20|_/, "-")
+      /(?<package_name>.*)-.*?
+       (?<filename_end>\.tar\.[a-z0=9]+|\.[a-z0-9]+)$/ix =~ File.basename(url)
 
-      page_url = "https://pypi.org/project/#{package_name}"
-      regex ||= /#{package_name} ([0-9.]+)/
+      # Use `\.t` instead of specific tarball extensions (e.g., .tar.gz)
+      filename_end.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/, "\.t")
+
+      page_url = "https://pypi.org/project/#{package_name.gsub(/%20|_/, "-")}"
+      regex ||= %r{href=.*?/packages.*?/#{package_name}[._-]v?(\d+(?:\.\d+)*)#{filename_end}}i
 
       PageMatch.find_versions(page_url, regex)
     end

--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -10,7 +10,7 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex = nil)
       package_name = url[%r{https://files.pythonhosted.org/packages/.*/.*/(.*)-.*}, 1]
-      package_name.gsub!("%20", "-")
+      package_name.gsub!(/%20|_/, "-")
 
       page_url = "https://pypi.org/project/#{package_name}"
       regex ||= /#{package_name} ([0-9.]+)/


### PR DESCRIPTION
This makes some changes to the `Pypi` strategy that resolve issues with specific formulae while bringing it more up to date with current regex standards.

* Use named capture groups to identify the package name and file name extension.
* Use `\.t` instead of specific tarball extensions (e.g., .tar.gz), as found in other strategies.
* Replace URL-encoded spaces (`%20`) and underscores in the package name with a hyphen but only for the`page_url`. We only do the replacement in the `page_url` because we need the original `package_name` for the default `regex`.
* Update the default regex to bring it up to current standards.

The `git-plus`, `pwncat`, and `trezor-agent` changes here depend on these changes, so I've included them here to wrap up livecheckable changes on the `Pypi` formulae.