### PR TITLE
helm@2: add livecheckable

### DIFF
--- a/Livecheckables/helm@2.rb
+++ b/Livecheckables/helm@2.rb
@@ -1,6 +1,6 @@
 class HelmAT2
   livecheck do
-    url "https://github.com/helm/helm.git"
+    url :stable
     regex(/^v?(2(?:\.\d+)+)$/i)
   end
 end

--- a/Livecheckables/helm@2.rb
+++ b/Livecheckables/helm@2.rb
@@ -1,0 +1,6 @@
+class HelmAT2
+  livecheck do
+    url "https://github.com/helm/helm.git"
+    regex(/^v?(2(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
helm 2.x is still actively maintained, it is good to keep it under the watch. The most recent release was three days back.

