### PR TITLE
Use stable for SourceForge formulae

### DIFF
--- a/Livecheckables/aften.rb
+++ b/Livecheckables/aften.rb
@@ -1,0 +1,9 @@
+class Aften
+  # Aften has moved from a version scheme like 0.07 to 0.0.8. We restrict
+  # matching to versions with three parts, since a version like 0.07 is parsed
+  # as 0.7 and seen as newer than 0.0.8.
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/aften[._-]v?(\d+(?:\.\d+){2,})\.t}i)
+  end
+end

--- a/Livecheckables/apng2gif.rb
+++ b/Livecheckables/apng2gif.rb
@@ -1,0 +1,5 @@
+class Apng2gif
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/argtable.rb
+++ b/Livecheckables/argtable.rb
@@ -1,0 +1,5 @@
+class Argtable
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/arss.rb
+++ b/Livecheckables/arss.rb
@@ -1,0 +1,5 @@
+class Arss
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/asciitex.rb
+++ b/Livecheckables/asciitex.rb
@@ -1,0 +1,5 @@
+class Asciitex
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/autopano-sift-c.rb
+++ b/Livecheckables/autopano-sift-c.rb
@@ -1,0 +1,9 @@
+class AutopanoSiftC
+  # We check the "autopano-sift-C" directory page since versions aren't present
+  # in the RSS feed as of writing.
+  livecheck do
+    url "https://sourceforge.net/projects/hugin/files/autopano-sift-C/"
+    strategy :page_match
+    regex(%r{href=.*?autopano-sift-C[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+end

--- a/Livecheckables/avanor.rb
+++ b/Livecheckables/avanor.rb
@@ -1,0 +1,5 @@
+class Avanor
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bacula-fd.rb
+++ b/Livecheckables/bacula-fd.rb
@@ -1,0 +1,5 @@
+class BaculaFd
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/base91.rb
+++ b/Livecheckables/base91.rb
@@ -1,0 +1,5 @@
+class Base91
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bashish.rb
+++ b/Livecheckables/bashish.rb
@@ -1,0 +1,5 @@
+class Bashish
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bbe.rb
+++ b/Livecheckables/bbe.rb
@@ -1,0 +1,5 @@
+class Bbe
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/beecrypt.rb
+++ b/Livecheckables/beecrypt.rb
@@ -1,0 +1,5 @@
+class Beecrypt
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bitchx.rb
+++ b/Livecheckables/bitchx.rb
@@ -1,0 +1,5 @@
+class Bitchx
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bittwist.rb
+++ b/Livecheckables/bittwist.rb
@@ -1,0 +1,5 @@
+class Bittwist
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/blazegraph.rb
+++ b/Livecheckables/blazegraph.rb
@@ -1,0 +1,6 @@
+class Blazegraph
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/v?(\d+(?:\.\d+)+)/blazegraph\.jar}i)
+  end
+end

--- a/Livecheckables/bochs.rb
+++ b/Livecheckables/bochs.rb
@@ -1,0 +1,5 @@
+class Bochs
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bogofilter.rb
+++ b/Livecheckables/bogofilter.rb
@@ -1,0 +1,5 @@
+class Bogofilter
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/brag.rb
+++ b/Livecheckables/brag.rb
@@ -1,0 +1,5 @@
+class Brag
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/briss.rb
+++ b/Livecheckables/briss.rb
@@ -1,0 +1,5 @@
+class Briss
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bsdsfv.rb
+++ b/Livecheckables/bsdsfv.rb
@@ -1,0 +1,5 @@
+class Bsdsfv
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bsponmpi.rb
+++ b/Livecheckables/bsponmpi.rb
@@ -1,0 +1,5 @@
+class Bsponmpi
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bvi.rb
+++ b/Livecheckables/bvi.rb
@@ -1,0 +1,5 @@
+class Bvi
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/calc.rb
+++ b/Livecheckables/calc.rb
@@ -1,6 +1,5 @@
 class Calc
   livecheck do
-    url "http://www.isthe.com/chongo/src/calc/"
-    regex(/href=.*?v?(\d+(?:\.\d+)+)_IS_LATEST_STABLE"/i)
+    url :stable
   end
 end

--- a/Livecheckables/cbmbasic.rb
+++ b/Livecheckables/cbmbasic.rb
@@ -1,0 +1,5 @@
+class Cbmbasic
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ccd2iso.rb
+++ b/Livecheckables/ccd2iso.rb
@@ -1,0 +1,5 @@
+class Ccd2iso
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ccrypt.rb
+++ b/Livecheckables/ccrypt.rb
@@ -1,0 +1,5 @@
+class Ccrypt
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/cdpr.rb
+++ b/Livecheckables/cdpr.rb
@@ -1,0 +1,5 @@
+class Cdpr
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/cdrdao.rb
+++ b/Livecheckables/cdrdao.rb
@@ -1,0 +1,5 @@
+class Cdrdao
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/cfv.rb
+++ b/Livecheckables/cfv.rb
@@ -1,0 +1,5 @@
+class Cfv
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/cgoban.rb
+++ b/Livecheckables/cgoban.rb
@@ -1,0 +1,5 @@
+class Cgoban
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/cidrmerge.rb
+++ b/Livecheckables/cidrmerge.rb
@@ -1,0 +1,5 @@
+class Cidrmerge
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/clean.rb
+++ b/Livecheckables/clean.rb
@@ -1,0 +1,5 @@
+class Clean
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/clpbar.rb
+++ b/Livecheckables/clpbar.rb
@@ -1,0 +1,5 @@
+class Clpbar
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/clucene.rb
+++ b/Livecheckables/clucene.rb
@@ -1,0 +1,6 @@
+class Clucene
+  livecheck do
+    url :stable
+    regex(/url=.*?clucene-core[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+  end
+end

--- a/Livecheckables/cmuclmtk.rb
+++ b/Livecheckables/cmuclmtk.rb
@@ -1,0 +1,9 @@
+class Cmuclmtk
+  # We check the "cmuclmtk" directory page since versions aren't present in the
+  # RSS feed as of writing.
+  livecheck do
+    url "https://sourceforge.net/projects/cmusphinx/files/cmuclmtk/"
+    strategy :page_match
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+end

--- a/Livecheckables/cpptest.rb
+++ b/Livecheckables/cpptest.rb
@@ -1,0 +1,5 @@
+class Cpptest
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/crunch.rb
+++ b/Livecheckables/crunch.rb
@@ -1,0 +1,5 @@
+class Crunch
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/cunit.rb
+++ b/Livecheckables/cunit.rb
@@ -1,0 +1,5 @@
+class Cunit
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/curlftpfs.rb
+++ b/Livecheckables/curlftpfs.rb
@@ -1,0 +1,5 @@
+class Curlftpfs
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/daemonlogger.rb
+++ b/Livecheckables/daemonlogger.rb
@@ -1,0 +1,5 @@
+class Daemonlogger
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/davmail.rb
+++ b/Livecheckables/davmail.rb
@@ -1,0 +1,5 @@
+class Davmail
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dbacl.rb
+++ b/Livecheckables/dbacl.rb
@@ -1,0 +1,5 @@
+class Dbacl
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dc3dd.rb
+++ b/Livecheckables/dc3dd.rb
@@ -1,0 +1,5 @@
+class Dc3dd
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dcfldd.rb
+++ b/Livecheckables/dcfldd.rb
@@ -1,0 +1,5 @@
+class Dcfldd
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dfu-util.rb
+++ b/Livecheckables/dfu-util.rb
@@ -1,0 +1,5 @@
+class DfuUtil
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dgen.rb
+++ b/Livecheckables/dgen.rb
@@ -1,0 +1,5 @@
+class Dgen
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dict.rb
+++ b/Livecheckables/dict.rb
@@ -1,0 +1,5 @@
+class Dict
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dirac.rb
+++ b/Livecheckables/dirac.rb
@@ -1,0 +1,5 @@
+class Dirac
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/disktype.rb
+++ b/Livecheckables/disktype.rb
@@ -1,6 +1,6 @@
 class Disktype
   livecheck do
-    url :head
-    regex(/release[._-]v?(\d+)/i)
+    url :stable
+    regex(%r{url=.*?/disktype[._-]v?(\d+(?:\.\d+)*)\.t}i)
   end
 end

--- a/Livecheckables/docutils.rb
+++ b/Livecheckables/docutils.rb
@@ -1,0 +1,5 @@
+class Docutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/docx2txt.rb
+++ b/Livecheckables/docx2txt.rb
@@ -1,0 +1,5 @@
+class Docx2txt
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dopewars.rb
+++ b/Livecheckables/dopewars.rb
@@ -1,0 +1,5 @@
+class Dopewars
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dosbox.rb
+++ b/Livecheckables/dosbox.rb
@@ -1,0 +1,5 @@
+class Dosbox
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/doublecpp.rb
+++ b/Livecheckables/doublecpp.rb
@@ -1,0 +1,5 @@
+class Doublecpp
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/doxymacs.rb
+++ b/Livecheckables/doxymacs.rb
@@ -1,0 +1,5 @@
+class Doxymacs
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dtach.rb
+++ b/Livecheckables/dtach.rb
@@ -1,0 +1,5 @@
+class Dtach
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/duff.rb
+++ b/Livecheckables/duff.rb
@@ -1,0 +1,5 @@
+class Duff
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dumb.rb
+++ b/Livecheckables/dumb.rb
@@ -1,0 +1,5 @@
+class Dumb
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/dvdbackup.rb
+++ b/Livecheckables/dvdbackup.rb
@@ -1,0 +1,5 @@
+class Dvdbackup
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ebook-tools.rb
+++ b/Livecheckables/ebook-tools.rb
@@ -1,0 +1,5 @@
+class EbookTools
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ekhtml.rb
+++ b/Livecheckables/ekhtml.rb
@@ -1,0 +1,5 @@
+class Ekhtml
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/empty.rb
+++ b/Livecheckables/empty.rb
@@ -1,0 +1,6 @@
+class Empty
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/empty[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
+  end
+end

--- a/Livecheckables/enigma.rb
+++ b/Livecheckables/enigma.rb
@@ -1,0 +1,5 @@
+class Enigma
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/esniper.rb
+++ b/Livecheckables/esniper.rb
@@ -1,0 +1,5 @@
+class Esniper
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ext2fuse.rb
+++ b/Livecheckables/ext2fuse.rb
@@ -1,0 +1,5 @@
+class Ext2fuse
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/fceux.rb
+++ b/Livecheckables/fceux.rb
@@ -1,0 +1,5 @@
+class Fceux
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/fdk-aac.rb
+++ b/Livecheckables/fdk-aac.rb
@@ -1,0 +1,5 @@
+class FdkAac
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/fizsh.rb
+++ b/Livecheckables/fizsh.rb
@@ -1,0 +1,6 @@
+class Fizsh
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/fizsh[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)\.t}i)
+  end
+end

--- a/Livecheckables/flac123.rb
+++ b/Livecheckables/flac123.rb
@@ -1,0 +1,5 @@
+class Flac123
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/flactag.rb
+++ b/Livecheckables/flactag.rb
@@ -1,0 +1,5 @@
+class Flactag
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/flake.rb
+++ b/Livecheckables/flake.rb
@@ -1,0 +1,5 @@
+class Flake
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/fmpp.rb
+++ b/Livecheckables/fmpp.rb
@@ -1,0 +1,5 @@
+class Fmpp
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/fprobe.rb
+++ b/Livecheckables/fprobe.rb
@@ -1,0 +1,5 @@
+class Fprobe
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/freeglut.rb
+++ b/Livecheckables/freeglut.rb
@@ -1,0 +1,5 @@
+class Freeglut
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/freeimage.rb
+++ b/Livecheckables/freeimage.rb
@@ -1,0 +1,5 @@
+class Freeimage
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ftjam.rb
+++ b/Livecheckables/ftjam.rb
@@ -1,0 +1,9 @@
+class Ftjam
+  # We check the "ftjam" directory page since versions aren't present in the
+  # RSS feed as of writing.
+  livecheck do
+    url "https://sourceforge.net/projects/freetype/files/ftjam/"
+    strategy :page_match
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+end

--- a/Livecheckables/gaffitter.rb
+++ b/Livecheckables/gaffitter.rb
@@ -1,0 +1,5 @@
+class Gaffitter
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gaul.rb
+++ b/Livecheckables/gaul.rb
@@ -1,0 +1,5 @@
+class Gaul
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gcviewer.rb
+++ b/Livecheckables/gcviewer.rb
@@ -1,0 +1,6 @@
+class Gcviewer
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/gcviewer[._-]v?(\d+(?:\.\d+)+)\.jar}i)
+  end
+end

--- a/Livecheckables/gdmap.rb
+++ b/Livecheckables/gdmap.rb
@@ -1,0 +1,5 @@
+class Gdmap
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/genext2fs.rb
+++ b/Livecheckables/genext2fs.rb
@@ -1,0 +1,5 @@
+class Genext2fs
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/geographiclib.rb
+++ b/Livecheckables/geographiclib.rb
@@ -1,0 +1,5 @@
+class Geographiclib
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gibbslda.rb
+++ b/Livecheckables/gibbslda.rb
@@ -1,0 +1,5 @@
+class Gibbslda
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gitslave.rb
+++ b/Livecheckables/gitslave.rb
@@ -1,0 +1,5 @@
+class Gitslave
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/glew.rb
+++ b/Livecheckables/glew.rb
@@ -1,0 +1,5 @@
+class Glew
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/global.rb
+++ b/Livecheckables/global.rb
@@ -1,0 +1,5 @@
+class Global
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-apl.rb
+++ b/Livecheckables/gnu-apl.rb
@@ -1,0 +1,5 @@
+class GnuApl
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnuplot.rb
+++ b/Livecheckables/gnuplot.rb
@@ -1,0 +1,5 @@
+class Gnuplot
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnuski.rb
+++ b/Livecheckables/gnuski.rb
@@ -1,0 +1,5 @@
+class Gnuski
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gobo.rb
+++ b/Livecheckables/gobo.rb
@@ -1,0 +1,5 @@
+class Gobo
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gptfdisk.rb
+++ b/Livecheckables/gptfdisk.rb
@@ -1,0 +1,5 @@
+class Gptfdisk
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gptsync.rb
+++ b/Livecheckables/gptsync.rb
@@ -1,0 +1,5 @@
+class Gptsync
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gqlplus.rb
+++ b/Livecheckables/gqlplus.rb
@@ -1,0 +1,5 @@
+class Gqlplus
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/graphicsmagick.rb
+++ b/Livecheckables/graphicsmagick.rb
@@ -1,6 +1,5 @@
 class Graphicsmagick
   livecheck do
-    url :homepage
-    regex(/<td>v?(\d+(?:\.\d+)+) \(Released/i)
+    url :stable
   end
 end

--- a/Livecheckables/grsync.rb
+++ b/Livecheckables/grsync.rb
@@ -1,0 +1,5 @@
+class Grsync
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gsmartcontrol.rb
+++ b/Livecheckables/gsmartcontrol.rb
@@ -1,6 +1,5 @@
 class Gsmartcontrol
   livecheck do
-    url :homepage
-    regex(/GSmartControl (\d+(\.\d+)*)/i)
+    url :stable
   end
 end

--- a/Livecheckables/gtk-gnutella.rb
+++ b/Livecheckables/gtk-gnutella.rb
@@ -1,0 +1,5 @@
+class GtkGnutella
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gtkdatabox.rb
+++ b/Livecheckables/gtkdatabox.rb
@@ -1,0 +1,5 @@
+class Gtkdatabox
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gtkextra.rb
+++ b/Livecheckables/gtkextra.rb
@@ -1,0 +1,5 @@
+class Gtkextra
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gtkspell3.rb
+++ b/Livecheckables/gtkspell3.rb
@@ -1,0 +1,5 @@
+class Gtkspell3
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gtmess.rb
+++ b/Livecheckables/gtmess.rb
@@ -1,0 +1,5 @@
+class Gtmess
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gts.rb
+++ b/Livecheckables/gts.rb
@@ -1,0 +1,5 @@
+class Gts
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/h264bitstream.rb
+++ b/Livecheckables/h264bitstream.rb
@@ -1,0 +1,5 @@
+class H264bitstream
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/healpix.rb
+++ b/Livecheckables/healpix.rb
@@ -1,0 +1,5 @@
+class Healpix
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/hilite.rb
+++ b/Livecheckables/hilite.rb
@@ -1,0 +1,5 @@
+class Hilite
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ht.rb
+++ b/Livecheckables/ht.rb
@@ -1,0 +1,5 @@
+class Ht
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/htmlcleaner.rb
+++ b/Livecheckables/htmlcleaner.rb
@@ -1,0 +1,5 @@
+class Htmlcleaner
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/htmlcxx.rb
+++ b/Livecheckables/htmlcxx.rb
@@ -1,0 +1,5 @@
+class Htmlcxx
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/iat.rb
+++ b/Livecheckables/iat.rb
@@ -1,0 +1,5 @@
+class Iat
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/id3lib.rb
+++ b/Livecheckables/id3lib.rb
@@ -1,0 +1,5 @@
+class Id3lib
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/id3v2.rb
+++ b/Livecheckables/id3v2.rb
@@ -1,0 +1,5 @@
+class Id3v2
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/imlib2.rb
+++ b/Livecheckables/imlib2.rb
@@ -1,0 +1,5 @@
+class Imlib2
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/iperf.rb
+++ b/Livecheckables/iperf.rb
@@ -1,0 +1,5 @@
+class Iperf
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ipmitool.rb
+++ b/Livecheckables/ipmitool.rb
@@ -1,0 +1,5 @@
+class Ipmitool
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ipmiutil.rb
+++ b/Livecheckables/ipmiutil.rb
@@ -1,0 +1,5 @@
+class Ipmiutil
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/isync.rb
+++ b/Livecheckables/isync.rb
@@ -1,0 +1,5 @@
+class Isync
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/jasmin.rb
+++ b/Livecheckables/jasmin.rb
@@ -1,0 +1,5 @@
+class Jasmin
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/jp2a.rb
+++ b/Livecheckables/jp2a.rb
@@ -1,0 +1,5 @@
+class Jp2a
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/lasi.rb
+++ b/Livecheckables/lasi.rb
@@ -1,0 +1,5 @@
+class Lasi
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/latex2rtf.rb
+++ b/Livecheckables/latex2rtf.rb
@@ -1,0 +1,5 @@
+class Latex2rtf
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/launch4j.rb
+++ b/Livecheckables/launch4j.rb
@@ -1,0 +1,5 @@
+class Launch4j
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/lci.rb
+++ b/Livecheckables/lci.rb
@@ -1,0 +1,5 @@
+class Lci
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/lensfun.rb
+++ b/Livecheckables/lensfun.rb
@@ -1,0 +1,5 @@
+class Lensfun
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/lesstif.rb
+++ b/Livecheckables/lesstif.rb
@@ -1,0 +1,5 @@
+class Lesstif
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libb64.rb
+++ b/Livecheckables/libb64.rb
@@ -1,0 +1,5 @@
+class Libb64
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libbinio.rb
+++ b/Livecheckables/libbinio.rb
@@ -1,0 +1,5 @@
+class Libbinio
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libbs2b.rb
+++ b/Livecheckables/libbs2b.rb
@@ -1,0 +1,5 @@
+class Libbs2b
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libcddb.rb
+++ b/Livecheckables/libcddb.rb
@@ -1,0 +1,5 @@
+class Libcddb
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libcmph.rb
+++ b/Livecheckables/libcmph.rb
@@ -1,0 +1,5 @@
+class Libcmph
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libcsv.rb
+++ b/Livecheckables/libcsv.rb
@@ -1,0 +1,5 @@
+class Libcsv
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libdbi.rb
+++ b/Livecheckables/libdbi.rb
@@ -1,0 +1,5 @@
+class Libdbi
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libdv.rb
+++ b/Livecheckables/libdv.rb
@@ -1,0 +1,5 @@
+class Libdv
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libgetdata.rb
+++ b/Livecheckables/libgetdata.rb
@@ -1,0 +1,5 @@
+class Libgetdata
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libgnt.rb
+++ b/Livecheckables/libgnt.rb
@@ -1,0 +1,6 @@
+class Libgnt
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/libgnt[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
+end

--- a/Livecheckables/libicns.rb
+++ b/Livecheckables/libicns.rb
@@ -1,0 +1,5 @@
+class Libicns
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libiptcdata.rb
+++ b/Livecheckables/libiptcdata.rb
@@ -1,0 +1,5 @@
+class Libiptcdata
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/liblo.rb
+++ b/Livecheckables/liblo.rb
@@ -1,0 +1,5 @@
+class Liblo
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libmatio.rb
+++ b/Livecheckables/libmatio.rb
@@ -1,0 +1,5 @@
+class Libmatio
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libmms.rb
+++ b/Livecheckables/libmms.rb
@@ -1,0 +1,5 @@
+class Libmms
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libmp3splt.rb
+++ b/Livecheckables/libmp3splt.rb
@@ -1,0 +1,9 @@
+class Libmp3splt
+  # We check the "libmp3splt" directory page since versions aren't present in
+  # the RSS feed as of writing.
+  livecheck do
+    url "https://sourceforge.net/projects/mp3splt/files/libmp3splt/"
+    strategy :page_match
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+[a-z]?)/?["' >]}i)
+  end
+end

--- a/Livecheckables/libmtp.rb
+++ b/Livecheckables/libmtp.rb
@@ -1,0 +1,5 @@
+class Libmtp
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libmwaw.rb
+++ b/Livecheckables/libmwaw.rb
@@ -1,5 +1,5 @@
 class Libmwaw
   livecheck do
-    url "https://git.code.sf.net/p/libmwaw/libmwaw.git"
+    url :stable
   end
 end

--- a/Livecheckables/libnids.rb
+++ b/Livecheckables/libnids.rb
@@ -1,0 +1,5 @@
+class Libnids
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libnova.rb
+++ b/Livecheckables/libnova.rb
@@ -1,0 +1,5 @@
+class Libnova
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/liboauth.rb
+++ b/Livecheckables/liboauth.rb
@@ -1,0 +1,5 @@
+class Liboauth
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libopendkim.rb
+++ b/Livecheckables/libopendkim.rb
@@ -1,0 +1,6 @@
+class Libopendkim
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/opendkim[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
+end

--- a/Livecheckables/libquicktime.rb
+++ b/Livecheckables/libquicktime.rb
@@ -1,0 +1,5 @@
+class Libquicktime
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libreadline-java.rb
+++ b/Livecheckables/libreadline-java.rb
@@ -1,0 +1,5 @@
+class LibreadlineJava
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libsmf.rb
+++ b/Livecheckables/libsmf.rb
@@ -1,0 +1,5 @@
+class Libsmf
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libsquish.rb
+++ b/Livecheckables/libsquish.rb
@@ -1,0 +1,5 @@
+class Libsquish
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libstxxl.rb
+++ b/Livecheckables/libstxxl.rb
@@ -1,0 +1,5 @@
+class Libstxxl
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libxmp-lite.rb
+++ b/Livecheckables/libxmp-lite.rb
@@ -1,0 +1,5 @@
+class LibxmpLite
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libxmp.rb
+++ b/Livecheckables/libxmp.rb
@@ -1,0 +1,5 @@
+class Libxmp
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/lifelines.rb
+++ b/Livecheckables/lifelines.rb
@@ -1,0 +1,5 @@
+class Lifelines
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/lpc21isp.rb
+++ b/Livecheckables/lpc21isp.rb
@@ -1,0 +1,5 @@
+class Lpc21isp
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/lsdvd.rb
+++ b/Livecheckables/lsdvd.rb
@@ -1,0 +1,5 @@
+class Lsdvd
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/luabind.rb
+++ b/Livecheckables/luabind.rb
@@ -1,0 +1,5 @@
+class Luabind
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/lxsplit.rb
+++ b/Livecheckables/lxsplit.rb
@@ -1,0 +1,5 @@
+class Lxsplit
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mac-robber.rb
+++ b/Livecheckables/mac-robber.rb
@@ -1,0 +1,5 @@
+class MacRobber
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mailcheck.rb
+++ b/Livecheckables/mailcheck.rb
@@ -1,0 +1,5 @@
+class Mailcheck
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/makensis.rb
+++ b/Livecheckables/makensis.rb
@@ -1,0 +1,5 @@
+class Makensis
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mboxgrep.rb
+++ b/Livecheckables/mboxgrep.rb
@@ -1,0 +1,5 @@
+class Mboxgrep
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mcrypt.rb
+++ b/Livecheckables/mcrypt.rb
@@ -1,0 +1,5 @@
+class Mcrypt
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mergelog.rb
+++ b/Livecheckables/mergelog.rb
@@ -1,0 +1,5 @@
+class Mergelog
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/minidlna.rb
+++ b/Livecheckables/minidlna.rb
@@ -1,0 +1,5 @@
+class Minidlna
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mjpegtools.rb
+++ b/Livecheckables/mjpegtools.rb
@@ -1,0 +1,5 @@
+class Mjpegtools
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mkclean.rb
+++ b/Livecheckables/mkclean.rb
@@ -1,0 +1,5 @@
+class Mkclean
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mlton.rb
+++ b/Livecheckables/mlton.rb
@@ -1,0 +1,6 @@
+class Mlton
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/mlton[._-]v?(\d+(?:\.\d+)*(?:-\d+)?)[._-]src\.t}i)
+  end
+end

--- a/Livecheckables/mp3blaster.rb
+++ b/Livecheckables/mp3blaster.rb
@@ -1,0 +1,5 @@
+class Mp3blaster
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mp3gain.rb
+++ b/Livecheckables/mp3gain.rb
@@ -1,0 +1,5 @@
+class Mp3gain
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mp3splt.rb
+++ b/Livecheckables/mp3splt.rb
@@ -1,0 +1,5 @@
+class Mp3splt
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mp3val.rb
+++ b/Livecheckables/mp3val.rb
@@ -1,0 +1,5 @@
+class Mp3val
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mpg321.rb
+++ b/Livecheckables/mpg321.rb
@@ -1,0 +1,5 @@
+class Mpg321
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/msktutil.rb
+++ b/Livecheckables/msktutil.rb
@@ -1,0 +1,5 @@
+class Msktutil
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mussh.rb
+++ b/Livecheckables/mussh.rb
@@ -1,0 +1,5 @@
+class Mussh
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/myman.rb
+++ b/Livecheckables/myman.rb
@@ -1,0 +1,5 @@
+class Myman
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/nedit.rb
+++ b/Livecheckables/nedit.rb
@@ -1,0 +1,5 @@
+class Nedit
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/netcat.rb
+++ b/Livecheckables/netcat.rb
@@ -1,0 +1,5 @@
+class Netcat
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/nettoe.rb
+++ b/Livecheckables/nettoe.rb
@@ -1,0 +1,5 @@
+class Nettoe
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ninvaders.rb
+++ b/Livecheckables/ninvaders.rb
@@ -1,0 +1,5 @@
+class Ninvaders
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/npush.rb
+++ b/Livecheckables/npush.rb
@@ -1,0 +1,5 @@
+class Npush
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/nsnake.rb
+++ b/Livecheckables/nsnake.rb
@@ -1,0 +1,5 @@
+class Nsnake
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/nsuds.rb
+++ b/Livecheckables/nsuds.rb
@@ -1,0 +1,6 @@
+class Nsuds
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/nsuds[._-]v?(\d+(?:\.\d+)+[A-Z]?)\.t}i)
+  end
+end

