### PR TITLE
Add/update node livecheckables

### DIFF
--- a/Livecheckables/node.rb
+++ b/Livecheckables/node.rb
@@ -1,0 +1,6 @@
+class Node
+  livecheck do
+    url "https://nodejs.org/dist/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+end

--- a/Livecheckables/node@10.rb
+++ b/Livecheckables/node@10.rb
@@ -1,6 +1,6 @@
 class NodeAT10
   livecheck do
-    url "https://nodejs.org/en/download/releases/"
-    regex(%r{<td data-label="Version">Node.js v?(10(?:\.\d+)+)</td>}i)
+    url "https://nodejs.org/dist/"
+    regex(%r{href=["']?v?(10(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/node@12.rb
+++ b/Livecheckables/node@12.rb
@@ -1,6 +1,6 @@
 class NodeAT12
   livecheck do
     url "https://nodejs.org/dist/"
-    regex(%r{href=.*?v?(12(?:\.\d+){2})/?["' >]}i)
+    regex(%r{href=["']?v?(12(?:\.\d+)+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
This adds a livecheckable for `node` which checks the `https://nodejs.org/dist/` directory index page and updates the existing `node@10` and `node@12` livecheckables to do the same thing (updating the URL and/or regex).