### PR TITLE
Update versioned gcc checks

### DIFF
--- a/Livecheckables/gcc@4.9.rb
+++ b/Livecheckables/gcc@4.9.rb
@@ -1,6 +1,6 @@
 class GccAT49
   livecheck do
-    url "https://ftp.gnu.org/gnu/gcc/"
-    regex(%r{href=.*?gcc[._-]v?(4\.9(?:\.\d+)+)/?["' >]}i)
+    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    regex(%r{href=.*?gcc[._-]v?(4\.9(?:\.\d+)*)(?:/?["' >]|\.t)}i)
   end
 end

--- a/Livecheckables/gcc@5.rb
+++ b/Livecheckables/gcc@5.rb
@@ -1,6 +1,6 @@
 class GccAT5
   livecheck do
-    url "https://ftp.gnu.org/gnu/gcc/"
-    regex(%r{href=.*?gcc[._-]v?(5(?:\.\d+)+)/?["' >]}i)
+    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    regex(%r{href=.*?gcc[._-]v?(5(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 end

--- a/Livecheckables/gcc@6.rb
+++ b/Livecheckables/gcc@6.rb
@@ -1,6 +1,6 @@
 class GccAT6
   livecheck do
-    url "https://ftp.gnu.org/gnu/gcc/"
-    regex(%r{href=.*?gcc[._-]v?(6(?:\.\d+)+)/?["' >]}i)
+    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    regex(%r{href=.*?gcc[._-]v?(6(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 end

--- a/Livecheckables/gcc@7.rb
+++ b/Livecheckables/gcc@7.rb
@@ -1,6 +1,6 @@
 class GccAT7
   livecheck do
-    url "https://ftp.gnu.org/gnu/gcc/"
-    regex(%r{href=.*?gcc[._-]v?(7(?:\.\d+)+)/?["' >]}i)
+    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    regex(%r{href=.*?gcc[._-]v?(7(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 end

--- a/Livecheckables/gcc@8.rb
+++ b/Livecheckables/gcc@8.rb
@@ -1,0 +1,6 @@
+class GccAT8
+  livecheck do
+    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    regex(%r{href=.*?gcc[._-]v?(8(?:\.\d+)+)(?:/?["' >]|\.t)}i)
+  end
+end

--- a/Livecheckables/gcc@9.rb
+++ b/Livecheckables/gcc@9.rb
@@ -1,0 +1,6 @@
+class GccAT9
+  livecheck do
+    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    regex(%r{href=.*?gcc[._-]v?(9(?:\.\d+)+)(?:/?["' >]|\.t)}i)
+  end
+end


### PR DESCRIPTION
This adds/modifies livecheckables for the various versioned `gcc` formulae, bringing them in line with the check for `gcc`.