### PR TITLE
amap: add livecheckable

### DIFF
--- a/Livecheckables/amap.rb
+++ b/Livecheckables/amap.rb
@@ -1,0 +1,7 @@
+class Amap
+  livecheck do
+    url "https://github.com/vanhauser-thc/THC-Archive/tree/master/Tools/"
+    strategy :page_match
+    regex(%r{href=.*?/amap[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
+end


### PR DESCRIPTION
This adds a livecheckable for `amap` which checks the page for the "Tools" directory of the GitHub repository where the `stable` archive comes from. The THC-Archive repository's "Tools" directory simply contains archive files for various tools, so we can't check the Git repo tags or releases for versions like we would normally do.