### PR TITLE
Use stable for GNOME formulae

### DIFF
--- a/Livecheckables/adwaita-icon-theme.rb
+++ b/Livecheckables/adwaita-icon-theme.rb
@@ -1,4 +1,4 @@
-class Goffice
+class AdwaitaIconTheme
   livecheck do
     url :stable
   end

--- a/Livecheckables/amtk.rb
+++ b/Livecheckables/amtk.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Amtk
   livecheck do
     url :stable
   end

--- a/Livecheckables/anjuta.rb
+++ b/Livecheckables/anjuta.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Anjuta
   livecheck do
     url :stable
   end

--- a/Livecheckables/aravis.rb
+++ b/Livecheckables/aravis.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Aravis
   livecheck do
     url :stable
   end

--- a/Livecheckables/atk.rb
+++ b/Livecheckables/atk.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Atk
   livecheck do
     url :stable
   end

--- a/Livecheckables/atkmm.rb
+++ b/Livecheckables/atkmm.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Atkmm
   livecheck do
     url :stable
   end

--- a/Livecheckables/baobab.rb
+++ b/Livecheckables/baobab.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Baobab
   livecheck do
     url :stable
   end

--- a/Livecheckables/clutter-gst.rb
+++ b/Livecheckables/clutter-gst.rb
@@ -1,4 +1,4 @@
-class Goffice
+class ClutterGst
   livecheck do
     url :stable
   end

--- a/Livecheckables/clutter-gtk.rb
+++ b/Livecheckables/clutter-gtk.rb
@@ -1,4 +1,4 @@
-class Goffice
+class ClutterGtk
   livecheck do
     url :stable
   end

--- a/Livecheckables/clutter.rb
+++ b/Livecheckables/clutter.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Clutter
   livecheck do
     url :stable
   end

--- a/Livecheckables/cogl.rb
+++ b/Livecheckables/cogl.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Cogl
   livecheck do
     url :stable
   end

--- a/Livecheckables/easy-tag.rb
+++ b/Livecheckables/easy-tag.rb
@@ -1,4 +1,4 @@
-class Goffice
+class EasyTag
   livecheck do
     url :stable
   end

--- a/Livecheckables/evince.rb
+++ b/Livecheckables/evince.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Evince
   livecheck do
     url :stable
   end

--- a/Livecheckables/file-roller.rb
+++ b/Livecheckables/file-roller.rb
@@ -1,4 +1,4 @@
-class Goffice
+class FileRoller
   livecheck do
     url :stable
   end

--- a/Livecheckables/gcab.rb
+++ b/Livecheckables/gcab.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gcab
   livecheck do
     url :stable
   end

--- a/Livecheckables/gconf.rb
+++ b/Livecheckables/gconf.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gconf
   livecheck do
     url :stable
   end

--- a/Livecheckables/gdk-pixbuf.rb
+++ b/Livecheckables/gdk-pixbuf.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GdkPixbuf
   livecheck do
     url :stable
   end

--- a/Livecheckables/gdl.rb
+++ b/Livecheckables/gdl.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gdl
   livecheck do
     url :stable
   end

--- a/Livecheckables/gedit.rb
+++ b/Livecheckables/gedit.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gedit
   livecheck do
     url :stable
   end

--- a/Livecheckables/geocode-glib.rb
+++ b/Livecheckables/geocode-glib.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GeocodeGlib
   livecheck do
     url :stable
   end

--- a/Livecheckables/gexiv2.rb
+++ b/Livecheckables/gexiv2.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gexiv2
   livecheck do
     url :stable
   end

--- a/Livecheckables/ghex.rb
+++ b/Livecheckables/ghex.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Ghex
   livecheck do
     url :stable
   end

--- a/Livecheckables/gitg.rb
+++ b/Livecheckables/gitg.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gitg
   livecheck do
     url :stable
   end

--- a/Livecheckables/gjs.rb
+++ b/Livecheckables/gjs.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gjs
   livecheck do
     url :stable
   end

--- a/Livecheckables/glade.rb
+++ b/Livecheckables/glade.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Glade
   livecheck do
     url :stable
   end

--- a/Livecheckables/glib-networking.rb
+++ b/Livecheckables/glib-networking.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GlibNetworking
   livecheck do
     url :stable
   end

--- a/Livecheckables/glib-openssl.rb
+++ b/Livecheckables/glib-openssl.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GlibOpenssl
   livecheck do
     url :stable
   end

--- a/Livecheckables/glib.rb
+++ b/Livecheckables/glib.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Glib
   livecheck do
     url :stable
   end

--- a/Livecheckables/glibmm.rb
+++ b/Livecheckables/glibmm.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Glibmm
   livecheck do
     url :stable
   end

