### PR TITLE
Add various strategy tweaks

### DIFF
--- a/livecheck/strategy/apache.rb
+++ b/livecheck/strategy/apache.rb
@@ -5,17 +5,17 @@ module LivecheckStrategy
     module_function
 
     def match?(url)
-      %r{www\.apache\.org/dyn}.match?(url)
+      %r{www\.apache\.org/dyn}i.match?(url)
     end
 
     def find_versions(url, regex = nil)
-      path, prefix, suffix = url.match(%r{path=(.+?)/([^/]*?)\d+(?:\.\d+)+(/|[^/]*)})[1, 3]
+      path, prefix, suffix = url.match(%r{path=(.+?)/([^/]*?)\d+(?:\.\d+)+(/|[^/]*)}i)[1, 3]
 
       # Use `\.t` instead of specific tarball extensions (e.g., .tar.gz)
-      suffix.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/, "\.t")
+      suffix.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/i, "\.t")
 
       page_url = "https://archive.apache.org/dist/#{path}/"
-      regex ||= /href=["']?#{Regexp.escape(prefix)}v?(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/
+      regex ||= /href=["']?#{Regexp.escape(prefix)}v?(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/i
 
       PageMatch.find_versions(page_url, regex)
     end

--- a/livecheck/strategy/bitbucket.rb
+++ b/livecheck/strategy/bitbucket.rb
@@ -5,15 +5,15 @@ module LivecheckStrategy
     module_function
 
     def match?(url)
-      %r{bitbucket\.org(/[^/]+){4}\.\w+}.match?(url)
+      %r{bitbucket\.org(/[^/]+){4}\.\w+}i.match?(url)
     end
 
     def find_versions(url, regex = nil)
       path, kind, prefix, suffix =
-        url.match(%r{bitbucket\.org/(.+?)/(get|downloads)/((?:[^/]+?[_-])?)v?\d+(?:\.\d+)+([^/]+)})[1, 4]
+        url.match(%r{bitbucket\.org/(.+?)/(get|downloads)/((?:[^/]+?[_-])?)v?\d+(?:\.\d+)+([^/]+)}i)[1, 4]
 
       # Use `\.t` instead of specific tarball extensions (e.g., .tar.gz)
-      suffix.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/, "\.t")
+      suffix.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/i, "\.t")
 
       page_url = if kind == "get"
         "https://bitbucket.org/#{path}/downloads/?tab=tags"

--- a/livecheck/strategy/bitbucket.rb
+++ b/livecheck/strategy/bitbucket.rb
@@ -9,8 +9,8 @@ module LivecheckStrategy
     end
 
     def find_versions(url, regex = nil)
-      path, kind, suffix =
-        url.match(%r{bitbucket\.org/(.+?)/(get|downloads)/(?:.*?[-_])?v?\d+(?:\.\d+)+([^/]+)})[1, 3]
+      path, kind, prefix, suffix =
+        url.match(%r{bitbucket\.org/(.+?)/(get|downloads)/((?:[^/]+?[_-])?)v?\d+(?:\.\d+)+([^/]+)})[1, 4]
 
       # Use `\.t` instead of specific tarball extensions (e.g., .tar.gz)
       suffix.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/, "\.t")
@@ -20,7 +20,7 @@ module LivecheckStrategy
       else
         "https://bitbucket.org/#{path}/downloads/"
       end
