### PR TITLE
csound: add livecheckable

### DIFF
--- a/Livecheckables/csound.rb
+++ b/Livecheckables/csound.rb
@@ -1,0 +1,6 @@
+class Csound
+  livecheck do
+    url "https://github.com/csound/csound/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+end


### PR DESCRIPTION
This adds a livecheckable for `csound` which checks the "latest" GitHub release, since `stable` uses a tag from the GitHub repository.