### PR TITLE
Add/update Savannah/non-GNU livecheckables

### DIFF
--- a/Livecheckables/aldo.rb
+++ b/Livecheckables/aldo.rb
@@ -1,0 +1,6 @@
+class Aldo
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/aldo/"
+    regex(/href=.*?aldo[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/atool.rb
+++ b/Livecheckables/atool.rb
@@ -1,7 +1,6 @@
 class Atool
   livecheck do
-    url "https://download.savannah.gnu.org/releases/atool/?C=M&O=D"
-    strategy :page_match
+    url "https://download.savannah.gnu.org/releases/atool/"
     regex(/href=.*?atool[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/avrdude.rb
+++ b/Livecheckables/avrdude.rb
@@ -1,7 +1,6 @@
 class Avrdude
   livecheck do
     url "https://download.savannah.gnu.org/releases/avrdude/"
-    strategy :page_match
     regex(/href=.*?avrdude[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/dvdrtools.rb
+++ b/Livecheckables/dvdrtools.rb
@@ -1,7 +1,6 @@
 class Dvdrtools
   livecheck do
     url "https://download.savannah.gnu.org/releases/dvdrtools/"
-    strategy :page_match
     regex(/href=.*?dvdrtools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/fastjar.rb
+++ b/Livecheckables/fastjar.rb
@@ -1,0 +1,6 @@
+class Fastjar
+  livecheck do
+    url "https://download.savannah.nongnu.org/releases/fastjar/"
+    regex(/href=.*?fastjar[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/icoutils.rb
+++ b/Livecheckables/icoutils.rb
@@ -1,7 +1,6 @@
 class Icoutils
   livecheck do
     url "https://download.savannah.gnu.org/releases/icoutils/"
-    strategy :page_match
     regex(/href=.*?icoutils[._-](\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libntlm.rb
+++ b/Livecheckables/libntlm.rb
@@ -1,0 +1,6 @@
+class Libntlm
+  livecheck do
+    url "https://www.nongnu.org/libntlm/releases/"
+    regex(/href=.*?libntlm[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/lzip.rb
+++ b/Livecheckables/lzip.rb
@@ -1,7 +1,6 @@
 class Lzip
   livecheck do
     url "https://download.savannah.gnu.org/releases/lzip/"
-    strategy :page_match
     regex(/href=.*?lzip[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/normalize.rb
+++ b/Livecheckables/normalize.rb
@@ -1,0 +1,6 @@
+class Normalize
+  livecheck do
+    url "https://download.savannah.gnu.org/releases/normalize/"
+    regex(/href=.*?normalize[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end

--- a/Livecheckables/tcc.rb
+++ b/Livecheckables/tcc.rb
@@ -1,0 +1,6 @@
+class Tcc
+  livecheck do
+    url "https://download.savannah.nongnu.org/releases/tinycc/"
+    regex(/href=.*?tcc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
This adds livecheckables for `aldo`, `fastjar`, `libntlm`, `normalize`, and `tcc`, which come from download.savannah.gnu.org, download.savannah.nongnu.org, or www.nongnu.org.

This also updates some existing Savannah livecheckables to bring them in line with the others. This primarily involves removing `strategy :page_match` (for now), as it isn't explicitly necessary and I had only added it while working on potentially adding support for Savannah URLs to the `Gnu` formula earlier.