### PR TITLE
Use stable urls and explain exceptions

### DIFF
--- a/Livecheckables/bashdb.rb
+++ b/Livecheckables/bashdb.rb
@@ -1,4 +1,7 @@
 class Bashdb
+  # We check the "bashdb" directory page because the bashdb project contains
+  # various software and bashdb releases may be pushed out of the SourceForge
+  # RSS feed.
   livecheck do
     url "https://sourceforge.net/projects/bashdb/files/bashdb/"
     strategy :page_match

--- a/Livecheckables/devil.rb
+++ b/Livecheckables/devil.rb
@@ -1,4 +1,4 @@
-class Mesa
+class Devil
   livecheck do
     url :stable
   end

--- a/Livecheckables/gcc.rb
+++ b/Livecheckables/gcc.rb
@@ -1,6 +1,6 @@
 class Gcc
   livecheck do
-    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    url :stable
     regex(%r{href=.*?gcc[._-]v?(\d+(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 end

--- a/Livecheckables/gcc@4.9.rb
+++ b/Livecheckables/gcc@4.9.rb
@@ -1,6 +1,6 @@
 class GccAT49
   livecheck do
-    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    url :stable
     regex(%r{href=.*?gcc[._-]v?(4\.9(?:\.\d+)*)(?:/?["' >]|\.t)}i)
   end
 end

--- a/Livecheckables/gcc@5.rb
+++ b/Livecheckables/gcc@5.rb
@@ -1,6 +1,6 @@
 class GccAT5
   livecheck do
-    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    url :stable
     regex(%r{href=.*?gcc[._-]v?(5(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 end

--- a/Livecheckables/gcc@6.rb
+++ b/Livecheckables/gcc@6.rb
@@ -1,6 +1,6 @@
 class GccAT6
   livecheck do
-    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    url :stable
     regex(%r{href=.*?gcc[._-]v?(6(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 end

--- a/Livecheckables/gcc@7.rb
+++ b/Livecheckables/gcc@7.rb
@@ -1,6 +1,6 @@
 class GccAT7
   livecheck do
-    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    url :stable
     regex(%r{href=.*?gcc[._-]v?(7(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 end

--- a/Livecheckables/gcc@8.rb
+++ b/Livecheckables/gcc@8.rb
@@ -1,6 +1,6 @@
 class GccAT8
   livecheck do
-    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    url :stable
     regex(%r{href=.*?gcc[._-]v?(8(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 end

--- a/Livecheckables/gcc@9.rb
+++ b/Livecheckables/gcc@9.rb
@@ -1,6 +1,6 @@
 class GccAT9
   livecheck do
-    url "https://ftp.gnu.org/gnu/gcc/?C=M&O=D"
+    url :stable
     regex(%r{href=.*?gcc[._-]v?(9(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 end

--- a/Livecheckables/geoserver.rb
+++ b/Livecheckables/geoserver.rb
@@ -1,10 +1,11 @@
 class Geoserver
   # GeoServer releases contain a large number of files for each version, so the
-  # SourceForge RSS feed may only contain the latest version (which may have a
-  # different major/minor version than the latest stable). We check the GitHub
-  # repo tags here instead, to make sure we get all the latest versions.
+  # SourceForge RSS feed may only contain the most recent version (which may
+  # have a different major/minor version than the latest stable). We check the
+  # "GeoServer" directory page instead, since this is reliable.
   livecheck do
-    url "https://github.com/geoserver/geoserver"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://sourceforge.net/projects/geoserver/files/GeoServer/"
+    strategy :page_match
+    regex(%r{href=(?:["']|.*?GeoServer/)?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end

--- a/Livecheckables/gtk+.rb
+++ b/Livecheckables/gtk+.rb
@@ -1,6 +1,6 @@
 class Gtkx
   livecheck do
-    url "https://download.gnome.org/sources/gtk+/"
+    url :stable
     regex(/gtk\+[._-]v?(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 end

--- a/Livecheckables/libdc1394.rb
+++ b/Livecheckables/libdc1394.rb
@@ -1,4 +1,4 @@
-class Mesa
+class Libdc1394
   livecheck do
     url :stable
   end

--- a/Livecheckables/pulseaudio.rb
+++ b/Livecheckables/pulseaudio.rb
@@ -1,7 +1,7 @@
-class Sqoop
+class Pulseaudio
   # The regex here avoids x.99 releases, as they're pre-release versions.
   livecheck do
     url :stable
-    regex(%r{href=["']?v?((?!\d+\.9\d+)\d+(?:\.\d+)+)/?["' >]}i)
+    regex(/href=["']?pulseaudio[._-]v?((?!\d+\.9\d+)\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/remake.rb
+++ b/Livecheckables/remake.rb
@@ -1,4 +1,7 @@
 class Remake
+  # We check the "remake" directory page because the bashdb project contains
+  # various software and remake releases may be pushed out of the SourceForge
+  # RSS feed.
   livecheck do
     url "https://sourceforge.net/projects/bashdb/files/remake/"
     strategy :page_match

--- a/Livecheckables/safe-rm.rb
+++ b/Livecheckables/safe-rm.rb
@@ -1,4 +1,4 @@
-class Mesa
+class SafeRm
   livecheck do
     url :stable
   end

--- a/Livecheckables/uchardet.rb
+++ b/Livecheckables/uchardet.rb
@@ -1,4 +1,4 @@
-class Mesa
+class Uchardet
   livecheck do
     url :stable
   end

--- a/Livecheckables/zboy.rb
+++ b/Livecheckables/zboy.rb
@@ -1,6 +1,6 @@
 class Zboy
   livecheck do
-    url :head
+    url :stable
     regex(%r{url=.*?/zboy[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 end

--- a/Livecheckables/zshdb.rb
+++ b/Livecheckables/zshdb.rb
@@ -1,4 +1,7 @@
 class Zshdb
+  # We check the "zshdb" directory page because the bashdb project contains
+  # various software and zshdb releases may be pushed out of the SourceForge
+  # RSS feed.
   livecheck do
     url "https://sourceforge.net/projects/bashdb/files/zshdb/"
     strategy :page_match


### PR DESCRIPTION
This should be most of the remaining formulae that could benefit from having a livecheckable using the stable URL (due to being compatible with an existing strategy).

For the related formulae that aren't using one of these strategies (i.e., using the `PageMatch` strategy due to a technical reason), I made sure to add explanatory comments where it made sense.