### PR TITLE
bde: add livecheckable

### DIFF
--- a/Livecheckables/bde.rb
+++ b/Livecheckables/bde.rb
@@ -1,0 +1,6 @@
+class Bde
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+end


### PR DESCRIPTION
Using the current std way to populate this livecheckable.

## before the change

```
$ brew livecheck bde
bde (guessed) : 3.59.0.2 ==> 20120129
```

## after the change
```
$ brew livecheck bde
bde : 3.59.0.2 ==> 3.60.0.1
```