### PR TITLE
imapsync: add livecheckable

### DIFF
--- a/Livecheckables/imapsync.rb
+++ b/Livecheckables/imapsync.rb
@@ -1,0 +1,6 @@
+class Imapsync
+  livecheck do
+    url "https://imapsync.lamiral.info/dist2/"
+    regex(/href=.*?imapsync[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+end


### PR DESCRIPTION
The default check for `imapsync` was checking the Git repository tags but the latest tagged version is `1.945` whereas the release in the formula (not from GitHub) is `1.977`. This adds a livecheckable that checks for the latest version in the same location as the stable archive, which addresses the issue.