### PR TITLE
Git: ensure #match? returns a boolean value

### DIFF
--- a/livecheck/strategy/git.rb
+++ b/livecheck/strategy/git.rb
@@ -59,7 +59,7 @@ module LivecheckStrategy
     # @param url [String] the URL to match against
     # @return [Boolean]
     def match?(url)
-      DownloadStrategyDetector.detect(url) <= GitDownloadStrategy
+      (DownloadStrategyDetector.detect(url) <= GitDownloadStrategy) == true
     end
 
     # Checks the Git tags for new versions. When a regex isn't provided,


### PR DESCRIPTION
The existing method of determining if a URL can be used with the `Git` strategy led to a situation where `#match?` would return `nil` if the URL doesn't match. The return value of `#match?` should always be a boolean and this ensures that's the case.