--- a/Livecheckables/nuvie.rb
+++ b/Livecheckables/nuvie.rb
@@ -1,0 +1,5 @@
+class Nuvie
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ocamlsdl.rb
+++ b/Livecheckables/ocamlsdl.rb
@@ -1,0 +1,5 @@
+class Ocamlsdl
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/octave.rb
+++ b/Livecheckables/octave.rb
@@ -1,0 +1,5 @@
+class Octave
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/open-jtalk.rb
+++ b/Livecheckables/open-jtalk.rb
@@ -1,0 +1,5 @@
+class OpenJtalk
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/open-ocd.rb
+++ b/Livecheckables/open-ocd.rb
@@ -1,0 +1,5 @@
+class OpenOcd
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/open-sp.rb
+++ b/Livecheckables/open-sp.rb
@@ -1,0 +1,5 @@
+class OpenSp
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/openmotif.rb
+++ b/Livecheckables/openmotif.rb
@@ -1,0 +1,5 @@
+class Openmotif
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/openslp.rb
+++ b/Livecheckables/openslp.rb
@@ -1,0 +1,5 @@
+class Openslp
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ophcrack.rb
+++ b/Livecheckables/ophcrack.rb
@@ -1,0 +1,5 @@
+class Ophcrack
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/optipng.rb
+++ b/Livecheckables/optipng.rb
@@ -1,0 +1,5 @@
+class Optipng
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/p7zip.rb
+++ b/Livecheckables/p7zip.rb
@@ -1,0 +1,5 @@
+class P7zip
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pcal.rb
+++ b/Livecheckables/pcal.rb
@@ -1,0 +1,5 @@
+class Pcal
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pdfcrack.rb
+++ b/Livecheckables/pdfcrack.rb
@@ -1,0 +1,5 @@
+class Pdfcrack
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pdfsandwich.rb
+++ b/Livecheckables/pdfsandwich.rb
@@ -1,0 +1,5 @@
+class Pdfsandwich
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/perceptualdiff.rb
+++ b/Livecheckables/perceptualdiff.rb
@@ -1,0 +1,5 @@
+class Perceptualdiff
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pev.rb
+++ b/Livecheckables/pev.rb
@@ -1,0 +1,5 @@
+class Pev
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pgdbf.rb
+++ b/Livecheckables/pgdbf.rb
@@ -1,0 +1,5 @@
+class Pgdbf
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pioneers.rb
+++ b/Livecheckables/pioneers.rb
@@ -1,0 +1,5 @@
+class Pioneers
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ploticus.rb
+++ b/Livecheckables/ploticus.rb
@@ -1,0 +1,5 @@
+class Ploticus
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/plplot.rb
+++ b/Livecheckables/plplot.rb
@@ -1,0 +1,5 @@
+class Plplot
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pms.rb
+++ b/Livecheckables/pms.rb
@@ -1,0 +1,5 @@
+class Pms
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pngnq.rb
+++ b/Livecheckables/pngnq.rb
@@ -1,0 +1,5 @@
+class Pngnq
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/podofo.rb
+++ b/Livecheckables/podofo.rb
@@ -1,0 +1,5 @@
+class Podofo
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pstoedit.rb
+++ b/Livecheckables/pstoedit.rb
@@ -1,0 +1,5 @@
+class Pstoedit
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/puf.rb
+++ b/Livecheckables/puf.rb
@@ -1,0 +1,5 @@
+class Puf
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/putmail.rb
+++ b/Livecheckables/putmail.rb
@@ -1,0 +1,5 @@
+class Putmail
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pwgen.rb
+++ b/Livecheckables/pwgen.rb
@@ -1,0 +1,5 @@
+class Pwgen
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/qrupdate.rb
+++ b/Livecheckables/qrupdate.rb
@@ -1,6 +1,6 @@
 class Qrupdate
   livecheck do