--- a/Livecheckables/gmime.rb
+++ b/Livecheckables/gmime.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gmime
   livecheck do
     url :stable
   end

--- a/Livecheckables/gnome-autoar.rb
+++ b/Livecheckables/gnome-autoar.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GnomeAutoar
   livecheck do
     url :stable
   end

--- a/Livecheckables/gnome-common.rb
+++ b/Livecheckables/gnome-common.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GnomeCommon
   livecheck do
     url :stable
   end

--- a/Livecheckables/gnome-latex.rb
+++ b/Livecheckables/gnome-latex.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GnomeLatex
   livecheck do
     url :stable
   end

--- a/Livecheckables/gnome-recipes.rb
+++ b/Livecheckables/gnome-recipes.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GnomeRecipes
   livecheck do
     url :stable
   end

--- a/Livecheckables/gnome-themes-standard.rb
+++ b/Livecheckables/gnome-themes-standard.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GnomeThemesStandard
   livecheck do
     url :stable
   end

--- a/Livecheckables/gnumeric.rb
+++ b/Livecheckables/gnumeric.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gnumeric
   livecheck do
     url :stable
   end

--- a/Livecheckables/gobject-introspection.rb
+++ b/Livecheckables/gobject-introspection.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GobjectIntrospection
   livecheck do
     url :stable
   end

--- a/Livecheckables/gom.rb
+++ b/Livecheckables/gom.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gom
   livecheck do
     url :stable
   end

--- a/Livecheckables/goocanvas.rb
+++ b/Livecheckables/goocanvas.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Goocanvas
   livecheck do
     url :stable
   end

--- a/Livecheckables/graphene.rb
+++ b/Livecheckables/graphene.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Graphene
   livecheck do
     url :stable
   end

--- a/Livecheckables/gsettings-desktop-schemas.rb
+++ b/Livecheckables/gsettings-desktop-schemas.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GsettingsDesktopSchemas
   livecheck do
     url :stable
   end

--- a/Livecheckables/gspell.rb
+++ b/Livecheckables/gspell.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gspell
   livecheck do
     url :stable
   end

--- a/Livecheckables/gssdp.rb
+++ b/Livecheckables/gssdp.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gssdp
   livecheck do
     url :stable
   end

--- a/Livecheckables/gstreamermm.rb
+++ b/Livecheckables/gstreamermm.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gstreamermm
   livecheck do
     url :stable
   end

