### PR TITLE
Bitbucket: Update regex

### DIFF
--- a/livecheck/livecheck_strategy/bitbucket.rb
+++ b/livecheck/livecheck_strategy/bitbucket.rb
@@ -10,12 +10,15 @@ module LivecheckStrategy
       path, kind, suffix =
         url.match(%r{bitbucket\.org/(.+?)/(get|downloads)/(?:.*?[-_])?v?\d+(?:\.\d+)+([^/]+)})[1, 3]
 
+      # Use `\.t` instead of specific tarball extensions (e.g., .tar.gz)
+      suffix.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/, "\.t")
+
       page_url = if kind == "get"
         "https://bitbucket.org/#{path}/downloads/?tab=tags"
       else
         "https://bitbucket.org/#{path}/downloads/"
       end
-      regex ||= /(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}"/
+      regex ||= /href=.*?v?(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/i
 
       PageMatch.find_versions(page_url, regex)
     end


### PR DESCRIPTION
This updates the `Bitbucket` strategy's regex to bring it more in line with our current standards.

This also makes tarball extensions in the `suffix` generic (i.e., `\.t`) as we do in other regexes. This helps to avoid the situation where the `stable` archive is a `.tar.gz` file but the upstream releases have moved to `.tar.xz` and we would miss the new releases if the regex was explicitly matching `.tar.gz`.