### PR TITLE
igv: update url and regex

### DIFF
--- a/Livecheckables/igv.rb
+++ b/Livecheckables/igv.rb
@@ -1,6 +1,6 @@
 class Igv
   livecheck do
-    url "http://software.broadinstitute.org/software/igv/download"
+    url "https://software.broadinstitute.org/software/igv/download"
     regex(/href=.*?IGV[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 end

--- a/Livecheckables/igv.rb
+++ b/Livecheckables/igv.rb
@@ -1,6 +1,6 @@
 class Igv
   livecheck do
-    url "https://github.com/igvteam/igv.git"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://data.broadinstitute.org/igv/projects/downloads/2.8/"
+    regex(/href=.*?IGV[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 end

--- a/Livecheckables/igv.rb
+++ b/Livecheckables/igv.rb
@@ -1,6 +1,6 @@
 class Igv
   livecheck do
-    url "https://data.broadinstitute.org/igv/projects/downloads/2.8/"
+    url "http://software.broadinstitute.org/software/igv/download"
     regex(/href=.*?IGV[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 end


### PR DESCRIPTION
## reason for the change

The artifact is in the FTP server, it is good to livecheck against the FTP server rather than github tag.

The files are actually different btw FTP server and Github repo.

```
$ du -h igv*
 52M	IGV_2.8.9.zip
118M	igv-2.8.10.zip
118M	igv-2.8.9.zip
```

## after the change
```
$ brew livecheck igv
igv : 2.8.9 ==> 2.8.9
```