### PR TITLE
onioncat: update url

### DIFF
--- a/Livecheckables/onioncat.rb
+++ b/Livecheckables/onioncat.rb
@@ -1,6 +1,6 @@
 class Onioncat
   livecheck do
-    url "https://www.cypherpunk.at/ocat/download/Source/stable/"
+    url "https://www.cypherpunk.at/ocat/download/Source/current/"
     regex(/href=.*?onioncat[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end


### PR DESCRIPTION
The `onioncat` formula was recently updated from 0.2.8 (latest "stable" release) to 0.3.8 (latest "current" release). The existing livecheckable was previously checking the "stable" release folder but with the formula moving to a "current" release, it was necessary to update the livecheckable accordingly.