### PR TITLE
pypy, pypy3: update url and add regex

### DIFF
--- a/Livecheckables/pypy.rb
+++ b/Livecheckables/pypy.rb
@@ -1,5 +1,6 @@
 class Pypy
   livecheck do
-    url :stable
+    url "https://downloads.python.org/pypy/"
+    regex(/href=.*?pypy2(?:\.\d+)*[._-]v?(\d+(?:\.\d+)+)-src\.t/i)
   end
 end

--- a/Livecheckables/pypy3.rb
+++ b/Livecheckables/pypy3.rb
@@ -1,5 +1,6 @@
 class Pypy3
   livecheck do
-    url :stable
+    url "https://downloads.python.org/pypy/"
+    regex(/href=.*?pypy3(?:\.\d+)*[._-]v?(\d+(?:\.\d+)+)-src\.t/i)
   end
 end


### PR DESCRIPTION
The `pypy` and `pypy3` formulae recently switched to using stable archives from https://downloads.python.org. The existing `livecheck` blocks for these formulae simply used `url :stable`, since they previously used Bitbucket archive files.

This updates the existing checks to identify versions on the https://downloads.python.org/pypy/ directory listing page where the stable archives come from.