### PR TITLE
Apache: add path parameter to URL_MATCH_REGEX

### DIFF
--- a/livecheck/strategy/apache.rb
+++ b/livecheck/strategy/apache.rb
@@ -19,7 +19,7 @@ module LivecheckStrategy
     module_function
 
     # The `Regexp` used to determine if the strategy applies to the URL.
-    URL_MATCH_REGEX = %r{www\.apache\.org/dyn}i.freeze
+    URL_MATCH_REGEX = %r{www\.apache\.org/dyn/.+path=.+}i.freeze
 
     # Whether the strategy can be applied to the provided URL.
     # @param url [String] the URL to match against


### PR DESCRIPTION
The `path` parameter is a required part of Apache URLs to be able to use the `Apache` strategy, so it makes sense to make it an explicit part of the `URL_MATCH_REGEX`.