### PR TITLE
aardvark_shell_utils: update url and regex

### DIFF
--- a/Livecheckables/aardvark_shell_utils.rb
+++ b/Livecheckables/aardvark_shell_utils.rb
@@ -1,6 +1,8 @@
 class AardvarkShellUtils
+  # This regex is multiline since there's a line break between `href=` and the
+  # attribute value on the homepage.
   livecheck do
-    url "http://downloads.laffeycomputer.com/current_builds/shellutils/"
-    regex(/href=.*?aardvark_shell_utils[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :homepage
+    regex(/href=.*?aardvark_shell_utils[._-]v?(\d+(?:\.\d+)+)\.t/im)
   end
 end


### PR DESCRIPTION
The existing check for `aardvark_shell_utils` broke because downloads.laffeycomputer.com is currently missing. This updates the livecheckable to use the homepage instead, updating the regex accordingly.