### PR TITLE
influxdb: update url and regex

### DIFF
--- a/Livecheckables/influxdb.rb
+++ b/Livecheckables/influxdb.rb
@@ -1,6 +1,6 @@
 class Influxdb
   livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://github.com/influxdata/influxdb/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end


### PR DESCRIPTION
patch for influxdb's recent introduction of tag `v9.9.9`

```
$ brew livecheck influxdb
influxdb : 1.8.1 ==> 1.8.2
```