### PR TITLE
atlassian-cli: update url

### DIFF
--- a/Livecheckables/atlassian-cli.rb
+++ b/Livecheckables/atlassian-cli.rb
@@ -1,6 +1,6 @@
 class AtlassianCli
   livecheck do
-    url "https://marketplace.atlassian.com/plugins/org.swift.atlassian.cli/versions"
+    url "https://marketplace.atlassian.com/apps/10886/atlassian-command-line-interface-cli/version-history"
     regex(/class="version">v?(\d+(?:\.\d+)+)</i)
   end
 end


### PR DESCRIPTION
The URL for the Atlassian CLI page on the marketplace changed, so this updates it to the current location.