-      regex ||= /href=.*?v?(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/i
+      regex ||= /href=.*?#{Regexp.escape(prefix)}v?(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/i
 
       PageMatch.find_versions(page_url, regex)
     end

--- a/livecheck/strategy/git.rb
+++ b/livecheck/strategy/git.rb
@@ -8,20 +8,20 @@ module LivecheckStrategy
 
     PRIORITY = 8
 
-    def tag_info(repo_url, filter = nil)
+    def tag_info(url, regex = nil)
       stdout_str, stderr_str, _status = Open3.capture3(
-        { "GIT_TERMINAL_PROMPT" => "0" }, "git", "ls-remote", "--tags", repo_url
+        { "GIT_TERMINAL_PROMPT" => "0" }, "git", "ls-remote", "--tags", url
       )
 
       tags_data = { tags: [] }
-      tags_data[:messages] = stderr_str.split("\n") unless stderr_str.blank?
+      tags_data[:messages] = stderr_str.split("\n") if stderr_str.present?
       return tags_data if stdout_str.blank?
 
       stdout_str.gsub!(%r{^.*\trefs/tags/}, "")
-      stdout_str.delete_suffix!("^{}")
+      stdout_str.gsub!("^{}", "")
 
       tags = stdout_str.split("\n").uniq.sort
-      tags.select! { |t| t =~ filter } if filter
+      tags.select! { |t| t =~ regex } if regex
       tags_data[:tags] = tags
 
       tags_data

--- a/livecheck/strategy/gnome.rb
+++ b/livecheck/strategy/gnome.rb
@@ -7,15 +7,15 @@ module LivecheckStrategy
     NICE_NAME = "GNOME"
 
     def match?(url)
-      /download\.gnome\.org/.match?(url)
+      /download\.gnome\.org/i.match?(url)
     end
 
     def find_versions(url, regex = nil)
-      package_name = url.match(%r{/sources/(.*?)/})[1]
+      package_name = url.match(%r{/sources/(.*?)/}i)[1]
 
       page_url = "https://download.gnome.org/sources/#{package_name}/cache.json"
       # Only match versions with an even-numbered minor (except x.90+)
-      regex ||= /#{Regexp.escape(package_name)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/
+      regex ||= /#{Regexp.escape(package_name)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i
 
       PageMatch.find_versions(page_url, regex)
     end

--- a/livecheck/strategy/gnu.rb
+++ b/livecheck/strategy/gnu.rb
@@ -7,8 +7,8 @@ module LivecheckStrategy
     NICE_NAME = "GNU"
 
     PROJECT_NAME_REGEXES = [
-      %r{/(?:gnu|software)/(.+?)/},
-      %r{//(.+?)\.gnu\.org(?:/)?$},
+      %r{/(?:gnu|software)/(.+?)/}i,
+      %r{//(.+?)\.gnu\.org(?:/)?$}i,
     ].freeze
 
     def match?(url)

--- a/livecheck/strategy/launchpad.rb
+++ b/livecheck/strategy/launchpad.rb
@@ -5,11 +5,11 @@ module LivecheckStrategy
     module_function
 
     def match?(url)
-      /launchpad\.net/.match?(url)
+      /launchpad\.net/i.match?(url)
     end
 
     def find_versions(url, regex = nil)
-      package_name = url.match(%r{launchpad\.net/([^/]*)})[1]
+      package_name = url.match(%r{launchpad\.net/([^/]*)}i)[1]
 
       page_url = "https://launchpad.net/#{package_name}"
       regex ||= %r{class="[^"]*version[^"]*"[^>]*>\s*Latest version is (.+)\s*</}

--- a/livecheck/strategy/launchpad.rb
+++ b/livecheck/strategy/launchpad.rb
@@ -12,7 +12,7 @@ module LivecheckStrategy
       package_name = url.match(%r{launchpad\.net/([^/]*)})[1]
 
       page_url = "https://launchpad.net/#{package_name}"
-      regex ||= %r{<div class="version">\s*Latest version is (.+)\s*</div>}
+      regex ||= %r{class="[^"]*version[^"]*"[^>]*>\s*Latest version is (.+)\s*</}
 
       PageMatch.find_versions(page_url, regex)
     end

--- a/livecheck/strategy/npm.rb
+++ b/livecheck/strategy/npm.rb
@@ -7,14 +7,14 @@ module LivecheckStrategy
     NICE_NAME = "npm"
 
     def match?(url)
-      /registry\.npmjs\.org/.match?(url)
+      /registry\.npmjs\.org/i.match?(url)
     end
 
     def find_versions(url, regex = nil)
       %r{registry\.npmjs\.org/(?<package_name>.+)/-/}i =~ url
 
       page_url = "https://www.npmjs.com/package/#{package_name}?activeTab=versions"
-      regex ||= %r{href=.*?/package/#{package_name}/v/(\d+(?:\.\d+)+)"}
+      regex ||= %r{href=.*?/package/#{package_name}/v/(\d+(?:\.\d+)+)"}i
 
       PageMatch.find_versions(page_url, regex)
     end

--- a/livecheck/strategy/npm.rb
+++ b/livecheck/strategy/npm.rb
@@ -14,7 +14,7 @@ module LivecheckStrategy
       %r{registry\.npmjs\.org/(?<package_name>.+)/-/}i =~ url
 
       page_url = "https://www.npmjs.com/package/#{package_name}?activeTab=versions"
-      regex ||= %r{/package/#{package_name}/v/(\d+(?:\.\d+)+)"}
+      regex ||= %r{href=.*?/package/#{package_name}/v/(\d+(?:\.\d+)+)"}
 
       PageMatch.find_versions(page_url, regex)
     end

--- a/livecheck/strategy/npm.rb
+++ b/livecheck/strategy/npm.rb
@@ -11,7 +11,7 @@ module LivecheckStrategy
     end
 
     def find_versions(url, regex = nil)
-      package_name = url.split("/")[3..-3].reject { |s| s == "-" }.join("/")
+      %r{registry\.npmjs\.org/(?<package_name>.+)/-/}i =~ url
 
       page_url = "https://www.npmjs.com/package/#{package_name}?activeTab=versions"
       regex ||= %r{/package/#{package_name}/v/(\d+(?:\.\d+)+)"}

--- a/livecheck/strategy/pypi.rb
+++ b/livecheck/strategy/pypi.rb
@@ -12,13 +12,13 @@ module LivecheckStrategy
 
     def find_versions(url, regex = nil)
       /(?<package_name>.*)-.*?
-       (?<filename_end>\.tar\.[a-z0-9]+|\.[a-z0-9]+)$/ix =~ File.basename(url)
+       (?<suffix>\.tar\.[a-z0-9]+|\.[a-z0-9]+)$/ix =~ File.basename(url)
 
       # Use `\.t` instead of specific tarball extensions (e.g., .tar.gz)
-      filename_end.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/, "\.t")
+      suffix.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/, "\.t")
 
       page_url = "https://pypi.org/project/#{package_name.gsub(/%20|_/, "-")}"
-      regex ||= %r{href=.*?/packages.*?/#{package_name}[._-]v?(\d+(?:\.\d+)*)#{filename_end}}i
+      regex ||= %r{href=.*?/packages.*?/#{package_name}[._-]v?(\d+(?:\.\d+)*)#{suffix}}i
 
       PageMatch.find_versions(page_url, regex)
     end

--- a/livecheck/strategy/pypi.rb
+++ b/livecheck/strategy/pypi.rb
@@ -7,7 +7,7 @@ module LivecheckStrategy
     NICE_NAME = "PyPI"
 
     def match?(url)
-      /files\.pythonhosted\.org/.match?(url)
+      /files\.pythonhosted\.org/i.match?(url)
     end
 
     def find_versions(url, regex = nil)
@@ -15,7 +15,7 @@ module LivecheckStrategy
        (?<suffix>\.tar\.[a-z0-9]+|\.[a-z0-9]+)$/ix =~ File.basename(url)
 
       # Use `\.t` instead of specific tarball extensions (e.g., .tar.gz)
-      suffix.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/, "\.t")
+      suffix.sub!(/\.t(?:ar\..+|[a-z0-9]+)$/i, "\.t")
 
       page_url = "https://pypi.org/project/#{package_name.gsub(/%20|_/, "-")}"
       regex ||= %r{href=.*?/packages.*?/#{package_name}[._-]v?(\d+(?:\.\d+)*)#{suffix}}i

--- a/livecheck/strategy/sourceforge.rb
+++ b/livecheck/strategy/sourceforge.rb
@@ -7,16 +7,16 @@ module LivecheckStrategy
     NICE_NAME = "SourceForge"
 
     def match?(url)
-      /(sourceforge|sf)\.net/.match?(url)
+      /(sourceforge|sf)\.net/i.match?(url)
     end
 
     def find_versions(url, regex = nil)
       project_name = if url.include?("/project")
-        url.match(%r{/projects?/([^/]+)/})[1]
+        url.match(%r{/projects?/([^/]+)/}i)[1]
       elsif url.include?(".net/p/")
-        url.match(%r{\.net/p/([^/]+)/})[1]
+        url.match(%r{\.net/p/([^/]+)/}i)[1]
       else
-        url.match(%r{\.net(?::/cvsroot)?/([^/]+)})[1]
+        url.match(%r{\.net(?::/cvsroot)?/([^/]+)}i)[1]
       end
 
       page_url = "https://sourceforge.net/projects/#{project_name}/rss"

--- a/livecheck/strategy/xorg.rb
+++ b/livecheck/strategy/xorg.rb
@@ -21,7 +21,7 @@ module LivecheckStrategy
       module_name = file_name.match(/^(.*)-\d+/)[1]
 
       page_url = url.sub("x.org/pub/", "x.org/archive/").delete_suffix(file_name)
-      regex ||= /href=.*?#{module_name}[._-]v?(\d+(?:\.\d+)+)\.t/
+      regex ||= /href=.*?#{module_name}[._-]v?(\d+(?:\.\d+)+)\.t/i
 
       match_data = { matches: {}, regex: regex, url: page_url }
 

--- a/livecheck/strategy/xorg.rb
+++ b/livecheck/strategy/xorg.rb
@@ -18,10 +18,10 @@ module LivecheckStrategy
       file_name = File.basename(url)
       return { matches: {}, regex: regex, url: url } unless file_name.include?("-")
 
-      package_name = file_name.match(/^(.*)-\d+/)[1]
+      module_name = file_name.match(/^(.*)-\d+/)[1]
 
       page_url = url.sub("x.org/pub/", "x.org/archive/").delete_suffix(file_name)
-      regex ||= /href=.*?#{package_name}[._-]v?(\d+(?:\.\d+)+)\.t/
+      regex ||= /href=.*?#{module_name}[._-]v?(\d+(?:\.\d+)+)\.t/
 
       match_data = { matches: {}, regex: regex, url: page_url }
 


### PR DESCRIPTION
## Bitbucket

* Identify the filename prefix in the URL and include it in the default regex, when available.

## Git

* Rename variables to bring them more in line with other strategy methods.
* Use `if stderr_str.present?` instead of `unless stderr_str.blank?`.
* Fix `^{}` removal from tags by using `gsub` instead (i.e., `delete_suffix` was a mistake in this context).

## Launchpad

* Reduce regex specificity, to hopefully make it a little less fragile over time.

## Npm

* Rework the `package_name` identification code to make it more understandable.
* Add `href=.*?` to the start of the default regex, to bring it more in line with current regex standards.

## Pypi

* Rename the `filename_end` variable to `suffix`, to bring it more in line with naming conventions in other strategies.

## Xorg
* Rename `package_name` to `module_name`, to reflect upstream terminology for the software.

## Various

* Make strategy regexes case insensitive, except where case sensitivity is needed.