### PR TITLE
qtads: add livecheckable

### DIFF
--- a/Livecheckables/qtads.rb
+++ b/Livecheckables/qtads.rb
@@ -1,0 +1,6 @@
+class Qtads
+  livecheck do
+    url "https://github.com/realnc/qtads/releases/latest"
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+  end
+end


### PR DESCRIPTION
This adds a livecheckable for `qtads` which checks the upstream GitHub repository, as that's where new releases now reside. This may not stick around in the long run, as there was trouble updating the `qtads` formula to 3.0.0 and there was discussion of moving the formula to a cask instead. In the interim time, here we are.