### PR TITLE
little-cms2: update url and regex

### DIFF
--- a/Livecheckables/little-cms2.rb
+++ b/Livecheckables/little-cms2.rb
@@ -1,6 +1,10 @@
 class LittleCms2
+  # The Little CMS website has been redesigned and there's no longer a
+  # "Download" page we can check for releases. As of writing this, checking the
+  # "Releases" blog posts seems to be our best option and we just have to hope
+  # that the post URLs, headings, etc. maintain a consistent format.
   livecheck do
-    url "http://www.littlecms.com/download.html"
-    regex(%r{<h1>Current version is v?(\d+(?:\.\d+)+)</h1>}i)
+    url "http://www.littlecms.com/categories/releases/"
+    regex(%r{href=.*lcms2[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 end


### PR DESCRIPTION
The existing check for `little-cms2` checked the first-party "Download" page for new releases. The formula uses archives from SourceForge but a given release isn't official until it's on the first-party website.

The first-party website has been redesigned and there's no longer a "Download" page to check. Instead, our only option seems to be checking the posts in the blog "Releases" category. At the moment, this check is identifying versions by checking the blog post URLs. There's currently only one example and it looks like this: `http://littlecms.com/blog/2019/10/02/lcms2-2.11/`

There's no telling if this naming convention will remain consistent, so this check will need to be updated in the future if this doesn't hold true over time. The other options right now are to match text in the post title (e.g., `LITTLE CMS 2.11 RELEASED`) or the post content snippet (e.g., `lcms2-2.11`, `2.11`, etc.). The current method may be the most reliable if it remains a consistent option over time.