### PR TITLE
Use stable for Bitbucket formulae

### DIFF
--- a/Livecheckables/connect.rb
+++ b/Livecheckables/connect.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Connect
   livecheck do
     url :stable
   end

--- a/Livecheckables/csv-fix.rb
+++ b/Livecheckables/csv-fix.rb
@@ -1,4 +1,4 @@
-class Mutt
+class CsvFix
   livecheck do
     url :stable
   end

--- a/Livecheckables/foma.rb
+++ b/Livecheckables/foma.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Foma
   livecheck do
     url :stable
   end

--- a/Livecheckables/fuse-zip.rb
+++ b/Livecheckables/fuse-zip.rb
@@ -1,4 +1,4 @@
-class Mutt
+class FuseZip
   livecheck do
     url :stable
   end

--- a/Livecheckables/game-music-emu.rb
+++ b/Livecheckables/game-music-emu.rb
@@ -1,4 +1,4 @@
-class Mutt
+class GameMusicEmu
   livecheck do
     url :stable
   end

--- a/Livecheckables/groovyserv.rb
+++ b/Livecheckables/groovyserv.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Groovyserv
   livecheck do
     url :stable
   end

--- a/Livecheckables/jerasure.rb
+++ b/Livecheckables/jerasure.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Jerasure
   livecheck do
     url :stable
   end

--- a/Livecheckables/makeicns.rb
+++ b/Livecheckables/makeicns.rb
@@ -1,0 +1,6 @@
+class Makeicns
+  livecheck do
+    url :stable
+    regex(/href=.*?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+  end
+end

--- a/Livecheckables/mecab-ko-dic.rb
+++ b/Livecheckables/mecab-ko-dic.rb
@@ -1,6 +1,6 @@
 class MecabKoDic
   livecheck do
-    url "https://bitbucket.org/eunjeon/mecab-ko-dic/downloads/"
+    url :stable
     regex(/href=.*?mecab-ko-dic[._-]v?(\d+(?:\.\d+)+-\d+)\.t/i)
   end
 end

--- a/Livecheckables/mecab-ko.rb
+++ b/Livecheckables/mecab-ko.rb
@@ -1,6 +1,6 @@
 class MecabKo
   livecheck do
-    url "https://bitbucket.org/eunjeon/mecab-ko/downloads/"
+    url :stable
     regex(/href=.*?mecab[._-]v?(\d+(?:\.\d+)+-ko-\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/mpi4py.rb
+++ b/Livecheckables/mpi4py.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Mpi4py
   livecheck do
     url :stable
   end

--- a/Livecheckables/mvnvm.rb
+++ b/Livecheckables/mvnvm.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Mvnvm
   livecheck do
     url :stable
   end

--- a/Livecheckables/ode.rb
+++ b/Livecheckables/ode.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Ode
   livecheck do
     url :stable
   end

--- a/Livecheckables/ori.rb
+++ b/Livecheckables/ori.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Ori
   livecheck do
     url :stable
   end

--- a/Livecheckables/procyon-decompiler.rb
+++ b/Livecheckables/procyon-decompiler.rb
@@ -1,4 +1,4 @@
-class Mutt
+class ProcyonDecompiler
   livecheck do
     url :stable
   end

--- a/Livecheckables/pypy.rb
+++ b/Livecheckables/pypy.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Pypy
   livecheck do
     url :stable
   end

--- a/Livecheckables/pypy3.rb
+++ b/Livecheckables/pypy3.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Pypy3
   livecheck do
     url :stable
   end

--- a/Livecheckables/sagittarius-scheme.rb
+++ b/Livecheckables/sagittarius-scheme.rb
@@ -1,4 +1,4 @@
-class Mutt
+class SagittariusScheme
   livecheck do
     url :stable
   end

--- a/Livecheckables/uru.rb
+++ b/Livecheckables/uru.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Uru
   livecheck do
     url :stable
   end

--- a/Livecheckables/vcprompt.rb
+++ b/Livecheckables/vcprompt.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Vcprompt
   livecheck do
     url :stable
   end

--- a/Livecheckables/vera++.rb
+++ b/Livecheckables/vera++.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Veraxx
   livecheck do
     url :stable
   end

--- a/Livecheckables/walkmod.rb
+++ b/Livecheckables/walkmod.rb
@@ -1,4 +1,4 @@
-class Mutt
+class Walkmod
   livecheck do
     url :stable
   end

--- a/Livecheckables/x265.rb
+++ b/Livecheckables/x265.rb
@@ -1,4 +1,4 @@
-class Mutt
+class X265
   livecheck do
     url :stable
   end


### PR DESCRIPTION
This adds/modifies livecheckables to use the `stable` URL for formulae with a `stable` URL that uses the `Bitbucket` strategy.