### PR TITLE
gdcm: update url and regex

### DIFF
--- a/Livecheckables/gdcm.rb
+++ b/Livecheckables/gdcm.rb
@@ -1,6 +1,6 @@
 class Gdcm
   livecheck do
-    url :homepage
-    regex(%r{url=.*?/gdcm[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url "https://github.com/malaterre/GDCM/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 end


### PR DESCRIPTION
This updates the existing livecheckable for `gdcm` to check the "latest" GitHub release, since the stable archives now come from the GitHub repository.