### PR TITLE
abook: add livecheckable

### DIFF
--- a/Livecheckables/abook.rb
+++ b/Livecheckables/abook.rb
@@ -1,0 +1,7 @@
+class Abook
+  livecheck do
+    url "http://abook.sourceforge.net/"
+    strategy :page_match
+    regex(/href=.*?abook[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
This adds a livecheckable for `abook` which checks the homepage, since that's where the stable archive comes from (not the SourceForge project files). We can't use `url :homepage` because the `https://abook.sourceforge.io` URL redirects to `http://abook.sourceforge.net` and we receive a `redirection forbidden` error.