### PR TITLE
Use #blank? instead of #empty?

### DIFF
--- a/livecheck/livecheck_strategy/git.rb
+++ b/livecheck/livecheck_strategy/git.rb
@@ -12,8 +12,8 @@ module LivecheckStrategy
       )
 
       tags_data = { tags: [] }
-      tags_data[:messages] = stderr_str.split("\n") unless stderr_str.empty?
-      return tags_data if stdout_str.empty?
+      tags_data[:messages] = stderr_str.split("\n") unless stderr_str.blank?
+      return tags_data if stdout_str.blank?
 
       stdout_str.gsub!(%r{^.*\trefs/tags/}, "")
       stdout_str.delete_suffix!("^{}")
@@ -37,7 +37,7 @@ module LivecheckStrategy
 
       if tags_data.key?(:messages)
         match_data[:messages] = tags_data[:messages]
-        return match_data if tags_data[:tags].empty?
+        return match_data if tags_data[:tags].blank?
       end
 
       tags_only_debian = tags_data[:tags].all? { |tag| tag.start_with?("debian/") }

--- a/livecheck/livecheck_strategy/gnu.rb
+++ b/livecheck/livecheck_strategy/gnu.rb
@@ -17,7 +17,7 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex = nil)
       match_list = PROJECT_NAME_REGEXES.map { |r| url.match(r) }.compact
-      return { matches: {}, regex: regex, url: url } if match_list.empty?
+      return { matches: {}, regex: regex, url: url } if match_list.blank?
 
       odebug "\nMultiple project names found: #{match_list}\n" if match_list.length > 1
 


### PR DESCRIPTION
This integrates the replacement of `#empty?` with `#blank?` found in the Homebrew/brew migration strategies PR. This should make it ever-so-slightly easier to integrate strategy changes from this repository into that PR in the near future.