### PR TITLE
go: update regex

### DIFF
--- a/Livecheckables/go.rb
+++ b/Livecheckables/go.rb
@@ -1,6 +1,6 @@
 class Go
   livecheck do
     url "https://golang.org/dl/"
-    regex(/href=.*?gov?(\d+(?:\.\d+)+)\.src/i)
+    regex(/href=.*?go[._-]?v?(\d+(?:\.\d+)+)[._-]src\.t/i)
   end
 end


### PR DESCRIPTION
This updates the regex in the existing livecheckable for `go` to something closer to our current standards.

* Use `[._-]` between the software name and numeric version. In this case we make it optional since it's currently not part of the version format (e.g., `go1.15`).
* Use `[._-]src` in place of `\.src`, in case the format changes to `-src` or `_src` in the future.