### PR TITLE
Add/update livecheckables for LibreOffice formulae

### DIFF
--- a/Livecheckables/cppunit.rb
+++ b/Livecheckables/cppunit.rb
@@ -1,6 +1,6 @@
 class Cppunit
   livecheck do
-    url :homepage
-    regex(/href=.*?cppunit[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://dev-www.libreoffice.org/src/"
+    regex(/href=["']?cppunit[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libcdr.rb
+++ b/Livecheckables/libcdr.rb
@@ -1,6 +1,6 @@
 class Libcdr
   livecheck do
     url "https://dev-www.libreoffice.org/src/"
-    regex(/.*href=.*?libcdr[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=["']?libcdr[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libetonyek.rb
+++ b/Livecheckables/libetonyek.rb
@@ -1,6 +1,6 @@
 class Libetonyek
   livecheck do
-    url "https://dev-www.libreoffice.org/src/libetonyek/"
-    regex(/href=.*?libetonyek[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://dev-www.libreoffice.org/src/"
+    regex(/href=["']?libetonyek[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libfreehand.rb
+++ b/Livecheckables/libfreehand.rb
@@ -1,0 +1,6 @@
+class Libfreehand
+  livecheck do
+    url "https://dev-www.libreoffice.org/src/"
+    regex(/href=["']?libfreehand[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/libmspub.rb
+++ b/Livecheckables/libmspub.rb
@@ -1,6 +1,6 @@
 class Libmspub
   livecheck do
-    url "https://dev-www.libreoffice.org/src/libmspub/"
-    regex(/href=.*?libmspub[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://dev-www.libreoffice.org/src/"
+    regex(/href=["']?libmspub[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libodfgen.rb
+++ b/Livecheckables/libodfgen.rb
@@ -1,0 +1,6 @@
+class Libodfgen
+  livecheck do
+    url "https://dev-www.libreoffice.org/src/"
+    regex(/href=["']?libodfgen[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/libpagemaker.rb
+++ b/Livecheckables/libpagemaker.rb
@@ -1,6 +1,6 @@
 class Libpagemaker
   livecheck do
-    url "https://dev-www.libreoffice.org/src/libpagemaker/"
-    regex(/href=.*?libpagemaker[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://dev-www.libreoffice.org/src/"
+    regex(/href=["']?libpagemaker[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/librevenge.rb
+++ b/Livecheckables/librevenge.rb
@@ -1,0 +1,6 @@
+class Librevenge
+  livecheck do
+    url "https://dev-www.libreoffice.org/src/"
+    regex(/href=["']?librevenge[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/libvisio.rb
+++ b/Livecheckables/libvisio.rb
@@ -1,6 +1,6 @@
 class Libvisio
   livecheck do
-    url "https://dev-www.libreoffice.org/src/libvisio/"
-    regex(/href=.*?libvisio[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://dev-www.libreoffice.org/src/"
+    regex(/href=["']?libvisio[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libwpd.rb
+++ b/Livecheckables/libwpd.rb
@@ -1,6 +1,6 @@
 class Libwpd
   livecheck do
     url "https://dev-www.libreoffice.org/src/"
-    regex(/.*href=.*?libwpd[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=["']?libwpd[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libwpg.rb
+++ b/Livecheckables/libwpg.rb
@@ -1,6 +1,6 @@
 class Libwpg
   livecheck do
     url "https://dev-www.libreoffice.org/src/"
-    regex(/.*href=.*?libwpg[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=["']?libwpg[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
This adds/modifies livecheckables that come from https://dev-www.libreoffice.org/src/, to standardize their URLs and regexes.