### PR TITLE
fossil: update url and regex

### DIFF
--- a/Livecheckables/fossil.rb
+++ b/Livecheckables/fossil.rb
@@ -1,6 +1,6 @@
 class Fossil
   livecheck do
-    url "https://www.fossil-scm.org/home/uv/download.js"
-    regex(/"title": *?"Version (\d+(?:\.\d+)+) circa/i)
+    url "https://www.fossil-scm.org/index.html/uv/download.js"
+    regex(/"title": *?"Version (\d+(?:\.\d+)+)/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `fossil` broke due to the `download.js` URL and the `title` string format changing. This updates the livecheckable accordingly.