### PR TITLE
Skip formulae with a missing Bitbucket repository

### DIFF
--- a/Livecheckables/connect.rb
+++ b/Livecheckables/connect.rb
@@ -1,5 +1,5 @@
 class Connect
   livecheck do
-    url :stable
+    skip "Bitbucket repository is missing"
   end
 end

--- a/Livecheckables/csv-fix.rb
+++ b/Livecheckables/csv-fix.rb
@@ -1,5 +1,5 @@
 class CsvFix
   livecheck do
-    url :stable
+    skip "Bitbucket repository is missing"
   end
 end

--- a/Livecheckables/makeicns.rb
+++ b/Livecheckables/makeicns.rb
@@ -1,6 +1,5 @@
 class Makeicns
   livecheck do
-    url :stable
-    regex(/href=.*?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+    skip "Bitbucket repository is missing"
   end
 end

--- a/Livecheckables/procyon-decompiler.rb
+++ b/Livecheckables/procyon-decompiler.rb
@@ -1,5 +1,5 @@
 class ProcyonDecompiler
   livecheck do
-    url :stable
+    skip "Bitbucket repository is missing"
   end
 end

--- a/Livecheckables/vcprompt.rb
+++ b/Livecheckables/vcprompt.rb
@@ -1,5 +1,5 @@
 class Vcprompt
   livecheck do
-    url :stable
+    skip "Bitbucket repository is missing"
   end
 end


### PR DESCRIPTION
Bitbucket finally dropped support for Mercurial repositories relatively recently and these repositories were seemingly removed. Now some of these checks give a `403 Forbidden` response, so we're skipping these formulae for the time being.

If these weren't skipped, then the `Bitbucket` strategy would try to fetch these pages and always fail. We can easily update these `livecheck` blocks if any of these repositories reappear in the future.