### PR TITLE
wildfly-as: update regex

### DIFF
--- a/Livecheckables/wildfly-as.rb
+++ b/Livecheckables/wildfly-as.rb
@@ -1,6 +1,6 @@
 class WildflyAs
   livecheck do
     url "https://wildfly.org/downloads/"
-    regex(/href=.*?wildfly[._-]v?(\d+(?:\.\d+)+\.Final)\.t/i)
+    regex(/href=.*?wildfly[._-]v?(\d+(?:\.\d+)+)\.Final\.t/i)
   end
 end


### PR DESCRIPTION
The existing livecheckable for `wildfly-as` included the `.Final` text at the end of the version. The formula doesn't include this text in its version these days, so I've updated the regex to exclude this text from the matched version.