### PR TITLE
Use stable for Apache formulae

### DIFF
--- a/Livecheckables/activemq-cpp.rb
+++ b/Livecheckables/activemq-cpp.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class ActivemqCpp
   livecheck do
     url :stable
   end

--- a/Livecheckables/activemq.rb
+++ b/Livecheckables/activemq.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Activemq
   livecheck do
     url :stable
   end

--- a/Livecheckables/ant.rb
+++ b/Livecheckables/ant.rb
@@ -1,6 +1,5 @@
 class Ant
   livecheck do
-    url "https://downloads.apache.org/ant/binaries/"
-    regex(/href=.*?apache-ant[._-]v?(\d+(?:\.\d+)+)(?:-bin)?\.t/i)
+    url :stable
   end
 end

--- a/Livecheckables/ant@1.9.rb
+++ b/Livecheckables/ant@1.9.rb
@@ -1,6 +1,6 @@
 class AntAT19
   livecheck do
-    url "https://downloads.apache.org/ant/binaries/"
+    url :stable
     regex(/href=.*?apache-ant[._-]v?(1\.9(?:\.\d+)*)(?:-bin)?\.t/i)
   end
 end

--- a/Livecheckables/apache-archiva.rb
+++ b/Livecheckables/apache-archiva.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class ApacheArchiva
   livecheck do
     url :stable
   end

--- a/Livecheckables/apache-arrow-glib.rb
+++ b/Livecheckables/apache-arrow-glib.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class ApacheArrowGlib
   livecheck do
     url :stable
   end

--- a/Livecheckables/apache-arrow.rb
+++ b/Livecheckables/apache-arrow.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class ApacheArrow
   livecheck do
     url :stable
   end

--- a/Livecheckables/apache-drill.rb
+++ b/Livecheckables/apache-drill.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class ApacheDrill
   livecheck do
     url :stable
   end

--- a/Livecheckables/apache-flink.rb
+++ b/Livecheckables/apache-flink.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class ApacheFlink
   livecheck do
     url :stable
   end

--- a/Livecheckables/apache-forrest.rb
+++ b/Livecheckables/apache-forrest.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class ApacheForrest
   livecheck do
     url :stable
   end

--- a/Livecheckables/apache-geode.rb
+++ b/Livecheckables/apache-geode.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class ApacheGeode
   livecheck do
     url :stable
   end

--- a/Livecheckables/apache-opennlp.rb
+++ b/Livecheckables/apache-opennlp.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class ApacheOpennlp
   livecheck do
     url :stable
   end

--- a/Livecheckables/apache-spark.rb
+++ b/Livecheckables/apache-spark.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class ApacheSpark
   livecheck do
     url :stable
   end

--- a/Livecheckables/apr-util.rb
+++ b/Livecheckables/apr-util.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class AprUtil
   livecheck do
     url :stable
   end

--- a/Livecheckables/apr.rb
+++ b/Livecheckables/apr.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Apr
   livecheck do
     url :stable
   end

--- a/Livecheckables/aurora-cli.rb
+++ b/Livecheckables/aurora-cli.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class AuroraCli
   livecheck do
     url :stable
   end

--- a/Livecheckables/avro-c.rb
+++ b/Livecheckables/avro-c.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class AvroC
   livecheck do
     url :stable
   end

--- a/Livecheckables/avro-cpp.rb
+++ b/Livecheckables/avro-cpp.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class AvroCpp
   livecheck do
     url :stable
   end

--- a/Livecheckables/avro-tools.rb
+++ b/Livecheckables/avro-tools.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class AvroTools
   livecheck do
     url :stable
   end

--- a/Livecheckables/batik.rb
+++ b/Livecheckables/batik.rb
@@ -1,6 +1,5 @@
 class Batik
   livecheck do
