### PR TITLE
Pypi: fix typo in regex

### DIFF
--- a/livecheck/livecheck_strategy/pypi.rb
+++ b/livecheck/livecheck_strategy/pypi.rb
@@ -10,7 +10,7 @@ module LivecheckStrategy
 
     def self.find_versions(url, regex = nil)
       /(?<package_name>.*)-.*?
-       (?<filename_end>\.tar\.[a-z0=9]+|\.[a-z0-9]+)$/ix =~ File.basename(url)
+       (?<filename_end>\.tar\.[a-z0-9]+|\.[a-z0-9]+)$/ix =~ File.basename(url)
 
       # Use `\.t` instead of specific tarball extensions (e.g., .tar.gz)
       filename_end.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/, "\.t")


### PR DESCRIPTION
There was a small typo in the `Pypi` strategy's regex for extracting parts of the URL, where `0=9` was used instead of `0-9` in a character class.