### PR TITLE
ivykis: update url and regex

### DIFF
--- a/Livecheckables/ivykis.rb
+++ b/Livecheckables/ivykis.rb
@@ -1,6 +1,6 @@
 class Ivykis
   livecheck do
-    url :homepage
-    regex(%r{url=.*?/ivykis[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)(?:[._-]trunk)?$/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `ivykis` checks the `homepage`, which is the SourceForge project. However, the `stable` archive currently comes from GitHub.

This updates the livecheckable to check the GitHub repo tags, as there's no "latest" version.