### PR TITLE
Use stable for GNU formulae

### DIFF
--- a/Livecheckables/a2ps.rb
+++ b/Livecheckables/a2ps.rb
@@ -1,0 +1,5 @@
+class A2ps
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/arm-linux-gnueabihf-binutils.rb
+++ b/Livecheckables/arm-linux-gnueabihf-binutils.rb
@@ -1,0 +1,5 @@
+class ArmLinuxGnueabihfBinutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/aspell.rb
+++ b/Livecheckables/aspell.rb
@@ -1,6 +1,5 @@
 class Aspell
   livecheck do
-    url "https://ftp.gnu.org/gnu/aspell/?C=M&O=D"
-    regex(/href=.*?aspell[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
   end
 end

--- a/Livecheckables/autoconf-archive.rb
+++ b/Livecheckables/autoconf-archive.rb
@@ -1,0 +1,5 @@
+class AutoconfArchive
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/autoconf.rb
+++ b/Livecheckables/autoconf.rb
@@ -1,6 +1,5 @@
 class Autoconf
   livecheck do
-    url "https://git.savannah.gnu.org/git/autoconf.git"
-    regex(/^(?:autoconf-)?v?(\d+(?:\.\d+)+)$/i)
+    url :stable
   end
 end

--- a/Livecheckables/autogen.rb
+++ b/Livecheckables/autogen.rb
@@ -1,6 +1,6 @@
 class Autogen
   livecheck do
-    url "https://ftp.gnu.org/gnu/autogen/"
+    url :stable
     regex(%r{href=.*?rel(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/automake.rb
+++ b/Livecheckables/automake.rb
@@ -1,0 +1,5 @@
+class Automake
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bc.rb
+++ b/Livecheckables/bc.rb
@@ -1,0 +1,5 @@
+class Bc
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/binutils.rb
+++ b/Livecheckables/binutils.rb
@@ -1,0 +1,5 @@
+class Binutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/bison.rb
+++ b/Livecheckables/bison.rb
@@ -1,0 +1,5 @@
+class Bison
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/cflow.rb
+++ b/Livecheckables/cflow.rb
@@ -1,0 +1,5 @@
+class Cflow
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/coreutils.rb
+++ b/Livecheckables/coreutils.rb
@@ -1,0 +1,5 @@
+class Coreutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/cpio.rb
+++ b/Livecheckables/cpio.rb
@@ -1,0 +1,5 @@
+class Cpio
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/cppi.rb
+++ b/Livecheckables/cppi.rb
@@ -1,0 +1,5 @@
+class Cppi
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/datamash.rb
+++ b/Livecheckables/datamash.rb
@@ -1,0 +1,5 @@
+class Datamash
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ddd.rb
+++ b/Livecheckables/ddd.rb
@@ -1,0 +1,5 @@
+class Ddd
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ddrescue.rb
+++ b/Livecheckables/ddrescue.rb
@@ -1,0 +1,5 @@
+class Ddrescue
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/deja-gnu.rb
+++ b/Livecheckables/deja-gnu.rb
@@ -1,0 +1,5 @@
+class DejaGnu
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/diction.rb
+++ b/Livecheckables/diction.rb
@@ -1,0 +1,5 @@
+class Diction
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/diffutils.rb
+++ b/Livecheckables/diffutils.rb
@@ -1,0 +1,5 @@
+class Diffutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/direvent.rb
+++ b/Livecheckables/direvent.rb
@@ -1,0 +1,5 @@
+class Direvent
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ed.rb
+++ b/Livecheckables/ed.rb
@@ -1,0 +1,5 @@
+class Ed
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/emacs.rb
+++ b/Livecheckables/emacs.rb
@@ -1,6 +1,5 @@
 class Emacs
   livecheck do
-    url :head
-    regex(/emacs[._-]v?(\d+\.\d+)$/i)
+    url :stable
   end
 end

--- a/Livecheckables/enscript.rb
+++ b/Livecheckables/enscript.rb
@@ -1,0 +1,5 @@
+class Enscript
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/findutils.rb
+++ b/Livecheckables/findutils.rb
@@ -1,0 +1,5 @@
+class Findutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/freedink.rb
+++ b/Livecheckables/freedink.rb
@@ -1,0 +1,5 @@
+class Freedink
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/freeipmi.rb
+++ b/Livecheckables/freeipmi.rb
@@ -1,0 +1,5 @@
+class Freeipmi
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gawk.rb
+++ b/Livecheckables/gawk.rb
@@ -1,0 +1,5 @@
+class Gawk
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gcal.rb
+++ b/Livecheckables/gcal.rb
@@ -1,0 +1,5 @@
+class Gcal
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gdb.rb
+++ b/Livecheckables/gdb.rb
@@ -1,6 +1,5 @@
 class Gdb
   livecheck do
-    url "https://ftp.gnu.org/gnu/gdb/?C=M&O=D"
-    regex(/href=.*?gdb[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
   end
 end

--- a/Livecheckables/gdbm.rb
+++ b/Livecheckables/gdbm.rb
@@ -1,0 +1,5 @@
+class Gdbm
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gengetopt.rb
+++ b/Livecheckables/gengetopt.rb
@@ -1,0 +1,5 @@
+class Gengetopt
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gettext.rb
+++ b/Livecheckables/gettext.rb
@@ -1,0 +1,5 @@
+class Gettext
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/glpk.rb
+++ b/Livecheckables/glpk.rb
@@ -1,0 +1,5 @@
+class Glpk
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-barcode.rb
+++ b/Livecheckables/gnu-barcode.rb
@@ -1,0 +1,5 @@
+class GnuBarcode
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-chess.rb
+++ b/Livecheckables/gnu-chess.rb
@@ -1,0 +1,6 @@
+class GnuChess
+  livecheck do
+    url :stable
+    regex(/href=.*?gnuchess[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/gnu-complexity.rb
+++ b/Livecheckables/gnu-complexity.rb
@@ -1,0 +1,5 @@
+class GnuComplexity
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-go.rb
+++ b/Livecheckables/gnu-go.rb
@@ -1,0 +1,5 @@
+class GnuGo
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-indent.rb
+++ b/Livecheckables/gnu-indent.rb
@@ -1,0 +1,5 @@
+class GnuIndent
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-sed.rb
+++ b/Livecheckables/gnu-sed.rb
@@ -1,0 +1,5 @@
+class GnuSed
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-shogi.rb
+++ b/Livecheckables/gnu-shogi.rb
@@ -1,0 +1,5 @@
+class GnuShogi
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-smalltalk.rb
+++ b/Livecheckables/gnu-smalltalk.rb
@@ -1,0 +1,5 @@
+class GnuSmalltalk
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-tar.rb
+++ b/Livecheckables/gnu-tar.rb
@@ -1,0 +1,5 @@
+class GnuTar
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-time.rb
+++ b/Livecheckables/gnu-time.rb
@@ -1,0 +1,5 @@
+class GnuTime
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-typist.rb
+++ b/Livecheckables/gnu-typist.rb
@@ -1,0 +1,5 @@
+class GnuTypist
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-units.rb
+++ b/Livecheckables/gnu-units.rb
@@ -1,0 +1,5 @@
+class GnuUnits
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnu-which.rb
+++ b/Livecheckables/gnu-which.rb
@@ -1,0 +1,5 @@
+class GnuWhich
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gnunet.rb
+++ b/Livecheckables/gnunet.rb
@@ -1,0 +1,5 @@
+class Gnunet
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gpatch.rb
+++ b/Livecheckables/gpatch.rb
@@ -1,0 +1,5 @@
+class Gpatch
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gperf.rb
+++ b/Livecheckables/gperf.rb
@@ -1,0 +1,5 @@
+class Gperf
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/grep.rb
+++ b/Livecheckables/grep.rb
@@ -1,0 +1,5 @@
+class Grep
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/groff.rb
+++ b/Livecheckables/groff.rb
@@ -1,0 +1,5 @@
+class Groff
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gsasl.rb
+++ b/Livecheckables/gsasl.rb
@@ -1,0 +1,5 @@
+class Gsasl
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/gsl.rb
+++ b/Livecheckables/gsl.rb
@@ -1,0 +1,5 @@
+class Gsl
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/guile.rb
+++ b/Livecheckables/guile.rb
@@ -1,6 +1,5 @@
 class Guile
   livecheck do
-    url "https://ftp.gnu.org/gnu/guile/"
-    regex(/href=.*?guile[._-]v?([\d.]+\.[\d.]+\.[\d.]+)\.t/i)
+    url :stable
   end
 end

--- a/Livecheckables/gzip.rb
+++ b/Livecheckables/gzip.rb
@@ -1,0 +1,5 @@
+class Gzip
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/hello.rb
+++ b/Livecheckables/hello.rb
@@ -1,0 +1,5 @@
+class Hello
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/help2man.rb
+++ b/Livecheckables/help2man.rb
@@ -1,0 +1,5 @@
+class Help2man
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/httptunnel.rb
+++ b/Livecheckables/httptunnel.rb
@@ -1,0 +1,5 @@
+class Httptunnel
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/i386-elf-gdb.rb
+++ b/Livecheckables/i386-elf-gdb.rb
@@ -1,6 +1,5 @@
 class I386ElfGdb
   livecheck do
-    url "https://ftp.gnu.org/gnu/gdb/?C=M&O=D"
-    regex(/href=.*?gdb[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
   end
 end

--- a/Livecheckables/i686-elf-binutils.rb
+++ b/Livecheckables/i686-elf-binutils.rb
@@ -1,0 +1,5 @@
+class I686ElfBinutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/i686-elf-gcc.rb
+++ b/Livecheckables/i686-elf-gcc.rb
@@ -1,0 +1,5 @@
+class I686ElfGcc
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/idutils.rb
+++ b/Livecheckables/idutils.rb
@@ -1,0 +1,5 @@
+class Idutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/inetutils.rb
+++ b/Livecheckables/inetutils.rb
@@ -1,0 +1,5 @@
+class Inetutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/kawa.rb
+++ b/Livecheckables/kawa.rb
@@ -1,7 +1,6 @@
 class Kawa
   livecheck do
-    url "https://ftp.gnu.org/gnu/kawa"
-    strategy :page_match
-    regex(/href=.*?kawa[._-]v?(\d+\.\d+(\.\d+)?)\.zip/i)
+    url :stable
+    regex(/href=.*?kawa[._-]v?(\d+(?:\.\d+)+)\.(?:t|zip)/i)
   end
 end

--- a/Livecheckables/libcdio.rb
+++ b/Livecheckables/libcdio.rb
@@ -1,0 +1,5 @@
+class Libcdio
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libextractor.rb
+++ b/Livecheckables/libextractor.rb
@@ -1,0 +1,5 @@
+class Libextractor
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libffcall.rb
+++ b/Livecheckables/libffcall.rb
@@ -1,0 +1,5 @@
+class Libffcall
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libiconv.rb
+++ b/Livecheckables/libiconv.rb
@@ -1,0 +1,5 @@
+class Libiconv
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libidn.rb
+++ b/Livecheckables/libidn.rb
@@ -1,0 +1,5 @@
+class Libidn
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libidn2.rb
+++ b/Livecheckables/libidn2.rb
@@ -1,6 +1,6 @@
 class Libidn2
   livecheck do
-    url "https://ftp.gnu.org/gnu/libidn/"
+    url :stable
     regex(/href=.*?libidn2[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libmicrohttpd.rb
+++ b/Livecheckables/libmicrohttpd.rb
@@ -1,0 +1,5 @@
+class Libmicrohttpd
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libmpc.rb
+++ b/Livecheckables/libmpc.rb
@@ -1,0 +1,5 @@
+class Libmpc
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libosip.rb
+++ b/Livecheckables/libosip.rb
@@ -1,0 +1,6 @@
+class Libosip
+  livecheck do
+    url :stable
+    regex(/href=.*?libosip2[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/libsigsegv.rb
+++ b/Livecheckables/libsigsegv.rb
@@ -1,0 +1,5 @@
+class Libsigsegv
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libtasn1.rb
+++ b/Livecheckables/libtasn1.rb
@@ -1,0 +1,5 @@
+class Libtasn1
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libtool.rb
+++ b/Livecheckables/libtool.rb
@@ -1,0 +1,5 @@
+class Libtool
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libunistring.rb
+++ b/Livecheckables/libunistring.rb
@@ -1,0 +1,5 @@
+class Libunistring
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/libxmi.rb
+++ b/Livecheckables/libxmi.rb
@@ -1,0 +1,5 @@
+class Libxmi
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/lightning.rb
+++ b/Livecheckables/lightning.rb
@@ -1,0 +1,5 @@
+class Lightning
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/m4.rb
+++ b/Livecheckables/m4.rb
@@ -1,0 +1,5 @@
+class M4
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mailutils.rb
+++ b/Livecheckables/mailutils.rb
@@ -1,0 +1,5 @@
+class Mailutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/make.rb
+++ b/Livecheckables/make.rb
@@ -1,0 +1,5 @@
+class Make
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/marst.rb
+++ b/Livecheckables/marst.rb
@@ -1,0 +1,5 @@
+class Marst
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mdk.rb
+++ b/Livecheckables/mdk.rb
@@ -1,0 +1,6 @@
+class Mdk
+  livecheck do
+    url :stable
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+end

--- a/Livecheckables/moe.rb
+++ b/Livecheckables/moe.rb
@@ -1,0 +1,5 @@
+class Moe
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mpfr.rb
+++ b/Livecheckables/mpfr.rb
@@ -1,0 +1,5 @@
+class Mpfr
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/mtools.rb
+++ b/Livecheckables/mtools.rb
@@ -1,0 +1,5 @@
+class Mtools
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ncurses.rb
+++ b/Livecheckables/ncurses.rb
@@ -1,0 +1,5 @@
+class Ncurses
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/nettle.rb
+++ b/Livecheckables/nettle.rb
@@ -1,0 +1,5 @@
+class Nettle
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ocrad.rb
+++ b/Livecheckables/ocrad.rb
@@ -1,0 +1,5 @@
+class Ocrad
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/parallel.rb
+++ b/Livecheckables/parallel.rb
@@ -1,0 +1,5 @@
+class Parallel
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/plotutils.rb
+++ b/Livecheckables/plotutils.rb
@@ -1,0 +1,5 @@
+class Plotutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/pth.rb
+++ b/Livecheckables/pth.rb
@@ -1,0 +1,5 @@
+class Pth
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/rcs.rb
+++ b/Livecheckables/rcs.rb
@@ -1,0 +1,5 @@
+class Rcs
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/recutils.rb
+++ b/Livecheckables/recutils.rb
@@ -1,0 +1,5 @@
+class Recutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/rush.rb
+++ b/Livecheckables/rush.rb
@@ -1,0 +1,5 @@
+class Rush
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/screen.rb
+++ b/Livecheckables/screen.rb
@@ -1,0 +1,5 @@
+class Screen
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/shtool.rb
+++ b/Livecheckables/shtool.rb
@@ -1,0 +1,5 @@
+class Shtool
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/source-highlight.rb
+++ b/Livecheckables/source-highlight.rb
@@ -1,6 +1,6 @@
 class SourceHighlight
   livecheck do
     url :stable
-    regex(/source-highlight[._-]v?(\d+(?:\.\d+)+)/i)
+    regex(/href=.*?source-highlight[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/stow.rb
+++ b/Livecheckables/stow.rb
@@ -1,0 +1,5 @@
+class Stow
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/texinfo.rb
+++ b/Livecheckables/texinfo.rb
@@ -1,0 +1,5 @@
+class Texinfo
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/ucommon.rb
+++ b/Livecheckables/ucommon.rb
@@ -1,0 +1,6 @@
+class Ucommon
+  livecheck do
+    url :stable
+    regex(/href=.*?ucommon[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/vcdimager.rb
+++ b/Livecheckables/vcdimager.rb
@@ -1,0 +1,5 @@
+class Vcdimager
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/wdiff.rb
+++ b/Livecheckables/wdiff.rb
@@ -1,0 +1,5 @@
+class Wdiff
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/wget.rb
+++ b/Livecheckables/wget.rb
@@ -1,0 +1,5 @@
+class Wget
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/x86_64-elf-binutils.rb
+++ b/Livecheckables/x86_64-elf-binutils.rb
@@ -1,0 +1,5 @@
+class X8664ElfBinutils
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/x86_64-elf-gcc.rb
+++ b/Livecheckables/x86_64-elf-gcc.rb
@@ -1,0 +1,5 @@
+class X8664ElfGcc
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/xboard.rb
+++ b/Livecheckables/xboard.rb
@@ -1,6 +1,5 @@
 class Xboard
   livecheck do
-    url "https://ftp.gnu.org/gnu/xboard/"
-    regex(/href=.*?xboard[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
   end
 end

--- a/Livecheckables/xorriso.rb
+++ b/Livecheckables/xorriso.rb
@@ -1,0 +1,5 @@
+class Xorriso
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/xshogi.rb
+++ b/Livecheckables/xshogi.rb
@@ -1,0 +1,5 @@
+class Xshogi
+  livecheck do
+    url :stable
+  end
+end

--- a/Livecheckables/zile.rb
+++ b/Livecheckables/zile.rb
@@ -1,0 +1,5 @@
+class Zile
+  livecheck do
+    url :stable
+  end
+end


### PR DESCRIPTION
This adds/modifies livecheckables to use the `stable` URL for formulae with a `stable` URL that uses the `Gnu` strategy.