### PR TITLE
Convert strategies back to classes

### DIFF
--- a/livecheck/strategy/apache.rb
+++ b/livecheck/strategy/apache.rb
@@ -15,16 +15,14 @@ module LivecheckStrategy
   # `/example-1.2.3/`, etc.), the default regex matches numeric versions
   # in directory names. Otherwise, the default regex matches numeric
   # versions in filenames.
-  module Apache
-    module_function
-
+  class Apache
     # The `Regexp` used to determine if the strategy applies to the URL.
     URL_MATCH_REGEX = %r{www\.apache\.org/dyn/.+path=.+}i.freeze
 
     # Whether the strategy can be applied to the provided URL.
     # @param url [String] the URL to match against
     # @return [Boolean]
-    def match?(url)
+    def self.match?(url)
       URL_MATCH_REGEX.match?(url)
     end
 
@@ -34,7 +32,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the content to check
     # @param regex [Regexp] a regex used for matching versions in content
     # @return [Hash]
-    def find_versions(url, regex = nil)
+    def self.find_versions(url, regex = nil)
       %r{
         path=
         (?<path>.+?)/ # Path to directory of files or version directories

--- a/livecheck/strategy/bitbucket.rb
+++ b/livecheck/strategy/bitbucket.rb
@@ -21,16 +21,14 @@ module LivecheckStrategy
   #
   # The default regex identifies versions in archive files found in `href`
   # attributes.
-  module Bitbucket
-    module_function
-
+  class Bitbucket
     # The `Regexp` used to determine if the strategy applies to the URL.
     URL_MATCH_REGEX = %r{bitbucket\.org(/[^/]+){4}\.\w+}i.freeze
 
     # Whether the strategy can be applied to the provided URL.
     # @param url [String] the URL to match against
     # @return [Boolean]
-    def match?(url)
+    def self.match?(url)
       URL_MATCH_REGEX.match?(url)
     end
 
@@ -40,7 +38,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the content to check
     # @param regex [Regexp] a regex used for matching versions in content
     # @return [Hash]
-    def find_versions(url, regex = nil)
+    def self.find_versions(url, regex = nil)
       %r{
         bitbucket\.org/
         (?<path>.+?)/ # The path leading up to the get or downloads part

--- a/livecheck/strategy/git.rb
+++ b/livecheck/strategy/git.rb
@@ -18,9 +18,7 @@ module LivecheckStrategy
   # `Version`. This works for some simple situations but even one unusual
   # tag can cause a bad result. It's better to provide a regex in a
   # `livecheck` block, so `livecheck` only matches what we really want.
-  module Git
-    module_function
-
+  class Git
     # The priority of the strategy on an informal scale of 1 to 10 (from
     # lowest to highest).
     PRIORITY = 8
@@ -31,7 +29,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the Git repository to check
     # @param regex [Regexp] the regex to use for filtering tags
     # @return [Hash]
-    def tag_info(url, regex = nil)
+    def self.tag_info(url, regex = nil)
       # Open3#capture3 is used here because we need to capture stderr
       # output and handle it in an appropriate manner. Alternatives like
       # SystemCommand always print errors (as well as debug output) and
@@ -58,7 +56,7 @@ module LivecheckStrategy
     # Whether the strategy can be applied to the provided URL.
     # @param url [String] the URL to match against
     # @return [Boolean]
-    def match?(url)
+    def self.match?(url)
       (DownloadStrategyDetector.detect(url) <= GitDownloadStrategy) == true
     end
 
@@ -68,7 +66,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the Git repository to check
     # @param regex [Regexp] the regex to use for matching versions
     # @return [Hash]
-    def find_versions(url, regex = nil)
+    def self.find_versions(url, regex = nil)
       match_data = { matches: {}, regex: regex, url: url }
 
       tags_data = tag_info(url, regex)

--- a/livecheck/strategy/gnome.rb
+++ b/livecheck/strategy/gnome.rb
@@ -10,9 +10,7 @@ module LivecheckStrategy
   #
   # The default regex restricts matching to filenames containing a version
   # with an even-numbered minor below 90, as these are stable releases.
-  module Gnome
-    module_function
-
+  class Gnome
     NICE_NAME = "GNOME"
 
     # The `Regexp` used to determine if the strategy applies to the URL.
@@ -21,7 +19,7 @@ module LivecheckStrategy
     # Whether the strategy can be applied to the provided URL.
     # @param url [String] the URL to match against
     # @return [Boolean]
-    def match?(url)
+    def self.match?(url)
       URL_MATCH_REGEX.match?(url)
     end
 
@@ -31,7 +29,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the content to check
     # @param regex [Regexp] a regex used for matching versions in content
     # @return [Hash]
-    def find_versions(url, regex = nil)
+    def self.find_versions(url, regex = nil)
       %r{/sources/(?<package_name>.*?)/}i =~ url
 
       page_url = "https://download.gnome.org/sources/#{package_name}/cache.json"

--- a/livecheck/strategy/gnu.rb
+++ b/livecheck/strategy/gnu.rb
@@ -23,9 +23,7 @@ module LivecheckStrategy
   #
   # The default regex identifies versions in archive files found in `href`
   # attributes.
-  module Gnu
-    module_function
-
+  class Gnu
     NICE_NAME = "GNU"
 
     # The `Regexp` used to determine if the strategy applies to the URL.
@@ -45,7 +43,7 @@ module LivecheckStrategy
     # Whether the strategy can be applied to the provided URL.
     # @param url [String] the URL to match against
     # @return [Boolean]
-    def match?(url)
+    def self.match?(url)
       URL_MATCH_REGEX.match?(url) && !url.include?("savannah.")
     end
 
@@ -55,7 +53,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the content to check
     # @param regex [Regexp] a regex used for matching versions in content
     # @return [Hash]
-    def find_versions(url, regex = nil)
+    def self.find_versions(url, regex = nil)
       project_names = PROJECT_NAME_REGEXES.map do |project_name_regex|
         m = url.match(project_name_regex)
         m["project_name"] if m

--- a/livecheck/strategy/hackage.rb
+++ b/livecheck/strategy/hackage.rb
@@ -10,16 +10,14 @@ module LivecheckStrategy
   #
   # The default regex checks for the latest version an `h3` heading element
   # with a format like `<h3>example-1.2.3/</h3>`.
-  module Hackage
-    module_function
-
+  class Hackage
     # The `Regexp` used to determine if the strategy applies to the URL.
     URL_MATCH_REGEX = /(?:downloads|hackage)\.haskell\.org/i.freeze
 
     # Whether the strategy can be applied to the provided URL.
     # @param url [String] the URL to match against
     # @return [Boolean]
-    def match?(url)
+    def self.match?(url)
       URL_MATCH_REGEX.match?(url)
     end
 
@@ -29,7 +27,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the content to check
     # @param regex [Regexp] a regex used for matching versions in content
     # @return [Hash]
-    def find_versions(url, regex = nil)
+    def self.find_versions(url, regex = nil)
       /^(?<package_name>.+?)-\d+/i =~ File.basename(url)
 
       # A page containing a directory listing of the latest source tarball

--- a/livecheck/strategy/launchpad.rb
+++ b/livecheck/strategy/launchpad.rb
@@ -17,16 +17,14 @@ module LivecheckStrategy
   #   Latest version is 1.2.3
   # </div>
   # ```
-  module Launchpad
-    module_function
-
+  class Launchpad
     # The `Regexp` used to determine if the strategy applies to the URL.
     URL_MATCH_REGEX = /launchpad\.net/i.freeze
 
     # Whether the strategy can be applied to the provided URL.
     # @param url [String] the URL to match against
     # @return [Boolean]
-    def match?(url)
+    def self.match?(url)
       URL_MATCH_REGEX.match?(url)
     end
 
@@ -36,7 +34,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the content to check
     # @param regex [Regexp] a regex used for matching versions in content
     # @return [Hash]
-    def find_versions(url, regex = nil)
+    def self.find_versions(url, regex = nil)
       %r{launchpad\.net/(?<project_name>[^/]+)}i =~ url
 
       # The main page for the project on Launchpad

--- a/livecheck/strategy/npm.rb
+++ b/livecheck/strategy/npm.rb
@@ -10,9 +10,7 @@ module LivecheckStrategy
   #
   # The default regex matches URLs in the `href` attributes of version tags
   # on the "Versions" tab of the package page.
-  module Npm
-    module_function
-
+  class Npm
     NICE_NAME = "npm"
 
     # The `Regexp` used to determine if the strategy applies to the URL.
@@ -21,7 +19,7 @@ module LivecheckStrategy
     # Whether the strategy can be applied to the provided URL.
     # @param url [String] the URL to match against
     # @return [Boolean]
-    def match?(url)
+    def self.match?(url)
       URL_MATCH_REGEX.match?(url)
     end
 
@@ -31,7 +29,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the content to check
     # @param regex [Regexp] a regex used for matching versions in content
     # @return [Hash]
-    def find_versions(url, regex = nil)
+    def self.find_versions(url, regex = nil)
       %r{registry\.npmjs\.org/(?<package_name>.+)/-/}i =~ url
 
       page_url = "https://www.npmjs.com/package/#{package_name}?activeTab=versions"

--- a/livecheck/strategy/page_match.rb
+++ b/livecheck/strategy/page_match.rb
@@ -13,9 +13,7 @@ module LivecheckStrategy
   # The `PageMatch#find_versions` method is also used within other
   # strategies, to handle the process of identifying version text in
   # content.
-  module PageMatch
-    module_function
-
+  class PageMatch
     NICE_NAME = "Page match"
 
     # A priority of zero causes livecheck to skip the strategy. We do this
@@ -32,7 +30,7 @@ module LivecheckStrategy
     # when the formula has a `livecheck` block containing a regex.
     # @param url [String] the URL to match against
     # @return [Boolean]
-    def match?(url)
+    def self.match?(url)
       URL_MATCH_REGEX.match?(url)
     end
 
@@ -42,7 +40,7 @@ module LivecheckStrategy
     # @param regex [Regexp] a regex used for matching versions in the
     #   content
     # @return [Array]
-    def page_matches(url, regex)
+    def self.page_matches(url, regex)
       page = URI.open(url).read
       matches = page.scan(regex)
       matches.map(&:first).uniq
@@ -53,7 +51,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the content to check
     # @param regex [Regexp] a regex used for matching versions in content
     # @return [Hash]
-    def find_versions(url, regex)
+    def self.find_versions(url, regex)
       match_data = { matches: {}, regex: regex, url: url }
 
       page_matches(url, regex).each do |match|

--- a/livecheck/strategy/pypi.rb
+++ b/livecheck/strategy/pypi.rb
@@ -10,9 +10,7 @@ module LivecheckStrategy
   #
   # As such, the default regex only targets the filename at the end of the
   # URL.
-  module Pypi
-    module_function
-
+  class Pypi
     NICE_NAME = "PyPI"
 
     # The `Regexp` used to determine if the strategy applies to the URL.
@@ -21,7 +19,7 @@ module LivecheckStrategy
     # Whether the strategy can be applied to the provided URL.
     # @param url [String] the URL to match against
     # @return [Boolean]
-    def match?(url)
+    def self.match?(url)
       URL_MATCH_REGEX.match?(url)
     end
 
@@ -31,7 +29,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the content to check
     # @param regex [Regexp] a regex used for matching versions in content
     # @return [Hash]
-    def find_versions(url, regex = nil)
+    def self.find_versions(url, regex = nil)
       /
         (?<package_name>.+)- # The package name followed by a hyphen
         .*? # The version string

--- a/livecheck/strategy/sourceforge.rb
+++ b/livecheck/strategy/sourceforge.rb
@@ -24,9 +24,7 @@ module LivecheckStrategy
   #
   # The default regex matches within `url` attributes in the RSS feed
   # and identifies versions within directory names or filenames.
-  module Sourceforge
-    module_function
-
+  class Sourceforge
     NICE_NAME = "SourceForge"
 
     # The `Regexp` used to determine if the strategy applies to the URL.
@@ -35,7 +33,7 @@ module LivecheckStrategy
     # Whether the strategy can be applied to the provided URL.
     # @param url [String] the URL to match against
     # @return [Boolean]
-    def match?(url)
+    def self.match?(url)
       URL_MATCH_REGEX.match?(url)
     end
 
@@ -45,7 +43,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the content to check
     # @param regex [Regexp] a regex used for matching versions in content
     # @return [Hash]
-    def find_versions(url, regex = nil)
+    def self.find_versions(url, regex = nil)
       if url.include?("/project")
         %r{/projects?/(?<project_name>[^/]+)/}i =~ url
       elsif url.include?(".net/p/")

--- a/livecheck/strategy/xorg.rb
+++ b/livecheck/strategy/xorg.rb
@@ -32,9 +32,7 @@ module LivecheckStrategy
   #
   # The default regex identifies versions in archive files found in `href`
   # attributes.
-  module Xorg
-    module_function
-
+  class Xorg
     NICE_NAME = "X.Org"
 
     # The `Regexp` used to determine if the strategy applies to the URL.
@@ -50,7 +48,7 @@ module LivecheckStrategy
     # Whether the strategy can be applied to the provided URL.
     # @param url [String] the URL to match against
     # @return [Boolean]
-    def match?(url)
+    def self.match?(url)
       URL_MATCH_REGEX.match?(url)
     end
 
@@ -65,7 +63,7 @@ module LivecheckStrategy
     # @param url [String] the URL of the content to check
     # @param regex [Regexp] a regex used for matching versions in content
     # @return [Hash]
-    def find_versions(url, regex)
+    def self.find_versions(url, regex)
       file_name = File.basename(url)
 
       /^(?<module_name>.+)-\d+/i =~ file_name


### PR DESCRIPTION
The strategies were converted to modules as part of the Homebrew/brew migration, to help ease the process of incorporating some changes from this repository into the related PRs in Homebrew/brew. We recently converted the strategies back to classes in one of those PRs, so this PR does the same thing here.