-    url "https://xmlgraphics.apache.org/batik/download.html"
-    regex(/href=.*?batik-bin[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
   end
 end

--- a/Livecheckables/cassandra.rb
+++ b/Livecheckables/cassandra.rb
@@ -1,6 +1,5 @@
 class Cassandra
   livecheck do
-    url "https://cassandra.apache.org/download/"
-    regex(/href=.*?apache-cassandra[._-]v?(\d+(?:\.\d+)+)(?:-bin)?\.t/i)
+    url :stable
   end
 end

--- a/Livecheckables/couchdb.rb
+++ b/Livecheckables/couchdb.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Couchdb
   livecheck do
     url :stable
   end

--- a/Livecheckables/derby.rb
+++ b/Livecheckables/derby.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Derby
   livecheck do
     url :stable
   end

--- a/Livecheckables/flume.rb
+++ b/Livecheckables/flume.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Flume
   livecheck do
     url :stable
   end

--- a/Livecheckables/fop.rb
+++ b/Livecheckables/fop.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Fop
   livecheck do
     url :stable
   end

--- a/Livecheckables/fuseki.rb
+++ b/Livecheckables/fuseki.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Fuseki
   livecheck do
     url :stable
   end

--- a/Livecheckables/hadoop.rb
+++ b/Livecheckables/hadoop.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Hadoop
   livecheck do
     url :stable
   end

--- a/Livecheckables/hbase.rb
+++ b/Livecheckables/hbase.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Hbase
   livecheck do
     url :stable
   end

--- a/Livecheckables/hive.rb
+++ b/Livecheckables/hive.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Hive
   livecheck do
     url :stable
   end

--- a/Livecheckables/httpd.rb
+++ b/Livecheckables/httpd.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Httpd
   livecheck do
     url :stable
   end

--- a/Livecheckables/ivy.rb
+++ b/Livecheckables/ivy.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Ivy
   livecheck do
     url :stable
   end

--- a/Livecheckables/jena.rb
+++ b/Livecheckables/jena.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Jena
   livecheck do
     url :stable
   end

--- a/Livecheckables/jmeter.rb
+++ b/Livecheckables/jmeter.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Jmeter
   livecheck do
     url :stable
   end

--- a/Livecheckables/jsvc.rb
+++ b/Livecheckables/jsvc.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Jsvc
   livecheck do
     url :stable
   end

--- a/Livecheckables/kafka.rb
+++ b/Livecheckables/kafka.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Kafka
   livecheck do
     url :stable
   end

--- a/Livecheckables/libpulsar.rb
+++ b/Livecheckables/libpulsar.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Libpulsar
   livecheck do
     url :stable
   end

--- a/Livecheckables/log4cxx.rb
+++ b/Livecheckables/log4cxx.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Log4cxx
   livecheck do
     url :stable
   end

--- a/Livecheckables/mahout.rb
+++ b/Livecheckables/mahout.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Mahout
   livecheck do
     url :stable
   end

--- a/Livecheckables/maven.rb
+++ b/Livecheckables/maven.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Maven
   livecheck do
     url :stable
   end

--- a/Livecheckables/mesos.rb
+++ b/Livecheckables/mesos.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Mesos
   livecheck do
     url :stable
   end

--- a/Livecheckables/nifi-registry.rb
+++ b/Livecheckables/nifi-registry.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class NifiRegistry
   livecheck do
     url :stable
   end

--- a/Livecheckables/nifi.rb
+++ b/Livecheckables/nifi.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Nifi
   livecheck do
     url :stable
   end

--- a/Livecheckables/pig.rb
+++ b/Livecheckables/pig.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Pig
   livecheck do
     url :stable
   end

--- a/Livecheckables/predictionio.rb
+++ b/Livecheckables/predictionio.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Predictionio
   livecheck do
     url :stable
   end

--- a/Livecheckables/qpid-proton.rb
+++ b/Livecheckables/qpid-proton.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class QpidProton
   livecheck do
     url :stable
   end

--- a/Livecheckables/solr.rb
+++ b/Livecheckables/solr.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Solr
   livecheck do
     url :stable
   end

--- a/Livecheckables/storm.rb
+++ b/Livecheckables/storm.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Storm
   livecheck do
     url :stable
   end

--- a/Livecheckables/subversion.rb
+++ b/Livecheckables/subversion.rb
@@ -1,6 +1,5 @@
 class Subversion
   livecheck do
-    url :homepage
-    regex(/Apache Subversion v?(\d+(?:\.\d+)+) Released/i)
+    url :stable
   end
 end

--- a/Livecheckables/thrift.rb
+++ b/Livecheckables/thrift.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Thrift
   livecheck do
     url :stable
   end

--- a/Livecheckables/tika.rb
+++ b/Livecheckables/tika.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Tika
   livecheck do
     url :stable
   end

--- a/Livecheckables/tomcat-native.rb
+++ b/Livecheckables/tomcat-native.rb
@@ -1,6 +1,5 @@
 class TomcatNative
   livecheck do
-    url "https://archive.apache.org/dist/tomcat/tomcat-connectors/native/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url :stable
   end
 end

--- a/Livecheckables/tomcat.rb
+++ b/Livecheckables/tomcat.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Tomcat
   livecheck do
     url :stable
   end

--- a/Livecheckables/tomcat@8.rb
+++ b/Livecheckables/tomcat@8.rb
@@ -1,6 +1,5 @@
 class TomcatAT8
   livecheck do
-    url "https://archive.apache.org/dist/tomcat/tomcat-8/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url :stable
   end
 end

--- a/Livecheckables/tomee-plume.rb
+++ b/Livecheckables/tomee-plume.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class TomeePlume
   livecheck do
     url :stable
   end

--- a/Livecheckables/tomee-plus.rb
+++ b/Livecheckables/tomee-plus.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class TomeePlus
   livecheck do
     url :stable
   end

--- a/Livecheckables/tomee-webprofile.rb
+++ b/Livecheckables/tomee-webprofile.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class TomeeWebprofile
   livecheck do
     url :stable
   end

--- a/Livecheckables/trafficserver.rb
+++ b/Livecheckables/trafficserver.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class Trafficserver
   livecheck do
     url :stable
   end

--- a/Livecheckables/xalan-c.rb
+++ b/Livecheckables/xalan-c.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class XalanC
   livecheck do
     url :stable
   end

--- a/Livecheckables/xerces-c.rb
+++ b/Livecheckables/xerces-c.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class XercesC
   livecheck do
     url :stable
   end

--- a/Livecheckables/xml-security-c.rb
+++ b/Livecheckables/xml-security-c.rb
@@ -1,4 +1,4 @@
-class TomcatAT7
+class XmlSecurityC
   livecheck do
     url :stable
   end

--- a/Livecheckables/zookeeper.rb
+++ b/Livecheckables/zookeeper.rb
@@ -1,6 +1,5 @@
 class Zookeeper
   livecheck do
-    url "https://zookeeper.apache.org/releases.html"
-    regex(/ZooKeeper (\d+(?:\.\d+)+) is our latest stable release/i)
+    url :stable
   end
 end


### PR DESCRIPTION
This adds/modifies livecheckables to use the stable URL for formulae with a `stable` URL that uses the `Apache` strategy. The existing livecheckables that were modified seem fine using the `Apache` strategy right now but we can always modify them in the future if they encounter issues with this approach.