### PR TITLE
Gnome: remove DEV_VERSION_ALLOWLIST

### DIFF
--- a/Livecheckables/gcab.rb
+++ b/Livecheckables/gcab.rb
@@ -1,5 +1,8 @@
 class Gcab
+  # We use a common regex because gcab doesn't use GNOME's "even-numbered minor
+  # is stable" version scheme.
   livecheck do
     url :stable
+    regex(/gcab[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gtk-doc.rb
+++ b/Livecheckables/gtk-doc.rb
@@ -1,5 +1,8 @@
 class GtkDoc
+  # We use a common regex because gtk-doc doesn't use GNOME's "even-numbered
+  # minor is stable" version scheme.
   livecheck do
     url :stable
+    regex(/gtk-doc[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/gtk-mac-integration.rb
+++ b/Livecheckables/gtk-mac-integration.rb
@@ -1,5 +1,8 @@
 class GtkMacIntegration
+  # We use a common regex because gtk-mac-integration doesn't use GNOME's
+  # "even-numbered minor is stable" version scheme.
   livecheck do
     url :stable
+    regex(/gtk-mac-integration[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libart.rb
+++ b/Livecheckables/libart.rb
@@ -1,5 +1,8 @@
 class Libart
+  # We use a common regex because libart doesn't use GNOME's "even-numbered
+  # minor is stable" version scheme.
   livecheck do
     url :stable
+    regex(/libart_lgpl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/Livecheckables/libepoxy.rb
+++ b/Livecheckables/libepoxy.rb
@@ -1,5 +1,8 @@
 class Libepoxy
+  # We use a common regex because libepoxy doesn't use GNOME's "even-numbered
+  # minor is stable" version scheme.
   livecheck do
     url :stable
+    regex(/libepoxy[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 end

--- a/livecheck/livecheck_strategy/gnome.rb
+++ b/livecheck/livecheck_strategy/gnome.rb
@@ -4,17 +4,6 @@ module LivecheckStrategy
   class Gnome
     NICE_NAME = "GNOME"
 
-    # Formulae that do not use GNOME's "even-numbered minor is stable" scheme
-    # "libart_lgpl" is the package name for libart
-    DEV_VERSION_ALLOWLIST = %w[
-      gcab
-      gtk-doc
-      gtk-mac-integration
-      libart_lgpl
-      libepoxy
-    ].freeze
-    private_constant :DEV_VERSION_ALLOWLIST
-
     def self.match?(url)
       /download\.gnome\.org/.match?(url)
     end
@@ -23,12 +12,8 @@ module LivecheckStrategy
       package_name = url.match(%r{/sources/(.*?)/})[1]
 
       page_url = "https://download.gnome.org/sources/#{package_name}/cache.json"
-      regex ||= if DEV_VERSION_ALLOWLIST.include?(package_name)
-        /#{Regexp.escape(package_name)}-(\d+(?:\.\d+)+)\.t/
-      else
-        # Only match versions with an even-numbered minor (except x.90+)
-        /#{Regexp.escape(package_name)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/
-      end
+      # Only match versions with an even-numbered minor (except x.90+)
+      regex ||= /#{Regexp.escape(package_name)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/
 
       PageMatch.find_versions(page_url, regex)
     end


### PR DESCRIPTION
This removes the `DEV_VERSION_ALLOWLIST` from the `Gnome` formula and adds appropriate regexes to the relevant livecheckables. This saves us from having to keep the allowlist up to date as formulae are added/removed while maintaining the same behavior for affected formulae.

Any checks that don't use GNOME's "even-numbered minor is stable" version scheme should simply override the default `Gnome` regex using a `livecheck` block, as these examples do.