### PR TITLE
geomview: add livecheckable

### DIFF
--- a/Livecheckables/geomview.rb
+++ b/Livecheckables/geomview.rb
@@ -1,0 +1,6 @@
+class Geomview
+  livecheck do
+    url "https://deb.debian.org/debian/pool/main/g/geomview/"
+    regex(/href=.*?geomview[._-]v?(\d+(?:\.\d+)+)(?:\.orig)?\.t/i)
+  end
+end


### PR DESCRIPTION
This adds a livecheckable for `geomview` which checks the Debian directory index where the `stable` archive is found.