--- a/Livecheckables/gtk+3.rb
+++ b/Livecheckables/gtk+3.rb
@@ -1,0 +1,6 @@
+class Gtkx3
+  livecheck do
+    url :stable
+    regex(/gtk\+[._-](3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/)
+  end
+end

--- a/Livecheckables/gtk-doc.rb
+++ b/Livecheckables/gtk-doc.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GtkDoc
   livecheck do
     url :stable
   end

--- a/Livecheckables/gtk-mac-integration.rb
+++ b/Livecheckables/gtk-mac-integration.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GtkMacIntegration
   livecheck do
     url :stable
   end

--- a/Livecheckables/gtk-vnc.rb
+++ b/Livecheckables/gtk-vnc.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GtkVnc
   livecheck do
     url :stable
   end

--- a/Livecheckables/gtkglext.rb
+++ b/Livecheckables/gtkglext.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gtkglext
   livecheck do
     url :stable
   end

--- a/Livecheckables/gtkmm3.rb
+++ b/Livecheckables/gtkmm3.rb
@@ -1,0 +1,6 @@
+class Gtkmm3
+  livecheck do
+    url :stable
+    regex(/gtkmm[._-]v?(3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
+  end
+end

--- a/Livecheckables/gtksourceview.rb
+++ b/Livecheckables/gtksourceview.rb
@@ -1,6 +1,6 @@
 class Gtksourceview
   livecheck do
-    url "https://download.gnome.org/sources/gtksourceview/"
+    url :stable
     regex(/gtksourceview[._-]v?(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/gtksourceview3.rb
+++ b/Livecheckables/gtksourceview3.rb
@@ -1,6 +1,6 @@
 class Gtksourceview3
   livecheck do
-    url "https://download.gnome.org/sources/gtksourceview/"
+    url :stable
     regex(/gtksourceview[._-]v?(3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/gtksourceview4.rb
+++ b/Livecheckables/gtksourceview4.rb
@@ -1,6 +1,6 @@
 class Gtksourceview4
   livecheck do
-    url "https://download.gnome.org/sources/gtksourceview/"
+    url :stable
     regex(/gtksourceview[._-]v?(4\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/gtksourceviewmm.rb
+++ b/Livecheckables/gtksourceviewmm.rb
@@ -1,6 +1,6 @@
 class Gtksourceviewmm
   livecheck do
-    url "https://download.gnome.org/sources/gtksourceviewmm/"
+    url :stable
     regex(/gtksourceviewmm[._-]v?(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/gtksourceviewmm3.rb
+++ b/Livecheckables/gtksourceviewmm3.rb
@@ -1,6 +1,6 @@
 class Gtksourceviewmm3
   livecheck do
-    url "https://download.gnome.org/sources/gtksourceviewmm/"
+    url :stable
     regex(/gtksourceviewmm[._-]v?(3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/gtranslator.rb
+++ b/Livecheckables/gtranslator.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gtranslator
   livecheck do
     url :stable
   end

--- a/Livecheckables/gucharmap.rb
+++ b/Livecheckables/gucharmap.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gucharmap
   livecheck do
     url :stable
   end

--- a/Livecheckables/gupnp-av.rb
+++ b/Livecheckables/gupnp-av.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GupnpAv
   livecheck do
     url :stable
   end

--- a/Livecheckables/gupnp-tools.rb
+++ b/Livecheckables/gupnp-tools.rb
@@ -1,4 +1,4 @@
-class Goffice
+class GupnpTools
   livecheck do
     url :stable
   end

--- a/Livecheckables/gupnp.rb
+++ b/Livecheckables/gupnp.rb
@@ -1,5 +1,5 @@
 class Gupnp
   livecheck do
-    url "https://github.com/GNOME/gupnp.git"
+    url :stable
   end
 end

--- a/Livecheckables/gxml.rb
+++ b/Livecheckables/gxml.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Gxml
   livecheck do
     url :stable
   end

--- a/Livecheckables/json-glib.rb
+++ b/Livecheckables/json-glib.rb
@@ -1,4 +1,4 @@
-class Goffice
+class JsonGlib
   livecheck do
     url :stable
   end

--- a/Livecheckables/jsonrpc-glib.rb
+++ b/Livecheckables/jsonrpc-glib.rb
@@ -1,4 +1,4 @@
-class Goffice
+class JsonrpcGlib
   livecheck do
     url :stable
   end

--- a/Livecheckables/libart.rb
+++ b/Livecheckables/libart.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libart
   livecheck do
     url :stable
   end

--- a/Livecheckables/libchamplain.rb
+++ b/Livecheckables/libchamplain.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libchamplain
   livecheck do
     url :stable
   end

--- a/Livecheckables/libcroco.rb
+++ b/Livecheckables/libcroco.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libcroco
   livecheck do
     url :stable
   end

--- a/Livecheckables/libdazzle.rb
+++ b/Livecheckables/libdazzle.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libdazzle
   livecheck do
     url :stable
   end

--- a/Livecheckables/libepoxy.rb
+++ b/Livecheckables/libepoxy.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libepoxy
   livecheck do
     url :stable
   end

--- a/Livecheckables/libgda.rb
+++ b/Livecheckables/libgda.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libgda
   livecheck do
     url :stable
   end

--- a/Livecheckables/libgdata.rb
+++ b/Livecheckables/libgdata.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libgdata
   livecheck do
     url :stable
   end

--- a/Livecheckables/libgee.rb
+++ b/Livecheckables/libgee.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libgee
   livecheck do
     url :stable
   end

--- a/Livecheckables/libgit2-glib.rb
+++ b/Livecheckables/libgit2-glib.rb
@@ -1,0 +1,6 @@
+class Libgit2Glib
+  livecheck do
+    url :stable
+    regex(/libgit2-glib[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/libglade.rb
+++ b/Livecheckables/libglade.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libglade
   livecheck do
     url :stable
   end

--- a/Livecheckables/libglademm.rb
+++ b/Livecheckables/libglademm.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libglademm
   livecheck do
     url :stable
   end

--- a/Livecheckables/libgnomecanvas.rb
+++ b/Livecheckables/libgnomecanvas.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libgnomecanvas
   livecheck do
     url :stable
   end

--- a/Livecheckables/libgnomecanvasmm.rb
+++ b/Livecheckables/libgnomecanvasmm.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libgnomecanvasmm
   livecheck do
     url :stable
   end

--- a/Livecheckables/libgsf.rb
+++ b/Livecheckables/libgsf.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libgsf
   livecheck do
     url :stable
   end

--- a/Livecheckables/libgtop.rb
+++ b/Livecheckables/libgtop.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libgtop
   livecheck do
     url :stable
   end

--- a/Livecheckables/libgweather.rb
+++ b/Livecheckables/libgweather.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libgweather
   livecheck do
     url :stable
   end

--- a/Livecheckables/libgxps.rb
+++ b/Livecheckables/libgxps.rb
@@ -1,0 +1,6 @@
+class Libgxps
+  livecheck do
+    url :stable
+    regex(/libgxps[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/libhttpseverywhere.rb
+++ b/Livecheckables/libhttpseverywhere.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libhttpseverywhere
   livecheck do
     url :stable
   end

--- a/Livecheckables/libidl.rb
+++ b/Livecheckables/libidl.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libidl
   livecheck do
     url :stable
   end

--- a/Livecheckables/libnotify.rb
+++ b/Livecheckables/libnotify.rb
@@ -1,0 +1,9 @@
+class Libnotify
+  # libnotify uses GNOME's "even-numbered minor is stable" version scheme but
+  # we've been using a development version 0.7.x for many years, so we have to
+  # match development versions until we're on a stable release.
+  livecheck do
+    url :stable
+    regex(/libnotify-(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/libpeas.rb
+++ b/Livecheckables/libpeas.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libpeas
   livecheck do
     url :stable
   end

--- a/Livecheckables/librest.rb
+++ b/Livecheckables/librest.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Librest
   livecheck do
     url :stable
   end

--- a/Livecheckables/librsvg.rb
+++ b/Livecheckables/librsvg.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Librsvg
   livecheck do
     url :stable
   end

--- a/Livecheckables/libsecret.rb
+++ b/Livecheckables/libsecret.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libsecret
   livecheck do
     url :stable
   end

--- a/Livecheckables/libsigc++.rb
+++ b/Livecheckables/libsigc++.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libsigcxx
   livecheck do
     url :stable
   end

--- a/Livecheckables/libsoup.rb
+++ b/Livecheckables/libsoup.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libsoup
   livecheck do
     url :stable
   end

--- a/Livecheckables/libxml++3.rb
+++ b/Livecheckables/libxml++3.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Libxmlxx3
   livecheck do
     url :stable
   end

--- a/Livecheckables/mm-common.rb
+++ b/Livecheckables/mm-common.rb
@@ -1,4 +1,4 @@
-class Goffice
+class MmCommon
   livecheck do
     url :stable
   end

--- a/Livecheckables/msitools.rb
+++ b/Livecheckables/msitools.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Msitools
   livecheck do
     url :stable
   end

--- a/Livecheckables/orbit.rb
+++ b/Livecheckables/orbit.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Orbit
   livecheck do
     url :stable
   end

--- a/Livecheckables/pangomm.rb
+++ b/Livecheckables/pangomm.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Pangomm
   livecheck do
     url :stable
   end

--- a/Livecheckables/prefixsuffix.rb
+++ b/Livecheckables/prefixsuffix.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Prefixsuffix
   livecheck do
     url :stable
   end

--- a/Livecheckables/pygobject3.rb
+++ b/Livecheckables/pygobject3.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Pygobject3
   livecheck do
     url :stable
   end

--- a/Livecheckables/simple-scan.rb
+++ b/Livecheckables/simple-scan.rb
@@ -1,4 +1,4 @@
-class Goffice
+class SimpleScan
   livecheck do
     url :stable
   end

--- a/Livecheckables/template-glib.rb
+++ b/Livecheckables/template-glib.rb
@@ -1,4 +1,4 @@
-class Goffice
+class TemplateGlib
   livecheck do
     url :stable
   end

--- a/Livecheckables/tepl.rb
+++ b/Livecheckables/tepl.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Tepl
   livecheck do
     url :stable
   end

--- a/Livecheckables/vala.rb
+++ b/Livecheckables/vala.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Vala
   livecheck do
     url :stable
   end

--- a/Livecheckables/vte3.rb
+++ b/Livecheckables/vte3.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Vte3
   livecheck do
     url :stable
   end

--- a/Livecheckables/yelp-tools.rb
+++ b/Livecheckables/yelp-tools.rb
@@ -1,4 +1,4 @@
-class Goffice
+class YelpTools
   livecheck do
     url :stable
   end

--- a/Livecheckables/zenity.rb
+++ b/Livecheckables/zenity.rb
@@ -1,4 +1,4 @@
-class Goffice
+class Zenity
   livecheck do
     url :stable
   end


### PR DESCRIPTION
This adds/modifies livecheckables to use the `stable` URL for formulae with a `stable` URL that uses the `Gnome` strategy. This also fixes a few issues with some existing livecheckables in the process:

* `gtk+3`: Only match versions with a major version of 3
* `gtkmm3`: Only match versions with a major version of 3
* `libgit2-glib`: Allow matching of any version, since the formula uses a development version (`0.99.0.1`).
* `libgxps`: Allow matching of any version, since the formula seemingly uses a development version (`0.3.1`).