-    url :homepage
+    url :stable
     regex(%r{url=.*?/qrupdate[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/qwt.rb
+++ b/Livecheckables/qwt.rb
@@ -1,0 +1,5 @@
+class Qwt
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/qwtpolar.rb
+++ b/Livecheckables/qwtpolar.rb
@@ -1,0 +1,5 @@
+class Qwtpolar
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/regina-rexx.rb
+++ b/Livecheckables/regina-rexx.rb
@@ -1,0 +1,5 @@
+class ReginaRexx
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/rhash.rb
+++ b/Livecheckables/rhash.rb
@@ -1,0 +1,5 @@
+class Rhash
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/rig.rb
+++ b/Livecheckables/rig.rb
@@ -1,0 +1,5 @@
+class Rig
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/rkflashtool.rb
+++ b/Livecheckables/rkflashtool.rb
@@ -1,0 +1,5 @@
+class Rkflashtool
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/rkhunter.rb
+++ b/Livecheckables/rkhunter.rb
@@ -1,0 +1,5 @@
+class Rkhunter
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/rnv.rb
+++ b/Livecheckables/rnv.rb
@@ -1,0 +1,5 @@
+class Rnv
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/robotfindskitten.rb
+++ b/Livecheckables/robotfindskitten.rb
@@ -1,0 +1,5 @@
+class Robotfindskitten
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/rssh.rb
+++ b/Livecheckables/rssh.rb
@@ -1,0 +1,5 @@
+class Rssh
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/saxon-b.rb
+++ b/Livecheckables/saxon-b.rb
@@ -1,0 +1,9 @@
+class SaxonB
+  # We check the "Saxon-B" directory page since versions aren't present in the
+  # RSS feed as of writing.
+  livecheck do
+    url "https://sourceforge.net/projects/saxon/files/Saxon-B/"
+    strategy :page_match
+    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+end

--- a/Livecheckables/sbcl.rb
+++ b/Livecheckables/sbcl.rb
@@ -1,0 +1,5 @@
+class Sbcl
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/sblim-sfcc.rb
+++ b/Livecheckables/sblim-sfcc.rb
@@ -1,0 +1,6 @@
+class SblimSfcc
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/sblim-sfcc[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
+end

--- a/Livecheckables/scrollkeeper.rb
+++ b/Livecheckables/scrollkeeper.rb
@@ -1,0 +1,5 @@
+class Scrollkeeper
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/shivavg.rb
+++ b/Livecheckables/shivavg.rb
@@ -1,0 +1,5 @@
+class Shivavg
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/sisc-scheme.rb
+++ b/Livecheckables/sisc-scheme.rb
@@ -1,0 +1,5 @@
+class SiscScheme
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/sispmctl.rb
+++ b/Livecheckables/sispmctl.rb
@@ -1,0 +1,5 @@
+class Sispmctl
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/smake.rb
+++ b/Livecheckables/smake.rb
@@ -1,0 +1,5 @@
+class Smake
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/smartmontools.rb
+++ b/Livecheckables/smartmontools.rb
@@ -1,0 +1,5 @@
+class Smartmontools
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/snap7.rb
+++ b/Livecheckables/snap7.rb
@@ -1,0 +1,5 @@
+class Snap7
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/sng.rb
+++ b/Livecheckables/sng.rb
@@ -1,0 +1,5 @@
+class Sng
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/soci.rb
+++ b/Livecheckables/soci.rb
@@ -1,0 +1,5 @@
+class Soci
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/sofia-sip.rb
+++ b/Livecheckables/sofia-sip.rb
@@ -1,0 +1,5 @@
+class SofiaSip
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/sox.rb
+++ b/Livecheckables/sox.rb
@@ -1,0 +1,5 @@
+class Sox
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/srecord.rb
+++ b/Livecheckables/srecord.rb
@@ -1,0 +1,5 @@
+class Srecord
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/sshguard.rb
+++ b/Livecheckables/sshguard.rb
@@ -1,0 +1,5 @@
+class Sshguard
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/star.rb
+++ b/Livecheckables/star.rb
@@ -1,0 +1,5 @@
+class Star
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/stoken.rb
+++ b/Livecheckables/stoken.rb
@@ -1,0 +1,5 @@
+class Stoken
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/swig.rb
+++ b/Livecheckables/swig.rb
@@ -1,0 +1,5 @@
+class Swig
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/sz81.rb
+++ b/Livecheckables/sz81.rb
@@ -1,0 +1,5 @@
+class Sz81
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ta-lib.rb
+++ b/Livecheckables/ta-lib.rb
@@ -1,0 +1,5 @@
+class TaLib
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/takt.rb
+++ b/Livecheckables/takt.rb
@@ -1,0 +1,5 @@
+class Takt
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/tass64.rb
+++ b/Livecheckables/tass64.rb
@@ -1,0 +1,5 @@
+class Tass64
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/teem.rb
+++ b/Livecheckables/teem.rb
@@ -1,0 +1,5 @@
+class Teem
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/tgif.rb
+++ b/Livecheckables/tgif.rb
@@ -1,0 +1,5 @@
+class Tgif
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/thrulay.rb
+++ b/Livecheckables/thrulay.rb
@@ -1,0 +1,5 @@
+class Thrulay
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/tiny-fugue.rb
+++ b/Livecheckables/tiny-fugue.rb
@@ -1,0 +1,6 @@
+class TinyFugue
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/tf[._-]v?(\d+(?:\.\d+)*(?:[a-z]\d+?)?)\.t}i)
+  end
+end

--- a/Livecheckables/tinyxml.rb
+++ b/Livecheckables/tinyxml.rb
@@ -1,0 +1,5 @@
+class Tinyxml
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/tkdiff.rb
+++ b/Livecheckables/tkdiff.rb
@@ -1,0 +1,6 @@
+class Tkdiff
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/tkdiff/v?(\d+(?:\.\d+)+)/[^"]+?\.zip}i)
+  end
+end

--- a/Livecheckables/torrentcheck.rb
+++ b/Livecheckables/torrentcheck.rb
@@ -1,0 +1,5 @@
+class Torrentcheck
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ttfautohint.rb
+++ b/Livecheckables/ttfautohint.rb
@@ -1,0 +1,6 @@
+class Ttfautohint
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/ttfautohint[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
+end

--- a/Livecheckables/two-lame.rb
+++ b/Livecheckables/two-lame.rb
@@ -1,0 +1,5 @@
+class TwoLame
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/typespeed.rb
+++ b/Livecheckables/typespeed.rb
@@ -1,0 +1,5 @@
+class Typespeed
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ufraw.rb
+++ b/Livecheckables/ufraw.rb
@@ -1,0 +1,5 @@
+class Ufraw
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/unrtf.rb
+++ b/Livecheckables/unrtf.rb
@@ -1,0 +1,5 @@
+class Unrtf
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/viennacl.rb
+++ b/Livecheckables/viennacl.rb
@@ -1,0 +1,5 @@
+class Viennacl
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/vpcs.rb
+++ b/Livecheckables/vpcs.rb
@@ -1,0 +1,5 @@
+class Vpcs
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/w-calc.rb
+++ b/Livecheckables/w-calc.rb
@@ -1,0 +1,5 @@
+class WCalc
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/winexe.rb
+++ b/Livecheckables/winexe.rb
@@ -1,0 +1,5 @@
+class Winexe
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/wput.rb
+++ b/Livecheckables/wput.rb
@@ -1,0 +1,5 @@
+class Wput
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/xlslib.rb
+++ b/Livecheckables/xlslib.rb
@@ -1,0 +1,5 @@
+class Xlslib
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/xmlcatmgr.rb
+++ b/Livecheckables/xmlcatmgr.rb
@@ -1,0 +1,5 @@
+class Xmlcatmgr
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/xmlrpc-c.rb
+++ b/Livecheckables/xmlrpc-c.rb
@@ -1,0 +1,5 @@
+class XmlrpcC
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/xmlstarlet.rb
+++ b/Livecheckables/xmlstarlet.rb
@@ -1,0 +1,5 @@
+class Xmlstarlet
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/xmltoman.rb
+++ b/Livecheckables/xmltoman.rb
@@ -1,0 +1,5 @@
+class Xmltoman
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/xmp.rb
+++ b/Livecheckables/xmp.rb
@@ -1,0 +1,6 @@
+class Xmp
+  livecheck do
+    url :stable
+    regex(%r{url=.*?/xmp[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
+end

--- a/Livecheckables/xplanet.rb
+++ b/Livecheckables/xplanet.rb
@@ -1,0 +1,5 @@
+class Xplanet
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/xz.rb
+++ b/Livecheckables/xz.rb
@@ -1,6 +1,5 @@
 class Xz
   livecheck do
-    url :homepage
-    regex(/v?(\d+(?:\.\d+)+) was released/i)
+    url :stable
   end
 end

--- a/Livecheckables/yamdi.rb
+++ b/Livecheckables/yamdi.rb
@@ -1,0 +1,5 @@
+class Yamdi
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/yconalyzer.rb
+++ b/Livecheckables/yconalyzer.rb
@@ -1,0 +1,5 @@
+class Yconalyzer
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/yydecode.rb
+++ b/Livecheckables/yydecode.rb
@@ -1,0 +1,5 @@
+class Yydecode
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/zsh.rb
+++ b/Livecheckables/zsh.rb
@@ -1,6 +1,5 @@
 class Zsh
   livecheck do
-    url "https://www.zsh.org/pub/"
-    regex(/href=.*?zsh[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
   end
 end


### PR DESCRIPTION
This adds livecheckables or modifies existing ones to check the stable archive source (using `url :stable` or some modified version of the stable URL) for SourceForge formulae. This ensures that livecheck will continue to check the stable source even if `head` is added to the formulae in the future.